### PR TITLE
Parse extglob patterns in case statements

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,6 +9,7 @@ Feature                Priority   Effort   Impact         Status
 ────────────────────────────────────────────────────────────────────
 [[ ]] parsing          P1         Medium   Very High      ✓ Done
 $(( )) parsing         P1         High     Very High      ✓ Done
+Extglob in case        P1         Low      Medium         ✓ Done
 Position tracking      P2         Medium   Very High      Not started
 JSON serialization     P2         Low      High           Not started
 Visitor pattern        P2         Low      High           Not started
@@ -71,6 +72,19 @@ Command substitutions, parameter expansions, and side effects inside `$(( ))` ar
 - Nested expansions: `$(cmd)`, `${var}`, `$((...))`
 - Numbers: decimal, hex (`0xFF`), octal (`0777`), base-N (`2#1010`)
 - Line continuation: `\<newline>`
+
+### Extglob patterns in case statements
+
+**Status:** ✓ Implemented
+
+`case $x in @(a|b)) echo match;; esac` now parses correctly.
+
+The case pattern parser recognizes extended glob syntax (`@(...)`, `?(...)`, `*(...)`, `+(...)`, `!(...)`), including:
+- Nested extglobs: `@(@(a|b))`
+- Grouping parens inside extglob: `@((a|b))`
+- Command substitution inside: `@($(cmd))`
+- Arithmetic inside: `@($((1+2)))`
+- Character classes: `@([a-z]*)`
 
 ## P2: Usability
 

--- a/tests/30_extglob_case.tests
+++ b/tests/30_extglob_case.tests
@@ -1,0 +1,147 @@
+# Extglob patterns in case statements
+# Extended glob patterns @(), ?(), *(), +(), !() must be handled
+
+=== basic @() extglob
+case $x in @(a|b)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a|b)" (command (word "echo") (word "match"))))
+
+=== basic ?() extglob
+case $x in ?(foo|bar)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "?(foo|bar)" (command (word "echo") (word "match"))))
+
+=== basic *() extglob
+case $x in *(a|b|c)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "*(a|b|c)" (command (word "echo") (word "match"))))
+
+=== basic +() extglob
+case $x in +(one|two)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "+(one|two)" (command (word "echo") (word "match"))))
+
+=== basic !() extglob
+case $x in !(bad|worse)) echo good;; esac
+---
+(case (word "$x" (param "x")) (pattern "!(bad|worse)" (command (word "echo") (word "good"))))
+
+=== extglob single alternative
+case $x in @(foo)) echo foo;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(foo)" (command (word "echo") (word "foo"))))
+
+=== extglob many alternatives
+case $x in @(a|b|c|d|e)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a|b|c|d|e)" (command (word "echo") (word "match"))))
+
+=== nested extglobs
+case $x in @(a|@(b|c))) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a|@(b|c))" (command (word "echo") (word "match"))))
+
+=== mixed nested extglobs
+case $x in @(?(a)|+(b))) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(?(a)|+(b))" (command (word "echo") (word "match"))))
+
+=== extglob with trailing glob
+case $x in @(foo|bar)*) echo prefix;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(foo|bar)*" (command (word "echo") (word "prefix"))))
+
+=== extglob with leading glob
+case $x in *@(foo|bar)) echo suffix;; esac
+---
+(case (word "$x" (param "x")) (pattern "*@(foo|bar)" (command (word "echo") (word "suffix"))))
+
+=== extglob in middle
+case $x in pre@(a|b)post) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "pre@(a|b)post" (command (word "echo") (word "match"))))
+
+=== multiple extglobs in alternation
+case $x in @(a|b)|@(c|d)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a|b)|@(c|d)" (command (word "echo") (word "match"))))
+
+=== extglob empty body
+case $x in @(a|b));; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a|b)"))
+
+=== multiple clauses with extglobs
+case $x in @(a)) echo a;; @(b)) echo b;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a)" (command (word "echo") (word "a"))) (pattern "@(b)" (command (word "echo") (word "b"))))
+
+=== extglob with optional leading paren
+case $x in (@(a|b)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a|b)" (command (word "echo") (word "match"))))
+
+=== extglob with wildcards inside
+case $x in @(*.txt|*.md)) echo doc;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(*.txt|*.md)" (command (word "echo") (word "doc"))))
+
+=== extglob with character classes
+case $x in @([a-z]*|[0-9]*)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@([a-z]*|[0-9]*)" (command (word "echo") (word "match"))))
+
+=== extglob and regular alternation
+case $x in foo|@(bar|baz)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "foo|@(bar|baz)" (command (word "echo") (word "match"))))
+
+=== regular and extglob alternation
+case $x in @(foo|bar)|baz) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(foo|bar)|baz" (command (word "echo") (word "match"))))
+
+=== deeply nested extglobs
+case $x in @(@(@(a)))) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(@(@(a)))" (command (word "echo") (word "match"))))
+
+=== command sub inside extglob
+case $x in @($(echo a)|b)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@($(echoa)|b)" (command (word "echo") (word "match"))))
+
+=== quoted content inside extglob
+case $x in @("foo"|bar)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(\"foo\"|bar)" (command (word "echo") (word "match"))))
+
+=== multiple extglobs in pattern
+case $x in @(a)*@(b)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a)*@(b)" (command (word "echo") (word "match"))))
+
+=== escaped paren inside extglob
+case $x in @(a\)|b)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(a\\)|b)" (command (word "echo") (word "match"))))
+
+=== arithmetic expansion inside extglob
+case $x in @($((1+2)))) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@($((1+2)))" (command (word "echo") (word "match"))))
+
+=== grouping parens inside extglob
+case $x in @((a))) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@((a))" (command (word "echo") (word "match"))))
+
+=== nested grouping in extglob
+case $x in @((a|b)|(c))) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@((a|b)|(c))" (command (word "echo") (word "match"))))
+
+=== backtick command sub in extglob
+case $x in @(`cmd`)) echo match;; esac
+---
+(case (word "$x" (param "x")) (pattern "@(`cmd`)" (command (word "echo") (word "match"))))

--- a/tests/test_bash_validation.py
+++ b/tests/test_bash_validation.py
@@ -129,9 +129,15 @@ def get_all_test_cases():
 @pytest.mark.parametrize("test_case", get_all_test_cases())
 def test_valid_bash_syntax(test_case):
     """Verify that the test input is valid bash syntax."""
+    # Build bash command - enable extglob for extglob tests
+    cmd = [BASH_PATH]
+    if "extglob" in test_case.file:
+        cmd.extend(["-O", "extglob"])
+    cmd.append("-n")
+
     # Run bash -n to check syntax without executing
     result = subprocess.run(
-        [BASH_PATH, "-n"],
+        cmd,
         input=test_case.input,
         capture_output=True,
         text=True,


### PR DESCRIPTION
Handle @(), ?(), *(), +(), !() extended glob patterns in case statement patterns, including nested extglobs, grouping parens, command substitutions, and arithmetic expansions inside patterns.