### PR TITLE
fuzzer fix: heredoc eof newline

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6860,8 +6860,29 @@ class Parser {
 				content_lines.push(`${line}\n`);
 				scan_pos = line_end + 1;
 			} else {
-				// EOF - don't add trailing newline
-				content_lines.push(line);
+				// EOF without a newline: bash treats the last line as newline-terminated,
+				// except for unquoted heredocs with an odd trailing backslash.
+				if (line_start < line_end) {
+					if (!quoted) {
+						trailing_bs = 0;
+						for (i = line.length - 1; i > -1; i--) {
+							if (line[i] === "\\") {
+								trailing_bs += 1;
+							} else {
+								break;
+							}
+						}
+						if (trailing_bs % 2 === 1) {
+							content_lines.push(line);
+						} else {
+							content_lines.push(`${line}\n`);
+						}
+					} else {
+						content_lines.push(`${line}\n`);
+					}
+				} else {
+					content_lines.push(line);
+				}
 				scan_pos = this.length;
 			}
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -5858,8 +5858,24 @@ class Parser:
                 content_lines.append(line + "\n")
                 scan_pos = line_end + 1
             else:
-                # EOF - don't add trailing newline
-                content_lines.append(line)
+                # EOF without a newline: bash treats the last line as newline-terminated,
+                # except for unquoted heredocs with an odd trailing backslash.
+                if line_start < line_end:
+                    if not quoted:
+                        trailing_bs = 0
+                        for i in range(len(line) - 1, -1, -1):
+                            if line[i] == "\\":
+                                trailing_bs += 1
+                            else:
+                                break
+                        if trailing_bs % 2 == 1:
+                            content_lines.append(line)
+                        else:
+                            content_lines.append(line + "\n")
+                    else:
+                        content_lines.append(line + "\n")
+                else:
+                    content_lines.append(line)
                 scan_pos = self.length
 
         # Join content (newlines already included per line)

--- a/tests/parable/fuzz-11126.tests
+++ b/tests/parable/fuzz-11126.tests
@@ -1,0 +1,7 @@
+=== unterminated heredoc adds newline at eof
+cat <<EOF
+x
+---
+(command (word "cat") (redirect "<<" "x
+"))
+---


### PR DESCRIPTION
## Summary
- Fix heredoc EOF newline behavior to match bash-oracle when delimiter is missing, including odd trailing backslash case
- MRE: cat <<EOF\nx

## Test plan
- [ ] New test added to 
- [ ] [lock] Resolved 1 package in 13ms
[dump-ast] OK
[fmt] 14 files already formatted
[lint] All checks passed!
[fmt-js] Checked 1 file in 52ms. No fixes applied.
[pypy3.11] 
[pypy3.11] 4266 passed, 0 failed in 1.94s
[3.12] 
[3.12] 4266 passed, 0 failed in 2.01s
[3.11] 
[3.11] 4266 passed, 0 failed in 2.04s
[3.13] 
[3.13] 4266 passed, 0 failed in 2.23s
[3.14] 
[3.14] 4266 passed, 0 failed in 2.25s
[transpile] OK
[3.10] 
[3.10] 4266 passed, 0 failed in 2.70s
4266 passed, 0 failed in 0.30s passes
