### PR TITLE
fuzzer fix: heredoc EOF newline handling

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6681,7 +6681,8 @@ class Parser {
 	}
 
 	_parseHeredoc(fd, strip_tabs) {
-		let c,
+		let add_newline,
+			c,
 			ch,
 			check_line,
 			content,
@@ -6860,8 +6861,22 @@ class Parser {
 				content_lines.push(`${line}\n`);
 				scan_pos = line_end + 1;
 			} else {
-				// EOF - don't add trailing newline
-				content_lines.push(line);
+				// EOF - bash keeps the trailing newline unless escaped by an odd backslash
+				add_newline = true;
+				if (!quoted) {
+					trailing_bs = 0;
+					for (i = line.length - 1; i > -1; i--) {
+						if (line[i] === "\\") {
+							trailing_bs += 1;
+						} else {
+							break;
+						}
+					}
+					if (trailing_bs % 2 === 1) {
+						add_newline = false;
+					}
+				}
+				content_lines.push(line + (add_newline ? "\n" : ""));
 				scan_pos = this.length;
 			}
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -5858,8 +5858,18 @@ class Parser:
                 content_lines.append(line + "\n")
                 scan_pos = line_end + 1
             else:
-                # EOF - don't add trailing newline
-                content_lines.append(line)
+                # EOF - bash keeps the trailing newline unless escaped by an odd backslash
+                add_newline = True
+                if not quoted:
+                    trailing_bs = 0
+                    for i in range(len(line) - 1, -1, -1):
+                        if line[i] == "\\":
+                            trailing_bs += 1
+                        else:
+                            break
+                    if trailing_bs % 2 == 1:
+                        add_newline = False
+                content_lines.append(line + ("\n" if add_newline else ""))
                 scan_pos = self.length
 
         # Join content (newlines already included per line)

--- a/tests/parable/fuzz-15765.tests
+++ b/tests/parable/fuzz-15765.tests
@@ -1,0 +1,9 @@
+# Fuzzer-discovered parser discrepancy
+
+=== heredoc delimiter with trailing less-than
+<<E
+<
+---
+(command (redirect "<<" "<
+"))
+---


### PR DESCRIPTION
## Summary
- Fix heredoc EOF newline handling when delimiter is missing (MRE: `<<E\n<`)

## Test plan
- [x] New test added to `tests/parable/fuzz-15765.tests`
- [x] `just check` passes
