### PR TITLE
fuzzer fix: preserve newline in arith for init

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1697,6 +1697,7 @@ class ForArith extends Node {
 			val = w._expandAllAnsiCQuotes(s);
 			val = w._stripLocaleStringDollars(val);
 			val = val.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+			val = val.replaceAll("\n", "\\n").replaceAll("\t", "\\t");
 			return val;
 		}
 
@@ -8270,7 +8271,7 @@ class Parser {
 				) {
 					// Check for closing ))
 					// End of ((...)) - preserve trailing whitespace
-					parts.push(current.join("").trimStart());
+					parts.push(current.join("").replace(/^[ \t]+/, ""));
 					this.advance();
 					this.advance();
 					break;
@@ -8279,7 +8280,7 @@ class Parser {
 				}
 			} else if (ch === ";" && paren_depth === 0) {
 				// Preserve trailing whitespace in expressions
-				parts.push(current.join("").trimStart());
+				parts.push(current.join("").replace(/^[ \t]+/, ""));
 				current = [];
 				this.advance();
 			} else {

--- a/src/parable.py
+++ b/src/parable.py
@@ -1432,6 +1432,7 @@ class ForArith(Node):
             val = w._expand_all_ansi_c_quotes(s)
             val = w._strip_locale_string_dollars(val)
             val = val.replace("\\", "\\\\").replace('"', '\\"')
+            val = val.replace("\n", "\\n").replace("\t", "\\t")
             return val
 
         suffix = ""
@@ -7013,7 +7014,7 @@ class Parser:
                     # Check for closing ))
                     if self.pos + 1 < self.length and self.source[self.pos + 1] == ")":
                         # End of ((...)) - preserve trailing whitespace
-                        parts.append("".join(current).lstrip())
+                        parts.append("".join(current).lstrip(" \t"))
                         self.advance()  # consume first )
                         self.advance()  # consume second )
                         break
@@ -7021,7 +7022,7 @@ class Parser:
                         current.append(self.advance())
             elif ch == ";" and paren_depth == 0:
                 # Preserve trailing whitespace in expressions
-                parts.append("".join(current).lstrip())
+                parts.append("".join(current).lstrip(" \t"))
                 current = []
                 self.advance()  # consume ;
             else:

--- a/tests/parable/fuzz-2502.tests
+++ b/tests/parable/fuzz-2502.tests
@@ -1,0 +1,8 @@
+# Fuzz 2502: preserve leading newline in arithmetic for init
+
+=== leading newline in for (( init ))
+for ((
+a;;)); do :; done
+---
+(arith-for (init (word "\na")) (test (word "1")) (step (word "1")) (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- Fix for ((...)) parsing to preserve leading newlines in init expressions (MRE: `for ((
a;;)); do :; done`)

## Test plan
- [ ] New test added to `tests/parable/fuzz-2502.tests`
- [ ] `just check` passes
