### PR TITLE
fuzzer fix: treat [[ as keyword only when standalone

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7087,7 +7087,7 @@ class Parser {
 		"-ef",
 	]);
 	parseConditionalExpr() {
-		let body;
+		let body, next_pos;
 		this.skipWhitespace();
 		// Check for [[
 		if (
@@ -7095,6 +7095,18 @@ class Parser {
 			this.peek() !== "[" ||
 			this.pos + 1 >= this.length ||
 			this.source[this.pos + 1] !== "["
+		) {
+			return null;
+		}
+		next_pos = this.pos + 2;
+		if (
+			next_pos < this.length &&
+			!(
+				_isWhitespace(this.source[next_pos]) ||
+				(this.source[next_pos] === "\\" &&
+					next_pos + 1 < this.length &&
+					this.source[next_pos + 1] === "\n")
+			)
 		) {
 			return null;
 		}
@@ -9041,8 +9053,12 @@ class Parser {
 			this.pos + 1 < this.length &&
 			this.source[this.pos + 1] === "["
 		) {
-			return this.parseConditionalExpr();
+			result = this.parseConditionalExpr();
+			if (result != null) {
+				return result;
+			}
 		}
+		// Fall through to simple command if [[ is not a conditional keyword
 		// Check for reserved words
 		word = this.peekWord();
 		// Reserved words that cannot start a statement (only valid in specific contexts)

--- a/src/parable.py
+++ b/src/parable.py
@@ -6079,6 +6079,16 @@ class Parser:
             or self.source[self.pos + 1] != "["
         ):
             return None
+        next_pos = self.pos + 2
+        if next_pos < self.length and not (
+            _is_whitespace(self.source[next_pos])
+            or (
+                self.source[next_pos] == "\\"
+                and next_pos + 1 < self.length
+                and self.source[next_pos + 1] == "\n"
+            )
+        ):
+            return None
 
         self.advance()  # consume first [
         self.advance()  # consume second [
@@ -7701,7 +7711,10 @@ class Parser:
 
         # Conditional expression [[ ]] - check before reserved words
         if ch == "[" and self.pos + 1 < self.length and self.source[self.pos + 1] == "[":
-            return self.parse_conditional_expr()
+            result = self.parse_conditional_expr()
+            if result is not None:
+                return result
+            # Fall through to simple command if [[ is not a conditional keyword
 
         # Check for reserved words
         word = self.peek_word()

--- a/tests/parable/fuzz-16729.tests
+++ b/tests/parable/fuzz-16729.tests
@@ -1,0 +1,5 @@
+=== double-bracket word without space
+[[:"a" == b ]]
+---
+(command (word "[[:\"a\"") (word "==") (word "b") (word "]]"))
+---


### PR DESCRIPTION
## Summary
- Fix parsing so [[ is only treated as a conditional keyword when standalone; otherwise parse as a normal word
- MRE: [[:"a" == b ]]

## Test plan
- [ ] New test added to 
- [ ] [lock] Resolved 1 package in 15ms
[dump-ast] OK
[lint] All checks passed!
[fmt] 14 files already formatted
[fmt-js] Checked 1 file in 35ms. No fixes applied.
[pypy3.11] 
[pypy3.11] 4269 passed, 0 failed in 1.89s
[3.12] 
[3.12] 4269 passed, 0 failed in 2.07s
[3.11] 
[3.11] 4269 passed, 0 failed in 2.09s
[3.13] 
[3.13] 4269 passed, 0 failed in 2.22s
[3.14] 
[3.14] 4269 passed, 0 failed in 2.30s
[transpile] OK
[3.10] 
[3.10] 4269 passed, 0 failed in 2.69s
4269 passed, 0 failed in 0.27s passes
