### PR TITLE
fuzzer fix: preserve $ inside param expansion

### DIFF
--- a/tests/parable/fuzz-7389.tests
+++ b/tests/parable/fuzz-7389.tests
@@ -1,0 +1,5 @@
+=== param expansion locale strip should not drop dollars in braces
+"${unset="$"}"
+---
+(command (word "\"${unset=\"$\"}\""))
+---


### PR DESCRIPTION
## Summary
- Fix locale string dollar stripping to avoid dropping literal $ inside ${...}
- MRE: "${unset="$"}"
- Add fuzzer repro test in tests/parable/fuzz-7389.tests

## Test plan
- [ ] New test added to `tests/parable/fuzz-7389.tests`
- [ ] `just check` passes
