### PR TITLE
fuzzer fix: preserve # in array literals

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -757,8 +757,8 @@ class Word extends Node {
 				normalized.push(ch);
 				brace_depth -= 1;
 				i += 1;
-			} else if (ch === "#" && brace_depth === 0) {
-				// Comment - skip to end of line (only at top level)
+			} else if (ch === "#" && brace_depth === 0 && in_whitespace) {
+				// Comment - skip to end of line (only at top level, start of word)
 				while (i < inner.length && inner[i] !== "\n") {
 					i += 1;
 				}

--- a/src/parable.py
+++ b/src/parable.py
@@ -644,8 +644,8 @@ class Word(Node):
                 normalized.append(ch)
                 brace_depth -= 1
                 i += 1
-            elif ch == "#" and brace_depth == 0:
-                # Comment - skip to end of line (only at top level)
+            elif ch == "#" and brace_depth == 0 and in_whitespace:
+                # Comment - skip to end of line (only at top level, start of word)
                 while i < len(inner) and inner[i] != "\n":
                     i += 1
             else:

--- a/tests/parable/fuzz-3779.tests
+++ b/tests/parable/fuzz-3779.tests
@@ -1,0 +1,7 @@
+# Fuzz 3779: preserve # inside array literal element
+
+=== hash in array literal element
+a=(x#)
+---
+(command (word "a=(x#)"))
+---


### PR DESCRIPTION
## Summary
- Fix array literal whitespace normalization so a literal # inside elements isn't treated as a comment; MRE: `a=(x#)`

## Test plan
- [ ] New test added to `tests/parable/fuzz-3779.tests`
- [ ] `just check` passes
