### PR TITLE
fuzzer fix: array subscript word split

### DIFF
--- a/tests/parable/fuzz-27607.tests
+++ b/tests/parable/fuzz-27607.tests
@@ -1,0 +1,5 @@
+=== word split after glob bracket with parameter expansion
+.a[ ${a[*]:-b}
+---
+(command (word ".a[") (word "${a[*]:-b}"))
+---


### PR DESCRIPTION
## Summary
- Fix array-subscript word splitting when a command starts with a non-identifier prefix and contains a bracketed subscript
- MRE: `.a[ ${a[*]:-b}`

## Test plan
- [ ] New test added to `tests/parable/fuzz-27607.tests`
- [ ] `just check` passes
