### PR TITLE
fuzzer fix: param subscript lookahead

### DIFF
--- a/tests/parable/fuzz-13731.tests
+++ b/tests/parable/fuzz-13731.tests
@@ -1,0 +1,5 @@
+=== double-quoted braced param with bracket and space
+"${un[-"e f"}"
+---
+(command (word "\"${un[-\"e f\"}\""))
+---


### PR DESCRIPTION
## Summary
- Treat unmatched parameter subscripts as literal so ${...} stays intact inside double quotes
- MRE: "${un[-"e f"}"

## Test plan
- [ ] New test added to `tests/parable/fuzz-13731.tests`
- [ ] `just check` passes
