### PR TITLE
fuzzer fix: guard array subscript spacing

### DIFF
--- a/tests/parable/fuzz-23004.tests
+++ b/tests/parable/fuzz-23004.tests
@@ -1,0 +1,5 @@
+=== word split after unterminated bracket literal
+@a[ $((0))
+---
+(command (word "@a[") (word "$((0))"))
+---


### PR DESCRIPTION
## Summary
- Fix array-assignment bracket scanning so unmatched subscripts don't absorb spaces; MRE: `@a[ $((0))`
- Add fuzz regression test in `tests/parable/fuzz-23004.tests`

## Test plan
- [ ] New test added to `tests/parable/fuzz-23004.tests`
- [ ] `just check` passes
