### PR TITLE
fuzzer fix: negation before list terminator

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3557,6 +3557,10 @@ function _isListTerminator(c) {
 	return c === "\n" || c === "|" || c === ";" || c === "(" || c === ")";
 }
 
+function _isNegationBoundary(c) {
+	return _isWhitespace(c) || c === ";" || c === "|" || c === ")";
+}
+
 function _isBackslashEscaped(value, idx) {
 	let bs_count, j;
 	bs_count = 0;
@@ -9284,13 +9288,13 @@ class Parser {
 						this.pos = saved;
 					}
 				}
-				this.skipWhitespace();
 			}
+			this.skipWhitespace();
 			// Check for ! after time
 			if (!this.atEnd() && this.peek() === "!") {
 				if (
 					this.pos + 1 >= this.length ||
-					_isWhitespace(this.source[this.pos + 1])
+					_isNegationBoundary(this.source[this.pos + 1])
 				) {
 					this.advance();
 					prefix_order = "time_negation";
@@ -9301,7 +9305,7 @@ class Parser {
 			// Check for '!' negation prefix (if no time yet)
 			if (
 				this.pos + 1 >= this.length ||
-				_isWhitespace(this.source[this.pos + 1])
+				_isNegationBoundary(this.source[this.pos + 1])
 			) {
 				this.advance();
 				this.skipWhitespace();

--- a/src/parable.py
+++ b/src/parable.py
@@ -3104,6 +3104,10 @@ def _is_list_terminator(c: str) -> bool:
     return c == "\n" or c == "|" or c == ";" or c == "(" or c == ")"
 
 
+def _is_negation_boundary(c: str) -> bool:
+    return _is_whitespace(c) or c == ";" or c == "|" or c == ")"
+
+
 def _is_backslash_escaped(value: str, idx: int) -> bool:
     """Return True if value[idx] is escaped by an odd number of backslashes."""
     bs_count = 0
@@ -7907,17 +7911,17 @@ class Parser:
                             self.pos = saved
                     else:
                         self.pos = saved
-                self.skip_whitespace()
+            self.skip_whitespace()
             # Check for ! after time
             if not self.at_end() and self.peek() == "!":
-                if self.pos + 1 >= self.length or _is_whitespace(self.source[self.pos + 1]):
+                if self.pos + 1 >= self.length or _is_negation_boundary(self.source[self.pos + 1]):
                     self.advance()
                     prefix_order = "time_negation"
                     self.skip_whitespace()
 
         # Check for '!' negation prefix (if no time yet)
         elif not self.at_end() and self.peek() == "!":
-            if self.pos + 1 >= self.length or _is_whitespace(self.source[self.pos + 1]):
+            if self.pos + 1 >= self.length or _is_negation_boundary(self.source[self.pos + 1]):
                 self.advance()
                 self.skip_whitespace()
                 # Recursively parse pipeline to handle ! ! cmd, ! time cmd, etc.

--- a/tests/parable/fuzz-17092.tests
+++ b/tests/parable/fuzz-17092.tests
@@ -1,0 +1,5 @@
+=== negation with empty command before list terminator
+!;
+---
+(negation (command))
+---


### PR DESCRIPTION
## Summary
- Treat `!` followed by list terminators like `;` as a negation prefix; MRE: `!;`
- Add regression test for the `!;` case

## Test plan
- [ ] New test added to `tests/parable/fuzz-17092.tests`
- [ ] `just check` passes
