### PR TITLE
fuzzer fix: parse indirect expansion ampersand

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6146,6 +6146,10 @@ class Parser {
 				}
 				// Check for operator (e.g., ${!##} = indirect of # with # op)
 				op = this._consumeParamOperator();
+				if (op == null && !this.atEnd() && this.peek() !== "}") {
+					// Unknown operator - bash still parses these (fails at runtime)
+					op = this.advance();
+				}
 				if (op != null) {
 					// Parse argument until closing brace
 					arg_chars = [];

--- a/src/parable.py
+++ b/src/parable.py
@@ -5290,6 +5290,9 @@ class Parser:
                     return None, ""
                 # Check for operator (e.g., ${!##} = indirect of # with # op)
                 op = self._consume_param_operator()
+                if op is None and not self.at_end() and self.peek() != "}":
+                    # Unknown operator - bash still parses these (fails at runtime)
+                    op = self.advance()
                 if op is not None:
                     # Parse argument until closing brace
                     arg_chars = []

--- a/tests/parable/fuzz-15375.tests
+++ b/tests/parable/fuzz-15375.tests
@@ -1,0 +1,5 @@
+=== indirect expansion with ampersand
+${!a&b}
+---
+(command (word "${!a&b}"))
+---


### PR DESCRIPTION
## Summary
- Fix indirect parameter expansion parsing so unknown operators like & remain inside the expansion (MRE: ${!a&b})

## Test plan
- [ ] New test added to `tests/parable/fuzz-15375.tests`
- [ ] `just check` passes