### PR TITLE
fuzzer fix: negation in cmdsub

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2969,9 +2969,9 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 	}
 	if (node.kind === "negation") {
 		if (node.pipeline) {
-			return `\\! ${_formatCmdsubNode(node.pipeline, indent)}`;
+			return `! ${_formatCmdsubNode(node.pipeline, indent)}`;
 		}
-		return "\\!";
+		return "! ";
 	}
 	if (node.kind === "time") {
 		prefix = node.posix ? "time -p " : "time ";

--- a/src/parable.py
+++ b/src/parable.py
@@ -2609,8 +2609,8 @@ def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -
         return "[[ " + body + " ]]"
     if node.kind == "negation":
         if node.pipeline:
-            return "\\! " + _format_cmdsub_node(node.pipeline, indent)
-        return "\\!"
+            return "! " + _format_cmdsub_node(node.pipeline, indent)
+        return "! "
     if node.kind == "time":
         prefix = "time -p " if node.posix else "time "
         if node.pipeline:

--- a/tests/parable/12_command_substitution.tests
+++ b/tests/parable/12_command_substitution.tests
@@ -616,7 +616,7 @@ x=$(while [[ $a ]]; do echo x; done)
 === negated command in cmdsub
 x=$(! cmd arg)
 ---
-(command (word "x=$(\\! cmd arg)"))
+(command (word "x=$(! cmd arg)"))
 ---
 
 

--- a/tests/parable/fuzz-6744.tests
+++ b/tests/parable/fuzz-6744.tests
@@ -1,0 +1,8 @@
+# Fuzz 6744: preserve space after ! before newline in command substitution
+
+=== command substitution negation newline
+$(!
+)
+---
+(command (word "$(! )"))
+---


### PR DESCRIPTION
## Summary
- Fix command substitution negation formatting to match bash-oracle for empty/whitespace-only commands (MRE: `$(!\n)`) and update cmdsub negation expectation

## Test plan
- [x] New test added to `tests/parable/fuzz-6744.tests`
- [x] `just check` passes
