### PR TITLE
fuzzer fix: empty param line continuation

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -5334,33 +5334,44 @@ class Parser:
         # ${param} or ${param<op><arg>}
         param = self._consume_param_name()
         if not param:
-            # Unknown syntax like ${(M)...} (zsh) - consume until matching }
-            # Bash accepts these syntactically but fails at runtime
-            depth = 1
-            content_start = self.pos
-            while not self.at_end() and depth > 0:
-                c = self.peek()
-                if c == "{":
-                    depth += 1
-                    self.advance()
-                elif c == "}":
-                    depth -= 1
-                    if depth == 0:
-                        break
-                    self.advance()
-                elif c == "\\":
-                    self.advance()
-                    if not self.at_end():
+            # Allow empty parameter for simple operators like ${:-word}
+            if not self.at_end() and (
+                self.peek() in "-=+?"
+                or (
+                    self.peek() == ":"
+                    and self.pos + 1 < self.length
+                    and _is_simple_param_op(self.source[self.pos + 1])
+                )
+            ):
+                param = ""
+            else:
+                # Unknown syntax like ${(M)...} (zsh) - consume until matching }
+                # Bash accepts these syntactically but fails at runtime
+                depth = 1
+                content_start = self.pos
+                while not self.at_end() and depth > 0:
+                    c = self.peek()
+                    if c == "{":
+                        depth += 1
                         self.advance()
-                else:
-                    self.advance()
-            if depth == 0:
-                content = _substring(self.source, content_start, self.pos)
-                self.advance()  # consume final }
-                text = _substring(self.source, start, self.pos)
-                return ParamExpansion(content), text
-            self.pos = start
-            return None, ""
+                    elif c == "}":
+                        depth -= 1
+                        if depth == 0:
+                            break
+                        self.advance()
+                    elif c == "\\":
+                        self.advance()
+                        if not self.at_end():
+                            self.advance()
+                    else:
+                        self.advance()
+                if depth == 0:
+                    content = _substring(self.source, content_start, self.pos)
+                    self.advance()  # consume final }
+                    text = _substring(self.source, start, self.pos)
+                    return ParamExpansion(content), text
+                self.pos = start
+                return None, ""
 
         if self.at_end():
             self.pos = start

--- a/tests/parable/fuzz-31393.tests
+++ b/tests/parable/fuzz-31393.tests
@@ -1,0 +1,6 @@
+=== parameter expansion line continuation
+${:-\
+}
+---
+(command (word "${:-}"))
+---


### PR DESCRIPTION
## Summary
- Fix empty-parameter expansion parsing to treat operators like `${:-...}` as valid and drop line continuations
- MRE:
```
${:-\\
}
```

## Test plan
- [x] New test added to `tests/parable/fuzz-31393.tests`
- [x] `just check` passes
