### PR TITLE
fuzzer fix: handle <& word targets

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6586,7 +6586,8 @@ class Parser {
 			target,
 			varfd,
 			varname,
-			varname_chars;
+			varname_chars,
+			word_start;
 		this.skipWhitespace();
 		if (this.atEnd()) {
 			return null;
@@ -6782,6 +6783,7 @@ class Parser {
 				!this.atEnd() &&
 				(/^[0-9]+$/.test(this.peek()) || this.peek() === "-")
 			) {
+				word_start = this.pos;
 				fd_chars = [];
 				while (!this.atEnd() && /^[0-9]+$/.test(this.peek())) {
 					fd_chars.push(this.advance());
@@ -6795,7 +6797,22 @@ class Parser {
 				if (!this.atEnd() && this.peek() === "-") {
 					fd_target += this.advance();
 				}
-				target = new Word(`&${fd_target}`);
+				// If more word characters follow, treat the whole target as a word (e.g., <&0=)
+				if (!this.atEnd() && !_isMetachar(this.peek())) {
+					this.pos = word_start;
+					inner_word = this.parseWord();
+					if (inner_word != null) {
+						target = new Word(`&${inner_word.value}`);
+						target.parts = inner_word.parts;
+					} else {
+						throw new ParseError(
+							`Expected target for redirect ${op}`,
+							this.pos,
+						);
+					}
+				} else {
+					target = new Word(`&${fd_target}`);
+				}
 			} else {
 				// Could be &$var or &word - parse word and prepend &
 				inner_word = this.parseWord();

--- a/src/parable.py
+++ b/src/parable.py
@@ -5803,6 +5803,7 @@ class Parser:
             self.advance()  # consume &
             # Parse the fd number or - for close, including move syntax like &10-
             if not self.at_end() and (self.peek().isdigit() or self.peek() == "-"):
+                word_start = self.pos
                 fd_chars = []
                 while not self.at_end() and self.peek().isdigit():
                     fd_chars.append(self.advance())
@@ -5813,7 +5814,17 @@ class Parser:
                 # Handle just - for close, or N- for move syntax
                 if not self.at_end() and self.peek() == "-":
                     fd_target += self.advance()  # consume the trailing -
-                target = Word("&" + fd_target)
+                # If more word characters follow, treat the whole target as a word (e.g., <&0=)
+                if not self.at_end() and not _is_metachar(self.peek()):
+                    self.pos = word_start
+                    inner_word = self.parse_word()
+                    if inner_word is not None:
+                        target = Word("&" + inner_word.value)
+                        target.parts = inner_word.parts
+                    else:
+                        raise ParseError("Expected target for redirect " + op, pos=self.pos)
+                else:
+                    target = Word("&" + fd_target)
             else:
                 # Could be &$var or &word - parse word and prepend &
                 inner_word = self.parse_word()

--- a/tests/parable/fuzz-27790.tests
+++ b/tests/parable/fuzz-27790.tests
@@ -1,0 +1,5 @@
+=== redirect fd with equals suffix
+<&0=
+---
+(command (redirect "<&" "0="))
+---


### PR DESCRIPTION
## Summary
- Fix parsing of redirection targets like `<&0=` so the `=` suffix stays in the redirect target (MRE: `<&0=`)

## Test plan
- [x] New test added to `tests/parable/fuzz-27790.tests`
- [x] `just check` passes
