### PR TITLE
fuzzer fix: preserve procsub subshell whitespace

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -912,13 +912,16 @@ class Word extends Node {
 			in_single,
 			inner,
 			j,
+			k,
 			node,
 			p,
 			parsed,
 			parser,
 			prefix,
+			prefix_ws,
 			procsub_idx,
 			procsub_parts,
+			raw_content,
 			result;
 		// Collect command substitutions from all parts, including nested ones
 		cmdsub_parts = [];
@@ -1039,6 +1042,19 @@ class Word extends Node {
 				// Format this process substitution (with in_procsub=True for no-space subshells)
 				node = procsub_parts[procsub_idx];
 				formatted = _formatCmdsubNode(node.command, 0, true);
+				if (node.command.kind === "subshell") {
+					raw_content = value.slice(i + 2, j - 1);
+					if (raw_content.startsWith("(")) {
+						k = 1;
+						while (k < raw_content.length && _isWhitespace(raw_content[k])) {
+							k += 1;
+						}
+						prefix_ws = raw_content.slice(1, k);
+						if (prefix_ws && formatted.startsWith("(")) {
+							formatted = `(${prefix_ws}${formatted.slice(1)}`;
+						}
+					}
+				}
 				result.push(`${direction}(${formatted})`);
 				procsub_idx += 1;
 				i = j;

--- a/src/parable.py
+++ b/src/parable.py
@@ -847,6 +847,15 @@ class Word(Node):
                 # Format this process substitution (with in_procsub=True for no-space subshells)
                 node = procsub_parts[procsub_idx]
                 formatted = _format_cmdsub_node(node.command, in_procsub=True)
+                if node.command.kind == "subshell":
+                    raw_content = _substring(value, i + 2, j - 1)
+                    if raw_content.startswith("("):
+                        k = 1
+                        while k < len(raw_content) and _is_whitespace(raw_content[k]):
+                            k += 1
+                        prefix_ws = _substring(raw_content, 1, k)
+                        if prefix_ws and formatted.startswith("("):
+                            formatted = "(" + prefix_ws + formatted[1:]
                 result.append(direction + "(" + formatted + ")")
                 procsub_idx += 1
                 i = j

--- a/tests/parable/fuzz-22420.tests
+++ b/tests/parable/fuzz-22420.tests
@@ -1,0 +1,8 @@
+# Fuzz 22420: preserve newlines inside words
+
+=== newline inside word
+<((
+b))
+---
+(command (word "<((\nb))"))
+---


### PR DESCRIPTION
## Summary
- Fix procsub subshell formatting to preserve leading whitespace (MRE: `<((\nb))`)

## Test plan
- [ ] New test added to `tests/parable/fuzz-22420.tests`
- [ ] `just check` passes
