### PR TITLE
fuzzer fix: preserve process substitution subshell spacing

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -846,7 +846,23 @@ class Word(Node):
                 j = _find_cmdsub_end(value, i + 2)
                 # Format this process substitution (with in_procsub=True for no-space subshells)
                 node = procsub_parts[procsub_idx]
-                formatted = _format_cmdsub_node(node.command, in_procsub=True)
+                inner_raw = _substring(value, i + 2, j - 1)
+                preserve_subshell_space = False
+                if (
+                    node.command.kind == "subshell"
+                    and len(inner_raw) >= 3
+                    and inner_raw[0] == "("
+                    and inner_raw[len(inner_raw) - 1] == ")"
+                    and (
+                        _is_whitespace(inner_raw[1])
+                        or _is_whitespace(inner_raw[len(inner_raw) - 2])
+                    )
+                ):
+                    # Preserve explicit spacing inside subshells like ( cmd )
+                    preserve_subshell_space = True
+                formatted = _format_cmdsub_node(
+                    node.command, in_procsub=not preserve_subshell_space
+                )
                 result.append(direction + "(" + formatted + ")")
                 procsub_idx += 1
                 i = j

--- a/tests/parable/fuzz-736384.tests
+++ b/tests/parable/fuzz-736384.tests
@@ -1,0 +1,7 @@
+# Fuzz 736384: preserve spaces in process substitution subshells
+
+=== process substitution subshell spacing
+$>(( "$x" ))
+---
+(command (word "$>(( \"$x\" ))"))
+---


### PR DESCRIPTION
## Summary
- Fix process substitution formatting to preserve explicit subshell spacing (MRE: `$>(( "$x" ))`).
- Add regression test in `tests/parable/fuzz-736384.tests`.

## Test plan
- [ ] New test added to `tests/parable/fuzz-736384.tests`
- [ ] `just check` passes
