### PR TITLE
fuzzer fix: escape trailing backslash in redirect target

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1502,6 +1502,10 @@ class Redirect extends Node {
 		target_val = this.target._stripLocaleStringDollars(target_val);
 		// Format command/process substitutions (uses self.target for parts access)
 		target_val = this.target._formatCommandSubstitutions(target_val);
+		// Escape trailing backslash (would escape the closing quote otherwise)
+		if (target_val.endsWith("\\") && !target_val.endsWith("\\\\")) {
+			target_val = `${target_val}\\`;
+		}
 		// For fd duplication, target starts with & (e.g., "&1", "&2", "&-")
 		if (target_val.startsWith("&")) {
 			// Determine the real operator

--- a/src/parable.py
+++ b/src/parable.py
@@ -1216,6 +1216,9 @@ class Redirect(Node):
         target_val = self.target._strip_locale_string_dollars(target_val)
         # Format command/process substitutions (uses self.target for parts access)
         target_val = self.target._format_command_substitutions(target_val)
+        # Escape trailing backslash (would escape the closing quote otherwise)
+        if target_val.endswith("\\") and not target_val.endswith("\\\\"):
+            target_val = target_val + "\\"
         # For fd duplication, target starts with & (e.g., "&1", "&2", "&-")
         if target_val.startswith("&"):
             # Determine the real operator

--- a/tests/parable/fuzz-17240.tests
+++ b/tests/parable/fuzz-17240.tests
@@ -1,0 +1,5 @@
+=== trailing backslash in redirect target
+>\
+---
+(command (redirect ">" "\\"))
+---


### PR DESCRIPTION
## Summary
- Redirect targets with trailing backslashes were not escaped in s-expr output
- MRE: `>\` - oracle outputs `(redirect ">" "\\")`, parable was outputting `(redirect ">" "\")`
- Added trailing backslash escaping to `Redirect.to_sexp()`, mirroring `HereDoc.to_sexp()`

## Test plan
- [x] New test added to `tests/parable/fuzz-17240.tests`
- [x] `just check` passes