### PR TITLE
fuzzer fix: skip ANSI-C quote expansion after $$

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -431,7 +431,8 @@ class Word extends Node {
 			} else if (
 				_startsWithAt(value, i, "$'") &&
 				!in_single_quote &&
-				!effective_in_dquote
+				!effective_in_dquote &&
+				(i === 0 || value[i - 1] !== "$")
 			) {
 				// ANSI-C quoted string - find matching closing quote
 				j = i + 2;

--- a/src/parable.py
+++ b/src/parable.py
@@ -379,7 +379,10 @@ class Word(Node):
                 result.append(value[i + 1])
                 i += 2
             elif (
-                _starts_with_at(value, i, "$'") and not in_single_quote and not effective_in_dquote
+                _starts_with_at(value, i, "$'")
+                and not in_single_quote
+                and not effective_in_dquote
+                and (i == 0 or value[i - 1] != "$")
             ):
                 # ANSI-C quoted string - find matching closing quote
                 j = i + 2

--- a/tests/parable/fuzz-30881.tests
+++ b/tests/parable/fuzz-30881.tests
@@ -1,0 +1,5 @@
+=== pid variable followed by single-quoted string
+$$'x'
+---
+(command (word "$$'x'"))
+---


### PR DESCRIPTION
## Summary
- Fix: `$$'x'` was incorrectly parsed as `$'x'` (ANSI-C quote) instead of `$$'x'` (PID variable + single-quoted string)
- The `_expand_all_ansi_c_quotes` post-processing was matching `$'` at position 1 in `$$'x'`
- Added check to skip ANSI-C expansion when `$'` is preceded by another `$`
- MRE: `$$'x'`

## Test plan
- [x] New test added to `tests/parable/fuzz-30881.tests`
- [x] `just check` passes