### PR TITLE
fuzzer fix: collect procsubs from arrays

### DIFF
--- a/tests/parable/fuzz-9972.tests
+++ b/tests/parable/fuzz-9972.tests
@@ -1,0 +1,5 @@
+=== redirect in procsub inside array assignment
+a=(<(<b))
+---
+(command (word "a=(<(< b))"))
+---


### PR DESCRIPTION
## Summary
- Process substitutions inside array assignments were not being formatted correctly (MRE: `a=(<(<b))`)
- Added `_collect_procsubs` function to recursively collect procsubs from arrays
- Also added handling for `<(` and `>(` in `_normalize_array_inner` to preserve them as-is

## Test plan
- [x] New test added to `tests/parable/fuzz-9972.tests`
- [x] `just check` passes