### PR TITLE
fuzzer fix: preserve trailing space in bare time command

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2999,7 +2999,7 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 		if (node.pipeline) {
 			return prefix + _formatCmdsubNode(node.pipeline, indent);
 		}
-		return prefix.trimEnd();
+		return prefix;
 	}
 	// Fallback: return empty for unknown types
 	return "";

--- a/src/parable.py
+++ b/src/parable.py
@@ -2630,7 +2630,7 @@ def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -
         prefix = "time -p " if node.posix else "time "
         if node.pipeline:
             return prefix + _format_cmdsub_node(node.pipeline, indent)
-        return prefix.rstrip()
+        return prefix
     # Fallback: return empty for unknown types
     return ""
 

--- a/tests/parable/fuzz-9799.tests
+++ b/tests/parable/fuzz-9799.tests
@@ -1,0 +1,5 @@
+=== time with empty pipeline in comsub
+$(time;)
+---
+(command (word "$(time )"))
+---


### PR DESCRIPTION
## Summary
- When `time` has no pipeline (e.g., `$(time;)`), Parable was stripping the trailing space from the output, producing `$(time)` instead of `$(time )` as bash-oracle expects
- MRE: `$(time;)`
- Fixed by removing `.rstrip()` call in the time serialization path

## Test plan
- [x] New test added to `tests/parable/fuzz-9799.tests`
- [x] `just check` passes