### PR TITLE
fuzzer fix: format cmdsubs in arithmetic commands

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2225,10 +2225,14 @@ class ArithmeticCommand extends Node {
 	}
 
 	toSexp() {
-		let escaped, r, redirect_parts, redirect_sexps, result;
+		let escaped, formatted, r, redirect_parts, redirect_sexps, result;
 		// bash-oracle format: (arith (word "content"))
 		// Redirects are siblings: (arith (word "...")) (redirect ...)
-		escaped = this.raw_content
+		// Format command substitutions using Word's method
+		formatted = new Word(this.raw_content)._formatCommandSubstitutions(
+			this.raw_content,
+		);
+		escaped = formatted
 			.replaceAll("\\", "\\\\")
 			.replaceAll('"', '\\"')
 			.replaceAll("\n", "\\n")

--- a/src/parable.py
+++ b/src/parable.py
@@ -1907,8 +1907,10 @@ class ArithmeticCommand(Node):
     def to_sexp(self) -> str:
         # bash-oracle format: (arith (word "content"))
         # Redirects are siblings: (arith (word "...")) (redirect ...)
+        # Format command substitutions using Word's method
+        formatted = Word(self.raw_content)._format_command_substitutions(self.raw_content)
         escaped = (
-            self.raw_content.replace("\\", "\\\\")
+            formatted.replace("\\", "\\\\")
             .replace('"', '\\"')
             .replace("\n", "\\n")
             .replace("\t", "\\t")

--- a/tests/parable/fuzz-22033.tests
+++ b/tests/parable/fuzz-22033.tests
@@ -1,0 +1,5 @@
+=== redirect inside command substitution in arith
+(($(a>b c)))
+---
+(arith (word "$(a c > b)"))
+---


### PR DESCRIPTION
## Summary
- Command substitutions inside arithmetic commands `((...))` were not being formatted correctly
- MRE: `(($(a>b c)))` - Parable output `$(a>b c)` instead of `$(a c > b)`
- Fixed by applying `_format_command_substitutions` in `ArithmeticCommand.to_sexp()`

## Test plan
- [x] New test added to `tests/parable/fuzz-22033.tests`
- [x] `just check` passes