### PR TITLE
fuzzer fix: skip semicolon after background in brace group

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2762,6 +2762,7 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 		sp,
 		term,
 		term_indent,
+		terminator,
 		then_body,
 		val,
 		variable,
@@ -3029,6 +3030,8 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 	if (node.kind === "brace-group") {
 		body = _formatCmdsubNode(node.body, indent);
 		body = body.replace(/[;]+$/, "");
+		// Don't add semicolon after background operator
+		terminator = body.endsWith(" &") ? " }" : "; }";
 		redirects = "";
 		if (node.redirects && node.redirects.length) {
 			redirect_parts = [];
@@ -3038,9 +3041,9 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 			redirects = redirect_parts.join(" ");
 		}
 		if (redirects && redirects.length) {
-			return `{ ${body}; } ${redirects}`;
+			return `{ ${body}${terminator} ${redirects}`;
 		}
-		return `{ ${body}; }`;
+		return `{ ${body}${terminator}`;
 	}
 	if (node.kind === "arith-cmd") {
 		return `((${node.raw_content}))`;

--- a/src/parable.py
+++ b/src/parable.py
@@ -2654,6 +2654,8 @@ def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -
     if node.kind == "brace-group":
         body = _format_cmdsub_node(node.body, indent)
         body = body.rstrip(";")  # Strip trailing semicolons before adding our own
+        # Don't add semicolon after background operator
+        terminator = " }" if body.endswith(" &") else "; }"
         redirects = ""
         if node.redirects:
             redirect_parts = []
@@ -2661,8 +2663,8 @@ def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -
                 redirect_parts.append(_format_redirect(r))
             redirects = " ".join(redirect_parts)
         if redirects:
-            return "{ " + body + "; } " + redirects
-        return "{ " + body + "; }"
+            return "{ " + body + terminator + " " + redirects
+        return "{ " + body + terminator
     if node.kind == "arith-cmd":
         return "((" + node.raw_content + "))"
     if node.kind == "cond-expr":

--- a/tests/parable/fuzz-20337.tests
+++ b/tests/parable/fuzz-20337.tests
@@ -1,0 +1,5 @@
+=== background in brace group inside command substitution
+$({ x& })
+---
+(command (word "$({ x & })"))
+---


### PR DESCRIPTION
## Summary
- When a brace group ends with a background operator (`&`), Parable was incorrectly adding a semicolon before `}`, producing `{ x &; }` instead of `{ x & }`
- MRE: `$({ x& })`

## Test plan
- [x] New test added to `tests/parable/fuzz-20337.tests`
- [x] `just check` passes