### PR TITLE
fuzzer fix: strip backslash-newline in redirect arith

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1564,6 +1564,8 @@ class Redirect extends Node {
 		target_val = this.target._stripLocaleStringDollars(target_val);
 		// Format command/process substitutions (uses self.target for parts access)
 		target_val = this.target._formatCommandSubstitutions(target_val);
+		// Strip line continuations (backslash-newline) from arithmetic expressions
+		target_val = this.target._stripArithLineContinuations(target_val);
 		// Escape trailing backslash (would escape the closing quote otherwise)
 		if (target_val.endsWith("\\") && !target_val.endsWith("\\\\")) {
 			target_val = `${target_val}\\`;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1265,6 +1265,8 @@ class Redirect(Node):
         target_val = self.target._strip_locale_string_dollars(target_val)
         # Format command/process substitutions (uses self.target for parts access)
         target_val = self.target._format_command_substitutions(target_val)
+        # Strip line continuations (backslash-newline) from arithmetic expressions
+        target_val = self.target._strip_arith_line_continuations(target_val)
         # Escape trailing backslash (would escape the closing quote otherwise)
         if target_val.endswith("\\") and not target_val.endswith("\\\\"):
             target_val = target_val + "\\"

--- a/tests/parable/fuzz-7380.tests
+++ b/tests/parable/fuzz-7380.tests
@@ -1,0 +1,6 @@
+=== strip backslash-newline in redirect arith
+>$((1\
+2))
+---
+(command (redirect ">" "$((12))"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where backslash-newline continuations inside arithmetic expressions were not stripped in redirect targets
- MRE: `>$((1\↵2))` was producing `$((1\↵2))` instead of `$((12))`
- Added call to `_strip_arith_line_continuations` in `Redirect.to_sexp()` to match `Word.to_sexp()` behavior

## Test plan
- [x] New test added to `tests/parable/fuzz-7380.tests`
- [x] `just check` passes