### PR TITLE
fuzzer fix: don't reformat cmdsubs inside extglobs

### DIFF
--- a/tests/parable/fuzz-23538.tests
+++ b/tests/parable/fuzz-23538.tests
@@ -1,0 +1,5 @@
+=== cmdsub inside extglob not reformatted
+echo @($(e&f))
+---
+(command (word "echo") (word "@($(e&f))"))
+---


### PR DESCRIPTION
## Summary
- Inside extended glob patterns like `@(...)`, command substitutions should not be reformatted
- MRE: `echo @($(e&f))` - oracle outputs `@($(e&f))`, Parable was outputting `@($(e & f))`
- Fix tracks extglob depth in `_format_command_substitutions` and skips formatting when inside extglobs