### PR TITLE
fuzzer fix: stop heredoc scan at closing paren in cmdsub

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3337,6 +3337,7 @@ function _skipHeredoc(value, start) {
 		line,
 		line_end,
 		line_start,
+		paren_depth,
 		quote_char,
 		stripped;
 	i = start + 2;
@@ -3371,17 +3372,32 @@ function _skipHeredoc(value, start) {
 		}
 		delimiter = value.slice(delim_start, i);
 	} else {
-		// Unquoted delimiter
-		while (i < value.length && !_isWhitespace(value[i])) {
+		// Unquoted delimiter - stop at metacharacters like )
+		while (i < value.length && !_isMetachar(value[i])) {
 			i += 1;
 		}
 		delimiter = value.slice(delim_start, i);
 	}
 	// Skip to end of line (heredoc content starts on next line)
+	// But track paren depth - if we hit a ) at depth 0, it closes the cmdsub
+	paren_depth = 0;
 	while (i < value.length && value[i] !== "\n") {
+		if (value[i] === "(") {
+			paren_depth += 1;
+		} else if (value[i] === ")") {
+			if (paren_depth === 0) {
+				// This ) closes the enclosing command substitution, stop here
+				break;
+			}
+			paren_depth -= 1;
+		}
 		i += 1;
 	}
-	if (i < value.length) {
+	// If we stopped at ) (closing cmdsub), return here - no heredoc content
+	if (i < value.length && value[i] === ")") {
+		return i;
+	}
+	if (i < value.length && value[i] === "\n") {
 		i += 1;
 	}
 	// Find the end delimiter on its own line

--- a/tests/parable/fuzz-18243.tests
+++ b/tests/parable/fuzz-18243.tests
@@ -1,0 +1,5 @@
+=== heredoc in cmdsub inside dquote
+"$(<<a)"
+---
+(command (word "\"$(<<a\na\n)\""))
+---


### PR DESCRIPTION
## Summary
- Fixed `_skip_heredoc` to track paren depth when scanning for end of line
- When `)` is encountered at depth 0, return immediately as it closes the cmdsub
- MRE: `"$(<<a)"` - was missing the closing `"`

## Test plan
- [x] New test added to `tests/parable/fuzz-18243.tests`
- [x] `just check` passes