### PR TITLE
fuzzer fix: no semicolon after background in brace cmdsub

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -984,7 +984,8 @@ class Word extends Node {
 			procsub_idx,
 			procsub_parts,
 			raw_content,
-			result;
+			result,
+			terminator;
 		// Collect command substitutions from all parts, including nested ones
 		cmdsub_parts = [];
 		procsub_parts = [];
@@ -1179,7 +1180,9 @@ class Word extends Node {
 						parsed = parser.parseList();
 						if (parsed) {
 							formatted = _formatCmdsubNode(parsed);
-							result.push(`${prefix + formatted}; }`);
+							formatted = formatted.replace(/[;]+$/, "");
+							terminator = formatted.endsWith(" &") ? " }" : "; }";
+							result.push(prefix + formatted + terminator);
 						} else {
 							result.push("${ }");
 						}

--- a/src/parable.py
+++ b/src/parable.py
@@ -959,7 +959,9 @@ class Word(Node):
                         parsed = parser.parse_list()
                         if parsed:
                             formatted = _format_cmdsub_node(parsed)
-                            result.append(prefix + formatted + "; }")
+                            formatted = formatted.rstrip(";")
+                            terminator = " }" if formatted.endswith(" &") else "; }"
+                            result.append(prefix + formatted + terminator)
                         else:
                             result.append("${ }")
                     except Exception:

--- a/tests/parable/fuzz-5283.tests
+++ b/tests/parable/fuzz-5283.tests
@@ -1,0 +1,5 @@
+=== brace cmdsub with trailing background
+${ a&}
+---
+(command (word "${ a & }"))
+---


### PR DESCRIPTION
## Summary
- When formatting `${ ...}` brace command substitutions, don't add semicolon after background operator
- MRE: `${ a&}` was formatted as `${ a &; }` instead of `${ a & }`

## Test plan
- [x] New test added to `tests/parable/fuzz-5283.tests`
- [x] `just check` passes