### PR TITLE
fuzzer fix: preserve $'...' in double quotes inside param expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -409,8 +409,8 @@ class Word extends Node {
 					continue;
 				}
 			}
-			// Inside ${...}, we can expand $'...' even if originally in double quotes
-			effective_in_dquote = in_double_quote && brace_depth === 0;
+			// Double quotes inside ${...} still protect $'...' from expansion
+			effective_in_dquote = in_double_quote;
 			// Track quote state to avoid matching $' inside regular quotes
 			if (ch === "'" && !effective_in_dquote) {
 				// Toggle quote state unless this is $' (handled below)

--- a/src/parable.py
+++ b/src/parable.py
@@ -360,8 +360,8 @@ class Word(Node):
                         in_single_quote, in_double_quote = quote_stack.pop()
                     i += 1
                     continue
-            # Inside ${...}, we can expand $'...' even if originally in double quotes
-            effective_in_dquote = in_double_quote and brace_depth == 0
+            # Double quotes inside ${...} still protect $'...' from expansion
+            effective_in_dquote = in_double_quote
             # Track quote state to avoid matching $' inside regular quotes
             if ch == "'" and not effective_in_dquote:
                 # Toggle quote state unless this is $' (handled below)

--- a/tests/parable/fuzz-6402.tests
+++ b/tests/parable/fuzz-6402.tests
@@ -1,0 +1,5 @@
+=== dollar-single-quote inside double quotes in param expansion
+${a-"$'x'"}
+---
+(command (word "${a-\"$'x'\"}"))
+---


### PR DESCRIPTION
## Summary
- When `$'...'` (ANSI-C quoting) appears inside double quotes within a parameter expansion like `${a-"$'x'"}`, it should be preserved literally, not expanded
- MRE: `${a-"$'x'"}` - oracle outputs `${a-"$'x'"}`, parable was incorrectly outputting `${a-"x"}`
- Fix: removed incorrect `brace_depth == 0` condition that was ignoring double quotes inside `${...}`

## Test plan
- [x] New test added to `tests/parable/fuzz-6402.tests`
- [x] `just check` passes