### PR TITLE
fuzzer fix: preserve $$ before double quotes

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -487,7 +487,14 @@ class Word extends Node {
 	}
 
 	_stripLocaleStringDollars(value) {
-		let brace_depth, ch, i, in_double_quote, in_single_quote, result;
+		let brace_depth,
+			ch,
+			dollar_count,
+			i,
+			in_double_quote,
+			in_single_quote,
+			j,
+			result;
 		result = [];
 		i = 0;
 		in_single_quote = false;
@@ -523,10 +530,23 @@ class Word extends Node {
 				!in_double_quote &&
 				brace_depth === 0
 			) {
-				// Locale string $"..." outside quotes - strip the $ and enter double quote
-				result.push('"');
-				in_double_quote = true;
-				i += 2;
+				// Count consecutive $ chars ending at i to check for $$ (PID param)
+				dollar_count = 1;
+				j = i - 1;
+				while (j >= 0 && value[j] === "$") {
+					dollar_count += 1;
+					j -= 1;
+				}
+				if (dollar_count % 2 === 1) {
+					// Odd count: locale string $"..." - strip the $ and enter double quote
+					result.push('"');
+					in_double_quote = true;
+					i += 2;
+				} else {
+					// Even count: this $ is part of $$ (PID), just append it
+					result.push(ch);
+					i += 1;
+				}
 			} else {
 				result.push(ch);
 				i += 1;

--- a/src/parable.py
+++ b/src/parable.py
@@ -461,10 +461,21 @@ class Word(Node):
                 and not in_double_quote
                 and brace_depth == 0
             ):
-                # Locale string $"..." outside quotes - strip the $ and enter double quote
-                result.append('"')
-                in_double_quote = True
-                i += 2
+                # Count consecutive $ chars ending at i to check for $$ (PID param)
+                dollar_count = 1
+                j = i - 1
+                while j >= 0 and value[j] == "$":
+                    dollar_count += 1
+                    j -= 1
+                if dollar_count % 2 == 1:
+                    # Odd count: locale string $"..." - strip the $ and enter double quote
+                    result.append('"')
+                    in_double_quote = True
+                    i += 2
+                else:
+                    # Even count: this $ is part of $$ (PID), just append it
+                    result.append(ch)
+                    i += 1
             else:
                 result.append(ch)
                 i += 1

--- a/tests/parable/fuzz-20737.tests
+++ b/tests/parable/fuzz-20737.tests
@@ -1,0 +1,5 @@
+=== $$ followed by double quote should not strip $
+: $$"x"
+---
+(command (word ":") (word "$$\"x\""))
+---


### PR DESCRIPTION
## Summary
- Fixed `_strip_locale_string_dollars` to correctly handle `$$"..."` patterns
- MRE: `: $$"x"` was outputting `$"x"` instead of `$$"x"`
- The bug occurred because `$"` was incorrectly detected as a locale string when preceded by `$` (which forms the `$$` PID special param)
- Fix: count consecutive `$` chars and only treat as locale string if count is odd

## Test plan
- [x] New test added to `tests/parable/fuzz-20737.tests`
- [x] `just check` passes