### PR TITLE
fuzzer fix: fall through to regular parsing when ${! has no valid param name

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6333,9 +6333,13 @@ class Parser {
 						return [new ParamIndirect(param, op, arg), text];
 					}
 				}
+				// Fell through - pattern didn't match, return None
+				this.pos = start;
+				return [null, ""];
+			} else {
+				// ${! followed by non-param char like | - fall through to regular parsing
+				this.pos = start + 2;
 			}
-			this.pos = start;
-			return [null, ""];
 		}
 		// ${param} or ${param<op><arg>}
 		param = this._consumeParamName();

--- a/src/parable.py
+++ b/src/parable.py
@@ -5434,8 +5434,12 @@ class Parser:
                         arg = "".join(arg_chars)
                         text = _substring(self.source, start, self.pos)
                         return ParamIndirect(param, op, arg), text
-            self.pos = start
-            return None, ""
+                # Fell through - pattern didn't match, return None
+                self.pos = start
+                return None, ""
+            else:
+                # ${! followed by non-param char like | - fall through to regular parsing
+                self.pos = start + 2  # reset to just after ${
 
         # ${param} or ${param<op><arg>}
         param = self._consume_param_name()

--- a/tests/parable/fuzz-21421.tests
+++ b/tests/parable/fuzz-21421.tests
@@ -1,0 +1,7 @@
+=== pipe char after indirect bang not treated as operator
+a
+${!|y}
+---
+(command (word "a"))
+(command (word "${!|y}"))
+---


### PR DESCRIPTION
## Summary
- When `${!` is followed by a character that's not a valid parameter name (like `|`), the indirect expansion parser was returning None, causing the word parser to treat `|` as a pipe operator
- Now it falls through to the regular parameter expansion code which has a fallback handler
- MRE: `a\n${!|y}`

## Test plan
- [x] New test added to `tests/parable/fuzz-21421.tests`
- [x] `just check` passes