### PR TITLE
fuzzer fix: fall through to literal when process sub content unparseable

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4300,9 +4300,13 @@ class Parser {
 				if (procsub_node) {
 					parts.push(procsub_node);
 					chars.push(procsub_text);
+				} else if (procsub_text) {
+					// Not a valid process substitution, treat full <(...) as literal
+					chars.push(procsub_text);
 				} else {
-					// Not a process substitution, treat as metacharacter
-					break;
+					// Couldn't parse at all, treat <( as literal chars
+					chars.push(this.advance());
+					chars.push(this.advance());
 				}
 			} else if (
 				ch === "(" &&
@@ -5023,6 +5027,11 @@ class Parser {
 		cmd = sub_parser.parseList();
 		if (cmd == null) {
 			cmd = new Empty();
+		}
+		// If content wasn't fully consumed, this isn't a valid process substitution
+		// Return the text so caller can treat it as literal characters
+		if (!sub_parser.atEnd()) {
+			return [null, text];
 		}
 		return [new ProcessSubstitution(direction, cmd), text];
 	}

--- a/src/parable.py
+++ b/src/parable.py
@@ -3690,9 +3690,13 @@ class Parser:
                 if procsub_node:
                     parts.append(procsub_node)
                     chars.append(procsub_text)
+                elif procsub_text:
+                    # Not a valid process substitution, treat full <(...) as literal
+                    chars.append(procsub_text)
                 else:
-                    # Not a process substitution, treat as metacharacter
-                    break
+                    # Couldn't parse at all, treat <( as literal chars
+                    chars.append(self.advance())  # <
+                    chars.append(self.advance())  # (
 
             # Array literal: name=(elements) or name+=(elements)
             elif (
@@ -4312,6 +4316,11 @@ class Parser:
         cmd = sub_parser.parse_list()
         if cmd is None:
             cmd = Empty()
+
+        # If content wasn't fully consumed, this isn't a valid process substitution
+        # Return the text so caller can treat it as literal characters
+        if not sub_parser.at_end():
+            return None, text
 
         return ProcessSubstitution(direction, cmd), text
 

--- a/tests/parable/fuzz-1061.tests
+++ b/tests/parable/fuzz-1061.tests
@@ -1,0 +1,5 @@
+=== process substitution with unparseable content preserved literally
+<((a)b)
+---
+(command (word "<((a)b)"))
+---


### PR DESCRIPTION
## Summary
- When `<(...)` looks syntactically like process substitution but the inner content doesn't fully parse as a valid command (e.g., `<((a)b)` where `(a)b` parses only as subshell `(a)` leaving `b` unconsumed), fall through to treating the entire `<(...)` as literal text
- MRE: `<((a)b)` was output as `<((a))` (losing `b)`), now correctly outputs `<((a)b)`

## Test plan
- [x] New test added to `tests/parable/fuzz-1061.tests`
- [x] `just check` passes