### PR TITLE
fuzzer fix: recognize & as special parameter only in braced expansions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3630,6 +3630,18 @@ function _isSpecialParam(c) {
 	);
 }
 
+function _isSpecialParamUnbraced(c) {
+	return (
+		c === "?" ||
+		c === "$" ||
+		c === "!" ||
+		c === "#" ||
+		c === "@" ||
+		c === "*" ||
+		c === "-"
+	);
+}
+
 function _isDigit(c) {
 	return c >= "0" && c <= "9";
 }
@@ -6233,8 +6245,8 @@ class Parser {
 			return this._parseBracedParam(start);
 		}
 		// Simple expansion $var or $special
-		// Special parameters: ?$!#@*-0-9
-		if (_isSpecialParamOrDigit(ch) || ch === "#") {
+		// Special parameters: ?$!#@*-0-9 (but NOT & which is a shell metachar)
+		if (_isSpecialParamUnbraced(ch) || _isDigit(ch) || ch === "#") {
 			this.advance();
 			text = this.source.slice(start, this.pos);
 			return [new ParamExpansion(ch), text];

--- a/src/parable.py
+++ b/src/parable.py
@@ -3137,6 +3137,11 @@ def _is_special_param(c: str) -> bool:
     )
 
 
+def _is_special_param_unbraced(c: str) -> bool:
+    """Special params valid after bare $ (excludes & which is a shell metachar)."""
+    return c == "?" or c == "$" or c == "!" or c == "#" or c == "@" or c == "*" or c == "-"
+
+
 def _is_digit(c: str) -> bool:
     return c >= "0" and c <= "9"
 
@@ -5349,8 +5354,8 @@ class Parser:
             return self._parse_braced_param(start)
 
         # Simple expansion $var or $special
-        # Special parameters: ?$!#@*-0-9
-        if _is_special_param_or_digit(ch) or ch == "#":
+        # Special parameters: ?$!#@*-0-9 (but NOT & which is a shell metachar)
+        if _is_special_param_unbraced(ch) or _is_digit(ch) or ch == "#":
             self.advance()
             text = _substring(self.source, start, self.pos)
             return ParamExpansion(ch), text

--- a/tests/parable/fuzz-25879.tests
+++ b/tests/parable/fuzz-25879.tests
@@ -1,0 +1,5 @@
+=== recognize & as metachar after bare $
+$&
+---
+(background (command (word "$")))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `$&` - the `&` character should only be treated as a special parameter inside braced expansions like `${&:-...}`, not after bare `$`
- MRE: `$&` was parsed as `(command (word "$&"))` but should be `(background (command (word "$")))`

## Test plan
- [x] New test added to `tests/parable/fuzz-25879.tests`
- [x] `just check` passes