### PR TITLE
fuzzer fix: don't treat & as special parameter in simple $X expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3630,6 +3630,18 @@ function _isSpecialParam(c) {
 	);
 }
 
+function _isSimpleSpecialParam(c) {
+	return (
+		c === "?" ||
+		c === "$" ||
+		c === "!" ||
+		c === "#" ||
+		c === "@" ||
+		c === "*" ||
+		c === "-"
+	);
+}
+
 function _isDigit(c) {
 	return c >= "0" && c <= "9";
 }
@@ -3708,6 +3720,10 @@ function _isArrayAssignmentPrefix(chars) {
 
 function _isSpecialParamOrDigit(c) {
 	return _isSpecialParam(c) || _isDigit(c);
+}
+
+function _isSimpleSpecialParamOrDigit(c) {
+	return _isSimpleSpecialParam(c) || _isDigit(c);
 }
 
 function _isParamExpansionOp(c) {
@@ -6242,8 +6258,8 @@ class Parser {
 			return this._parseBracedParam(start);
 		}
 		// Simple expansion $var or $special
-		// Special parameters: ?$!#@*-0-9
-		if (_isSpecialParamOrDigit(ch) || ch === "#") {
+		// Special parameters: ?$!#@*-0-9 (but not & which is the background operator)
+		if (_isSimpleSpecialParamOrDigit(ch) || ch === "#") {
 			this.advance();
 			text = this.source.slice(start, this.pos);
 			return [new ParamExpansion(ch), text];

--- a/src/parable.py
+++ b/src/parable.py
@@ -3137,6 +3137,15 @@ def _is_special_param(c: str) -> bool:
     )
 
 
+def _is_simple_special_param(c: str) -> bool:
+    """Special parameters valid for unbraced $X expansion in command context.
+
+    Unlike braced ${&} or arithmetic $(($&)), simple $& in command context
+    should not treat & as a special parameter since & is the background operator.
+    """
+    return c == "?" or c == "$" or c == "!" or c == "#" or c == "@" or c == "*" or c == "-"
+
+
 def _is_digit(c: str) -> bool:
     return c >= "0" and c <= "9"
 
@@ -3206,6 +3215,10 @@ def _is_array_assignment_prefix(chars: list[str]) -> bool:
 
 def _is_special_param_or_digit(c: str) -> bool:
     return _is_special_param(c) or _is_digit(c)
+
+
+def _is_simple_special_param_or_digit(c: str) -> bool:
+    return _is_simple_special_param(c) or _is_digit(c)
 
 
 def _is_param_expansion_op(c: str) -> bool:
@@ -5358,8 +5371,8 @@ class Parser:
             return self._parse_braced_param(start)
 
         # Simple expansion $var or $special
-        # Special parameters: ?$!#@*-0-9
-        if _is_special_param_or_digit(ch) or ch == "#":
+        # Special parameters: ?$!#@*-0-9 (but not & which is the background operator)
+        if _is_simple_special_param_or_digit(ch) or ch == "#":
             self.advance()
             text = _substring(self.source, start, self.pos)
             return ParamExpansion(ch), text

--- a/tests/parable/fuzz-18310.tests
+++ b/tests/parable/fuzz-18310.tests
@@ -1,0 +1,5 @@
+=== ampersand is not a special parameter
+$&
+---
+(background (command (word "$")))
+---


### PR DESCRIPTION
## Summary
- In simple unbraced expansion `$&`, the `&` should not be treated as a special parameter since it's the background operator
- MRE: `$&` - oracle parses as `(background (command (word "$")))` but Parable was treating it as `(command (word "$&"))`
- Fix: Add `_is_simple_special_param` that excludes `&`, used only for simple `$X` expansion in command context
- Braced `${&}` and arithmetic `$(($&))` contexts still correctly treat `&` as a valid parameter