### PR TITLE
fuzzer fix: reject empty subscript in braced fd variables

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6835,7 +6835,11 @@ class Parser {
 					if (varname.includes("[") || varname.includes("]")) {
 						left = varname.indexOf("[");
 						right = varname.lastIndexOf("]");
-						if (left !== -1 && right === varname.length - 1 && right > left) {
+						if (
+							left !== -1 &&
+							right === varname.length - 1 &&
+							right > left + 1
+						) {
 							base = varname.slice(0, left);
 							if (
 								base.length > 0 &&

--- a/src/parable.py
+++ b/src/parable.py
@@ -5837,7 +5837,7 @@ class Parser:
                     if "[" in varname or "]" in varname:
                         left = varname.find("[")
                         right = varname.rfind("]")
-                        if left != -1 and right == len(varname) - 1 and right > left:
+                        if left != -1 and right == len(varname) - 1 and right > left + 1:
                             base = varname[:left]
                             if base and (base[0].isalpha() or base[0] == "_"):
                                 is_valid_varfd = True

--- a/tests/parable/fuzz-24189.tests
+++ b/tests/parable/fuzz-24189.tests
@@ -1,0 +1,5 @@
+=== brace with empty subscript before redirect is a word, not fd var
+{a[]}<x
+---
+(command (word "{a[]}") (redirect "<" "x"))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `{varname[]}<x` where empty brackets should not be a valid fd variable
- MRE: `{a[]}<x` was parsed as `(redirect "{a[]}<" "x")` instead of `(word "{a[]}") (redirect "<" "x")`
- Changed subscript validation from `right > left` to `right > left + 1` to require non-empty subscript

## Test plan
- [x] New test added to `tests/parable/fuzz-24189.tests`
- [x] `just check` passes