### PR TITLE
fuzzer fix: normalize whitespace in subscripted array appends

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -556,8 +556,15 @@ class Word extends Node {
 	}
 
 	_normalizeArrayWhitespace(value) {
-		let close_paren_pos, i, inner, open_paren_pos, prefix, result, suffix;
-		// Match array assignment pattern: name=( or name+=(
+		let close_paren_pos,
+			depth,
+			i,
+			inner,
+			open_paren_pos,
+			prefix,
+			result,
+			suffix;
+		// Match array assignment pattern: name=( or name+=( or name[sub]=( or name[sub]+=(
 		// Parse identifier: starts with letter/underscore, then alnum/underscore
 		i = 0;
 		if (
@@ -571,6 +578,22 @@ class Word extends Node {
 			(/^[a-zA-Z0-9]$/.test(value[i]) || value[i] === "_")
 		) {
 			i += 1;
+		}
+		// Optional subscript(s): [...]
+		while (i < value.length && value[i] === "[") {
+			depth = 1;
+			i += 1;
+			while (i < value.length && depth > 0) {
+				if (value[i] === "[") {
+					depth += 1;
+				} else if (value[i] === "]") {
+					depth -= 1;
+				}
+				i += 1;
+			}
+			if (depth !== 0) {
+				return value;
+			}
 		}
 		// Optional + for +=
 		if (i < value.length && value[i] === "+") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -483,7 +483,7 @@ class Word(Node):
 
     def _normalize_array_whitespace(self, value: str) -> str:
         """Normalize whitespace inside array assignments: arr=(a  b\tc) -> arr=(a b c)."""
-        # Match array assignment pattern: name=( or name+=(
+        # Match array assignment pattern: name=( or name+=( or name[sub]=( or name[sub]+=(
         # Parse identifier: starts with letter/underscore, then alnum/underscore
         i = 0
         if not (i < len(value) and (value[i].isalpha() or value[i] == "_")):
@@ -491,6 +491,18 @@ class Word(Node):
         i += 1
         while i < len(value) and (value[i].isalnum() or value[i] == "_"):
             i += 1
+        # Optional subscript(s): [...]
+        while i < len(value) and value[i] == "[":
+            depth = 1
+            i += 1
+            while i < len(value) and depth > 0:
+                if value[i] == "[":
+                    depth += 1
+                elif value[i] == "]":
+                    depth -= 1
+                i += 1
+            if depth != 0:
+                return value
         # Optional + for +=
         if i < len(value) and value[i] == "+":
             i += 1

--- a/tests/parable/fuzz-29687.tests
+++ b/tests/parable/fuzz-29687.tests
@@ -1,0 +1,5 @@
+=== strip leading whitespace in subscripted array append
+a[0]+=( 1)
+---
+(command (word "a[0]+=(1)"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_normalize_array_whitespace` to handle subscripted array assignments like `a[0]+=(...)` 
- Previously only handled `name=(` or `name+=(` patterns, missing `name[sub]=(`
- MRE: `a[0]+=( 1)` was parsed as `a[0]+=( 1)` instead of `a[0]+=(1)`

## Test plan
- [x] New test added to `tests/parable/fuzz-29687.tests`
- [x] `just check` passes