### PR TITLE
fuzzer fix: strip backslash-newline in arithmetic commands

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7421,6 +7421,8 @@ class Parser {
 			return null;
 		}
 		content = this.source.slice(content_start, this.pos);
+		// Strip backslash-newline line continuations
+		content = content.replaceAll("\\\n", "");
 		this.advance();
 		this.advance();
 		// Parse the arithmetic expression

--- a/src/parable.py
+++ b/src/parable.py
@@ -6300,6 +6300,8 @@ class Parser:
             return None
 
         content = _substring(self.source, content_start, self.pos)
+        # Strip backslash-newline line continuations
+        content = content.replace("\\\n", "")
         self.advance()  # consume first )
         self.advance()  # consume second )
 

--- a/tests/parable/fuzz-3173.tests
+++ b/tests/parable/fuzz-3173.tests
@@ -1,0 +1,6 @@
+=== backslash-newline line continuation inside arithmetic
+((\
+1))
+---
+(arith (word "1"))
+---


### PR DESCRIPTION
## Summary
- Backslash-newline line continuations inside `((...))` arithmetic commands were not being stripped
- MRE: `((\<newline>1))` → Parable produced `(arith (word "\\\n1"))` instead of `(arith (word "1"))`
- Fixed by stripping `\<newline>` from content in `parse_arithmetic_command`

## Test plan
- [x] New test added to `tests/parable/fuzz-3173.tests`
- [x] `just check` passes