### PR TITLE
fuzzer fix: handle heredoc delimiter followed by ) in cmdsub formatting

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3408,7 +3408,8 @@ function _skipHeredoc(value, start) {
 		line_start,
 		paren_depth,
 		quote_char,
-		stripped;
+		stripped,
+		tabs_stripped;
 	i = start + 2;
 	// Handle <<- (strip tabs)
 	if (i < value.length && value[i] === "-") {
@@ -3491,6 +3492,16 @@ function _skipHeredoc(value, start) {
 			} else {
 				return line_end;
 			}
+		}
+		// Check if delimiter followed by ) which closes cmdsub
+		if (
+			stripped.startsWith(delimiter) &&
+			stripped.length > delimiter.length &&
+			stripped[delimiter.length] === ")"
+		) {
+			// Return position of the ) so caller can close the cmdsub
+			tabs_stripped = line.length - stripped.length;
+			return line_start + tabs_stripped + delimiter.length;
 		}
 		if (line_end < value.length) {
 			i = line_end + 1;

--- a/src/parable.py
+++ b/src/parable.py
@@ -3010,6 +3010,15 @@ def _skip_heredoc(value: str, start: int) -> int:
                 return line_end + 1
             else:
                 return line_end
+        # Check if delimiter followed by ) which closes cmdsub
+        if (
+            stripped.startswith(delimiter)
+            and len(stripped) > len(delimiter)
+            and stripped[len(delimiter)] == ")"
+        ):
+            # Return position of the ) so caller can close the cmdsub
+            tabs_stripped = len(line) - len(stripped)
+            return line_start + tabs_stripped + len(delimiter)
         if line_end < len(value):
             i = line_end + 1
         else:

--- a/tests/parable/fuzz-23181.tests
+++ b/tests/parable/fuzz-23181.tests
@@ -1,0 +1,6 @@
+=== heredoc in command substitution drops trailing content
+$(<<a
+a)x
+---
+(command (word "$(<<a\na\n)x"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_skip_heredoc` to recognize when a heredoc delimiter is immediately followed by `)` inside a command substitution
- This caused `_format_command_substitutions` to scan past the `)` and lose trailing content
- MRE: `$(<<a\na)x` was incorrectly formatted as `$(<<a\na\n)` instead of `$(<<a\na\n)x`

## Test plan
- [x] New test added to `tests/parable/fuzz-23181.tests`
- [x] `just check` passes