### PR TITLE
fuzzer fix: normalize pipes in arith-for command substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1889,6 +1889,7 @@ class ForArith extends Node {
 			w = new Word(s, []);
 			val = w._expandAllAnsiCQuotes(s);
 			val = w._stripLocaleStringDollars(val);
+			val = w._formatCommandSubstitutions(val);
 			val = val.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 			val = val.replaceAll("\n", "\\n").replaceAll("\t", "\\t");
 			return val;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1574,6 +1574,7 @@ class ForArith(Node):
             w = Word(s, [])
             val = w._expand_all_ansi_c_quotes(s)
             val = w._strip_locale_string_dollars(val)
+            val = w._format_command_substitutions(val)
             val = val.replace("\\", "\\\\").replace('"', '\\"')
             val = val.replace("\n", "\\n").replace("\t", "\\t")
             return val

--- a/tests/parable/fuzz-12388.tests
+++ b/tests/parable/fuzz-12388.tests
@@ -1,0 +1,5 @@
+=== pipe normalization in arith-for command substitution
+for (( $(a|b); ; )); do :; done
+---
+(arith-for (init (word "$(a | b)")) (test (word "1")) (step (word "1")) (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- `ForArith.to_sexp()` wasn't normalizing pipes inside command substitutions
- MRE: `for (( $(a|b); ; )); do :; done` → Parable output `$(a|b)`, oracle expects `$(a | b)`
- Added `_format_command_substitutions()` call to `format_arith_val()` helper

## Test plan
- [x] New test added to `tests/parable/fuzz-12388.tests`
- [x] `just check` passes