### PR TITLE
fuzzer fix: allow newlines in varprefix expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6359,7 +6359,7 @@ class Parser {
 				// These are NOT operators - the @/* is part of the indirect form
 				if (!this.atEnd() && _isAtOrStar(this.peek())) {
 					suffix = this.advance();
-					while (!this.atEnd() && _isWhitespaceNoNewline(this.peek())) {
+					while (!this.atEnd() && _isWhitespace(this.peek())) {
 						this.advance();
 					}
 					if (!this.atEnd() && this.peek() === "}") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -5439,7 +5439,7 @@ class Parser:
                 # These are NOT operators - the @/* is part of the indirect form
                 if not self.at_end() and _is_at_or_star(self.peek()):
                     suffix = self.advance()
-                    while not self.at_end() and _is_whitespace_no_newline(self.peek()):
+                    while not self.at_end() and _is_whitespace(self.peek()):
                         self.advance()
                     if not self.at_end() and self.peek() == "}":
                         self.advance()

--- a/tests/parable/fuzz-7542.tests
+++ b/tests/parable/fuzz-7542.tests
@@ -1,0 +1,6 @@
+=== newline in varprefix expansion
+${!x*
+}a
+---
+(command (word "${!x*\n}a"))
+---


### PR DESCRIPTION
## Summary
- Parable was splitting `${!prefix*}` and `${!prefix@}` at newlines before the closing brace
- MRE: `${!x*\n}a` parsed as two commands instead of one word
- Fix: allow any whitespace (including newlines) before closing brace in prefix match

## Test plan
- [x] New test added to `tests/parable/fuzz-7542.tests`
- [x] `just check` passes