### PR TITLE
fuzzer fix: reject braced fd variable before &> and &>>

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6926,8 +6926,8 @@ class Parser {
 			this.pos + 1 < this.length &&
 			this.source[this.pos + 1] === ">"
 		) {
-			if (fd != null) {
-				// We consumed digits that should be a word, not an fd
+			if (fd != null || varfd != null) {
+				// We consumed digits/varfd that should be a word, not an fd
 				// Restore position and let parse_word handle them
 				this.pos = start;
 				return null;

--- a/src/parable.py
+++ b/src/parable.py
@@ -5894,8 +5894,8 @@ class Parser:
         # they should be a separate word, not an fd. E.g., "2&>1" is command "2"
         # with redirect "&> 1", not fd 2 redirected.
         if ch == "&" and self.pos + 1 < self.length and self.source[self.pos + 1] == ">":
-            if fd is not None:
-                # We consumed digits that should be a word, not an fd
+            if fd is not None or varfd is not None:
+                # We consumed digits/varfd that should be a word, not an fd
                 # Restore position and let parse_word handle them
                 self.pos = start
                 return None

--- a/tests/parable/fuzz-16010.tests
+++ b/tests/parable/fuzz-16010.tests
@@ -1,0 +1,5 @@
+=== braced fd variable before &> is a word not fd variable
+{fd}&>1
+---
+(command (word "{fd}") (redirect "&>" "1"))
+---


### PR DESCRIPTION
## Summary
- Parable incorrectly allowed braced fd variables (`{varname}`) before `&>` and `&>>` operators
- MRE: `{fd}&>1` was parsed as `(command (redirect "&>" "1"))` instead of `(command (word "{fd}") (redirect "&>" "1"))`
- Fix: check for `varfd is not None` in addition to `fd is not None` when encountering `&>` or `&>>`

- [x] New test added to `tests/parable/fuzz-16010.tests`
- [x] `just check` passes