### PR TITLE
fuzzer fix: normalize whitespace in for loop variable command substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1139,7 +1139,7 @@ class Word extends Node {
 					try {
 						parser = new Parser(inner);
 						parsed = parser.parseList();
-						formatted = parsed ? _formatCmdsubNode(parsed) : inner;
+						formatted = parsed ? _formatCmdsubNode(parsed) : "";
 					} catch (_) {
 						formatted = inner;
 					}
@@ -1829,7 +1829,15 @@ class For extends Node {
 	}
 
 	toSexp() {
-		let r, redirect_parts, suffix, var_escaped, w, word_parts, word_strs;
+		let r,
+			redirect_parts,
+			suffix,
+			temp_word,
+			var_escaped,
+			var_formatted,
+			w,
+			word_parts,
+			word_strs;
 		// bash-oracle format: (for (word "var") (in (word "a") ...) body)
 		suffix = "";
 		if (this.redirects && this.redirects.length) {
@@ -1839,7 +1847,10 @@ class For extends Node {
 			}
 			suffix = ` ${redirect_parts.join(" ")}`;
 		}
-		var_escaped = this.variable.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+		// Format command substitutions in var (e.g., for $(echo i) normalizes whitespace)
+		temp_word = new Word(this.variable, []);
+		var_formatted = temp_word._formatCommandSubstitutions(this.variable);
+		var_escaped = var_formatted.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 		if (this.words == null) {
 			// No 'in' clause - bash-oracle implies (in (word "\"$@\""))
 			return `(for (word "${var_escaped}") (in (word "\\"$@\\"")) ${this.body.toSexp()})${suffix}`;

--- a/src/parable.py
+++ b/src/parable.py
@@ -909,7 +909,7 @@ class Word(Node):
                     try:
                         parser = Parser(inner)
                         parsed = parser.parse_list()
-                        formatted = _format_cmdsub_node(parsed) if parsed else inner
+                        formatted = _format_cmdsub_node(parsed) if parsed else ""
                     except Exception:
                         formatted = inner
                 # Add space after $( if content starts with ( to avoid $((
@@ -1517,7 +1517,10 @@ class For(Node):
             for r in self.redirects:
                 redirect_parts.append(r.to_sexp())
             suffix = " " + " ".join(redirect_parts)
-        var_escaped = self.var.replace("\\", "\\\\").replace('"', '\\"')
+        # Format command substitutions in var (e.g., for $(echo i) normalizes whitespace)
+        temp_word = Word(self.var, [])
+        var_formatted = temp_word._format_command_substitutions(self.var)
+        var_escaped = var_formatted.replace("\\", "\\\\").replace('"', '\\"')
         if self.words is None:
             # No 'in' clause - bash-oracle implies (in (word "\"$@\""))
             return (

--- a/tests/parable/fuzz-1025.tests
+++ b/tests/parable/fuzz-1025.tests
@@ -1,0 +1,5 @@
+=== whitespace in for loop variable command substitution
+for $( )i;do :;done
+---
+(for (word "$()i") (in (word "\"$@\"")) (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug where whitespace inside command substitutions in for loop variable names wasn't being normalized
- MRE: `for $( )i;do :;done` - Parable output `$( )i` instead of `$()i`
- Two fixes:
  1. `For.to_sexp()` now formats command substitutions in the variable name before escaping
  2. `_format_command_substitutions` now returns empty string (instead of raw whitespace) when parsing whitespace-only command substitution content

## Test plan
- [x] New test added to `tests/parable/fuzz-1025.tests`
- [x] `just check` passes