### PR TITLE
fuzzer fix: strip locale $"..." inside parameter expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -527,8 +527,7 @@ class Word extends Node {
 			} else if (
 				_startsWithAt(value, i, '$"') &&
 				!in_single_quote &&
-				!in_double_quote &&
-				brace_depth === 0
+				!in_double_quote
 			) {
 				// Count consecutive $ chars ending at i to check for $$ (PID param)
 				dollar_count = 1;

--- a/src/parable.py
+++ b/src/parable.py
@@ -455,12 +455,7 @@ class Word(Node):
                 in_double_quote = not in_double_quote
                 result.append(ch)
                 i += 1
-            elif (
-                _starts_with_at(value, i, '$"')
-                and not in_single_quote
-                and not in_double_quote
-                and brace_depth == 0
-            ):
+            elif _starts_with_at(value, i, '$"') and not in_single_quote and not in_double_quote:
                 # Count consecutive $ chars ending at i to check for $$ (PID param)
                 dollar_count = 1
                 j = i - 1

--- a/tests/parable/fuzz-6926.tests
+++ b/tests/parable/fuzz-6926.tests
@@ -1,0 +1,5 @@
+=== $"..." inside parameter expansion
+${a:-$"x"}
+---
+(command (word "${a:-\"x\"}"))
+---


### PR DESCRIPTION
## Summary
- Fix: locale strings `$"..."` inside parameter expansion were not having the `$` stripped
- MRE: `${a:-$"x"}` was outputting `${a:-$"x"}` instead of `${a:-"x"}`
- The `_strip_locale_string_dollars` method was skipping stripping when `brace_depth > 0`, but we need to strip inside `${...}` too

## Test plan
- [x] New test added to `tests/parable/fuzz-6926.tests`
- [x] `just check` passes