### PR TITLE
fuzzer fix: use compact redirect formatting in subshells inside process substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2825,7 +2825,7 @@ function _formatCondBody(node) {
 	return "";
 }
 
-function _formatCmdsubNode(node, indent, in_procsub) {
+function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 	let body,
 		cmd,
 		cmds,
@@ -2872,6 +2872,9 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 	if (in_procsub == null) {
 		in_procsub = false;
 	}
+	if (compact_redirects == null) {
+		compact_redirects = false;
+	}
 	sp = " ".repeat(indent);
 	inner_sp = " ".repeat(indent + 4);
 	if (node.kind === "empty") {
@@ -2887,7 +2890,7 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 			parts.push(val);
 		}
 		for (r of node.redirects) {
-			parts.push(_formatRedirect(r));
+			parts.push(_formatRedirect(r, compact_redirects));
 		}
 		return parts.join(" ");
 	}
@@ -3103,7 +3106,7 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 		return `function ${name} () \n{ \n${inner_sp}${body}\n}`;
 	}
 	if (node.kind === "subshell") {
-		body = _formatCmdsubNode(node.body, indent, in_procsub);
+		body = _formatCmdsubNode(node.body, indent, in_procsub, in_procsub);
 		redirects = "";
 		if (node.redirects && node.redirects.length) {
 			redirect_parts = [];
@@ -3165,8 +3168,11 @@ function _formatCmdsubNode(node, indent, in_procsub) {
 	return "";
 }
 
-function _formatRedirect(r) {
+function _formatRedirect(r, compact) {
 	let after_amp, delim, is_literal_fd, op, target;
+	if (compact == null) {
+		compact = false;
+	}
 	if (r.kind === "heredoc") {
 		// Include heredoc content: <<DELIM\ncontent\nDELIM\n
 		if (r.strip_tabs) {
@@ -3217,6 +3223,9 @@ function _formatRedirect(r) {
 		} else if (op === "0<") {
 			op = "<";
 		}
+		return op + target;
+	}
+	if (compact) {
 		return op + target;
 	}
 	return `${op} ${target}`;

--- a/src/parable.py
+++ b/src/parable.py
@@ -2496,7 +2496,9 @@ def _format_cond_body(node: Node) -> str:
     return ""
 
 
-def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -> str:
+def _format_cmdsub_node(
+    node: Node, indent: int = 0, in_procsub: bool = False, compact_redirects: bool = False
+) -> str:
     """Format an AST node for command substitution output (bash-oracle pretty-print format)."""
     sp = _repeat_str(" ", indent)
     inner_sp = _repeat_str(" ", indent + 4)
@@ -2511,7 +2513,7 @@ def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -
             val = w._format_command_substitutions(val)
             parts.append(val)
         for r in node.redirects:
-            parts.append(_format_redirect(r))
+            parts.append(_format_redirect(r, compact=compact_redirects))
         return " ".join(parts)
     if node.kind == "pipeline":
         # Build list of (cmd, needs_pipe_both_redirect) filtering out PipeBoth markers
@@ -2700,7 +2702,7 @@ def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -
         body = _format_cmdsub_node(inner_body, indent + 4).rstrip(";")
         return f"function {name} () \n{{ \n{inner_sp}{body}\n}}"
     if node.kind == "subshell":
-        body = _format_cmdsub_node(node.body, indent, in_procsub)
+        body = _format_cmdsub_node(node.body, indent, in_procsub, compact_redirects=in_procsub)
         redirects = ""
         if node.redirects:
             redirect_parts = []
@@ -2746,7 +2748,7 @@ def _format_cmdsub_node(node: Node, indent: int = 0, in_procsub: bool = False) -
     return ""
 
 
-def _format_redirect(r: "Redirect | HereDoc") -> str:
+def _format_redirect(r: "Redirect | HereDoc", compact: bool = False) -> str:
     """Format a redirect for command substitution output."""
     if r.kind == "heredoc":
         # Include heredoc content: <<DELIM\ncontent\nDELIM\n
@@ -2790,6 +2792,8 @@ def _format_redirect(r: "Redirect | HereDoc") -> str:
                 op = ">"
             elif op == "0<":
                 op = "<"
+        return op + target
+    if compact:
         return op + target
     return op + " " + target
 

--- a/tests/parable/fuzz-20769.tests
+++ b/tests/parable/fuzz-20769.tests
@@ -1,0 +1,5 @@
+=== compact redirect in subshell inside process substitution
+<((<=))
+---
+(command (word "<((<=))"))
+---


### PR DESCRIPTION
## Summary
- When a redirect is inside a subshell that's inside a process substitution, the oracle formats it without a space (`<x`) while Parable was adding a space (`< x`)
- MRE: `<((<=))` — oracle shows `<((<=))`, Parable was showing `<((< =))`
- Added `compact_redirects` parameter to `_format_cmdsub_node` and `compact` to `_format_redirect` to handle this case

## Test plan
- [x] New test added to `tests/parable/fuzz-20769.tests`
- [x] `just check` passes