### PR TITLE
fuzzer fix: don't start bracket tracking after subscript close

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4107,11 +4107,7 @@ class Parser {
 					_isArrayAssignmentPrefix(chars)
 				) {
 					prev_char = chars[chars.length - 1];
-					if (
-						/^[a-zA-Z0-9]$/.test(prev_char) ||
-						prev_char === "_" ||
-						prev_char === "]"
-					) {
+					if (/^[a-zA-Z0-9]$/.test(prev_char) || prev_char === "_") {
 						bracket_depth += 1;
 						chars.push(this.advance());
 						continue;

--- a/src/parable.py
+++ b/src/parable.py
@@ -3503,7 +3503,7 @@ class Parser:
                     and _is_array_assignment_prefix(chars)
                 ):
                     prev_char = chars[len(chars) - 1]
-                    if prev_char.isalnum() or (prev_char == "_" or prev_char == "]"):
+                    if prev_char.isalnum() or prev_char == "_":
                         bracket_depth += 1
                         chars.append(self.advance())
                         continue

--- a/tests/parable/fuzz-19957.tests
+++ b/tests/parable/fuzz-19957.tests
@@ -1,0 +1,7 @@
+=== bracket after subscript is literal
+a[][
+y
+---
+(command (word "a[]["))
+(command (word "y"))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug where `[` after a completed subscript (e.g., `a[][`) incorrectly started bracket tracking
- MRE: `a[][\ny` was parsed as one word instead of two commands
- Fix: Remove `prev_char == "]"` from the bracket tracking condition

## Test plan
- [x] New test added to `tests/parable/fuzz-19957.tests`
- [x] `just check` passes