### PR TITLE
fuzzer fix: preserve newlines in array subscripts

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -666,19 +666,33 @@ class Word extends Node {
 	}
 
 	_normalizeArrayInner(inner) {
-		let brace_depth, ch, depth, dq_content, i, in_whitespace, j, normalized;
+		let brace_depth,
+			bracket_depth,
+			ch,
+			depth,
+			dq_content,
+			i,
+			in_whitespace,
+			j,
+			normalized;
 		normalized = [];
 		i = 0;
 		in_whitespace = true;
 		brace_depth = 0;
+		bracket_depth = 0;
 		while (i < inner.length) {
 			ch = inner[i];
 			if (_isWhitespace(ch)) {
-				if (!in_whitespace && normalized && brace_depth === 0) {
+				if (
+					!in_whitespace &&
+					normalized &&
+					brace_depth === 0 &&
+					bracket_depth === 0
+				) {
 					normalized.push(" ");
 					in_whitespace = true;
 				}
-				if (brace_depth > 0) {
+				if (brace_depth > 0 || bracket_depth > 0) {
 					normalized.push(ch);
 				}
 				i += 1;
@@ -851,6 +865,17 @@ class Word extends Node {
 				while (i < inner.length && inner[i] !== "\n") {
 					i += 1;
 				}
+			} else if (ch === "[") {
+				// Start of subscript [...] - preserve whitespace inside
+				in_whitespace = false;
+				normalized.push(ch);
+				bracket_depth += 1;
+				i += 1;
+			} else if (ch === "]" && bracket_depth > 0) {
+				// End of subscript
+				normalized.push(ch);
+				bracket_depth -= 1;
+				i += 1;
 			} else {
 				in_whitespace = false;
 				normalized.push(ch);

--- a/src/parable.py
+++ b/src/parable.py
@@ -562,13 +562,14 @@ class Word(Node):
         i = 0
         in_whitespace = True  # Start true to skip leading whitespace
         brace_depth = 0  # Track ${...} nesting
+        bracket_depth = 0  # Track [...] subscript nesting
         while i < len(inner):
             ch = inner[i]
             if _is_whitespace(ch):
-                if not in_whitespace and normalized and brace_depth == 0:
+                if not in_whitespace and normalized and brace_depth == 0 and bracket_depth == 0:
                     normalized.append(" ")
                     in_whitespace = True
-                if brace_depth > 0:
+                if brace_depth > 0 or bracket_depth > 0:
                     normalized.append(ch)
                 i += 1
             elif ch == "'":
@@ -703,6 +704,17 @@ class Word(Node):
                 # Comment - skip to end of line (only at top level, start of word)
                 while i < len(inner) and inner[i] != "\n":
                     i += 1
+            elif ch == "[":
+                # Start of subscript [...] - preserve whitespace inside
+                in_whitespace = False
+                normalized.append(ch)
+                bracket_depth += 1
+                i += 1
+            elif ch == "]" and bracket_depth > 0:
+                # End of subscript
+                normalized.append(ch)
+                bracket_depth -= 1
+                i += 1
             else:
                 in_whitespace = False
                 normalized.append(ch)

--- a/tests/parable/fuzz-31964.tests
+++ b/tests/parable/fuzz-31964.tests
@@ -1,0 +1,6 @@
+=== newline in array subscript inside compound assignment
+a=([
+])
+---
+(command (word "a=([\n])"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_normalize_array_inner` to preserve whitespace (including newlines) inside array subscripts `[...]`
- MRE: `a=([\n])` was being normalized to `a=([ ])` instead of preserving the newline
- Added `bracket_depth` tracking similar to existing `brace_depth` for `${...}`

## Test plan
- [x] New test added to `tests/parable/fuzz-31964.tests`
- [x] `just check` passes