### PR TITLE
fuzzer fix: no space after >& or <& in fd dup redirects

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3236,6 +3236,10 @@ function _formatRedirect(r, compact) {
 		}
 		return op + target;
 	}
+	// For >& and <& (fd dup operators), no space before target
+	if (op.endsWith("&")) {
+		return op + target;
+	}
 	if (compact) {
 		return op + target;
 	}

--- a/src/parable.py
+++ b/src/parable.py
@@ -2792,6 +2792,9 @@ def _format_redirect(r: "Redirect | HereDoc", compact: bool = False) -> str:
             elif op == "0<":
                 op = "<"
         return op + target
+    # For >& and <& (fd dup operators), no space before target
+    if op.endswith("&"):
+        return op + target
     if compact:
         return op + target
     return op + " " + target

--- a/tests/parable/fuzz-13961.tests
+++ b/tests/parable/fuzz-13961.tests
@@ -1,0 +1,5 @@
+=== no space after >& in command substitution
+$(>&x)
+---
+(command (word "$(>&x)"))
+---


### PR DESCRIPTION
## Summary
- For fd duplication redirects like `>&x` or `<&$fd`, Parable was incorrectly adding a space after the operator (outputting `>& x` instead of `>&x`)
- MRE: `$(>&x)` - oracle outputs `$(>&x)`, Parable was outputting `$(>& x)`
- Fix: in `_format_redirect`, skip adding space when the operator ends with `&` (i.e., `>&` or `<&`)

- [x] New test added to `tests/parable/fuzz-13961.tests`
- [x] `just check` passes