### PR TITLE
fuzzer fix: place & before heredoc content in command substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2850,6 +2850,7 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		inner_body,
 		inner_sp,
 		is_last,
+		last,
 		name,
 		needs_redirect,
 		p,
@@ -2988,7 +2989,15 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 					}
 					result.push("\n");
 				} else if (p.op === "&") {
-					result.push(" &");
+					// If previous command has heredoc, insert & before heredoc content
+					if (result.length > 0 && result[result.length - 1].includes("\n")) {
+						last = result[result.length - 1];
+						first_nl = last.indexOf("\n");
+						result[result.length - 1] =
+							`${last.slice(0, first_nl)} &${last.slice(first_nl)}`;
+					} else {
+						result.push(" &");
+					}
 				} else {
 					result.push(` ${p.op}`);
 				}
@@ -3007,6 +3016,10 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		}
 		// Strip trailing ; or newline
 		s = result.join("");
+		// If we have & with heredoc (& before newline content), preserve trailing newline and add space
+		if (s.includes(" &\n") && s.endsWith("\n")) {
+			return `${s} `;
+		}
 		while (s.endsWith(";") || s.endsWith("\n")) {
 			s = s.slice(0, s.length - 1);
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -2581,7 +2581,13 @@ def _format_cmdsub_node(
                         continue
                     result.append("\n")
                 elif p.op == "&":
-                    result.append(" &")
+                    # If previous command has heredoc, insert & before heredoc content
+                    if result and "\n" in result[len(result) - 1]:
+                        last = result[len(result) - 1]
+                        first_nl = last.find("\n")
+                        result[len(result) - 1] = last[:first_nl] + " &" + last[first_nl:]
+                    else:
+                        result.append(" &")
                 else:
                     result.append(" " + p.op)
             else:
@@ -2590,6 +2596,9 @@ def _format_cmdsub_node(
                 result.append(_format_cmdsub_node(p, indent))
         # Strip trailing ; or newline
         s = "".join(result)
+        # If we have & with heredoc (& before newline content), preserve trailing newline and add space
+        if " &\n" in s and s.endswith("\n"):
+            return s + " "
         while s.endswith(";") or s.endswith("\n"):
             s = _substring(s, 0, len(s) - 1)
         return s

--- a/tests/parable/fuzz-1004.tests
+++ b/tests/parable/fuzz-1004.tests
@@ -1,0 +1,7 @@
+=== async command with preceding heredoc redirect
+$(<<E a&
+E
+)
+---
+(command (word "$(a <<E &\nE\n )"))
+---


### PR DESCRIPTION
## Summary
- When a command with a heredoc is followed by `&`, the `&` should appear after the heredoc delimiter but before the content
- MRE: `$(<<E a&\nE\n)` - expected `$(a <<E &\nE\n )`, was `$(a <<E\nE\n &)`
- Also preserves trailing newline and adds space before `)` when `&` precedes heredoc in command substitution

## Test plan
- [x] New test added to `tests/parable/fuzz-1004.tests`
- [x] `just check` passes