### PR TITLE
fuzzer fix: correctly handle ANSI-C quotes after multiple dollar signs

### DIFF
--- a/tests/parable/fuzz-26765.tests
+++ b/tests/parable/fuzz-26765.tests
@@ -1,0 +1,5 @@
+=== ANSI-C quote after even number of dollar signs
+$$$'a'
+---
+(command (word "$$'a'"))
+---


### PR DESCRIPTION
## Summary
- Fixed ANSI-C quote expansion when preceded by multiple `$` signs
- The bug caused `$$$'a'` to output `$$$'a'` instead of `$$'a'` (MRE: `$$$'a'`)
- Added `_count_consecutive_dollars_before()` helper to properly determine when `$'...'` should be treated as ANSI-C vs regular quote

The fix ensures that ANSI-C expansion only occurs when there are an even number of consecutive `$` before the `$'`, matching bash's behavior where `$$` pairs consume dollar signs as the special PID variable.
