### PR TITLE
fuzzer fix: reject semicolons inside conditional expressions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7892,6 +7892,10 @@ class Parser {
 			) {
 				break;
 			}
+			// Semicolons are not valid inside conditionals
+			if (ch === ";") {
+				break;
+			}
 			// Glob bracket expression [...] - consume until closing ]
 			// Handles [[:alpha:]], [^0-9], []a-z] (] as first char), etc.
 			if (ch === "[") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -6654,6 +6654,9 @@ class Parser:
                 break
             if ch == "|" and self.pos + 1 < self.length and self.source[self.pos + 1] == "|":
                 break
+            # Semicolons are not valid inside conditionals
+            if ch == ";":
+                break
 
             # Glob bracket expression [...] - consume until closing ]
             # Handles [[:alpha:]], [^0-9], []a-z] (] as first char), etc.

--- a/tests/parable/fuzz-25815.tests
+++ b/tests/parable/fuzz-25815.tests
@@ -1,0 +1,5 @@
+=== semicolon not allowed inside conditional expression
+[[ a == b;]]
+---
+<error>
+---


### PR DESCRIPTION
## Summary
- Parable was incorrectly parsing `[[ a == b;]]` as valid, including the semicolon as part of the term `b;`
- Bash rejects semicolons inside `[[ ]]` conditionals as syntax errors
- Fixed by treating `;` as a word terminator in `_parse_cond_word()`

MRE: `[[ a == b;]]`