### PR TITLE
fuzzer fix: reject unterminated backticks as syntax error

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5067,8 +5067,7 @@ class Parser {
 			}
 		}
 		if (this.atEnd()) {
-			this.pos = start;
-			return [null, ""];
+			throw new ParseError("Unterminated backtick", start);
 		}
 		this.advance();
 		text_chars.push("`");

--- a/src/parable.py
+++ b/src/parable.py
@@ -4304,8 +4304,7 @@ class Parser:
                 text_chars.append(ch)
 
         if self.at_end():
-            self.pos = start
-            return None, ""
+            raise ParseError("Unterminated backtick", pos=start)
 
         self.advance()  # consume closing `
         text_chars.append("`")  # closing backtick

--- a/tests/parable/fuzz-11579.tests
+++ b/tests/parable/fuzz-11579.tests
@@ -1,0 +1,5 @@
+=== unmatched backtick is syntax error
+`
+---
+<error>
+---


### PR DESCRIPTION
## Summary
- Parable was incorrectly accepting unterminated backticks (e.g., just `` ` ``) as a literal word character
- Now raises `ParseError` for unterminated backtick command substitution, matching bash behavior
- MRE: `` ` `` (single backtick)

## Test plan
- [x] New test added to `tests/parable/fuzz-11579.tests`
- [x] `just check` passes