### PR TITLE
fuzzer fix: allow missing operands in arithmetic expressions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2408,6 +2408,17 @@ class ArithNumber extends Node {
 	}
 }
 
+class ArithEmpty extends Node {
+	constructor() {
+		super();
+		this.kind = "empty";
+	}
+
+	toSexp() {
+		return "(empty)";
+	}
+}
+
 class ArithVar extends Node {
 	constructor(name) {
 		super();
@@ -5817,6 +5828,11 @@ class Parser {
 			}
 			escaped_char = this._arithAdvance();
 			return new ArithEscape(escaped_char);
+		}
+		// Check for end of expression or operators - bash allows missing operands
+		// (defers validation to runtime), so we return an empty node
+		if (this._arithAtEnd() || ")]:,?|&<>=!+-*/%^~".includes(c)) {
+			return new ArithEmpty();
 		}
 		// Number or variable
 		return this._arithParseNumberOrVar();

--- a/src/parable.py
+++ b/src/parable.py
@@ -2029,6 +2029,16 @@ class ArithNumber(Node):
         return '(number "' + self.value + '")'
 
 
+class ArithEmpty(Node):
+    """A missing operand in arithmetic context (e.g., in $((|)) or $((1|)))."""
+
+    def __init__(self):
+        self.kind = "empty"
+
+    def to_sexp(self) -> str:
+        return "(empty)"
+
+
 class ArithVar(Node):
     """A variable reference in arithmetic context (without $)."""
 
@@ -4952,6 +4962,11 @@ class Parser:
                 )
             escaped_char = self._arith_advance()  # consume escaped character
             return ArithEscape(escaped_char)
+
+        # Check for end of expression or operators - bash allows missing operands
+        # (defers validation to runtime), so we return an empty node
+        if self._arith_at_end() or c in ")]:,?|&<>=!+-*/%^~":
+            return ArithEmpty()
 
         # Number or variable
         return self._arith_parse_number_or_var()

--- a/tests/parable/fuzz-7364.tests
+++ b/tests/parable/fuzz-7364.tests
@@ -1,0 +1,11 @@
+=== arithmetic with lone pipe operator
+echo $((|))
+---
+(command (word "echo") (word "$((|))"))
+---
+
+=== arithmetic with trailing pipe operator
+echo $((1|))
+---
+(command (word "echo") (word "$((1|))"))
+---


### PR DESCRIPTION
## Summary
- Bash allows malformed arithmetic expressions like `$((|))` and `$((1|))` at parse time, only erroring at runtime
- Parable was rejecting these at parse time with "Unexpected character" error
- Fixed by adding `ArithEmpty` node type and returning it when we encounter operators/`)` where an operand is expected
- MRE: `echo $((|))`

- [x] New test added to `tests/parable/fuzz-7364.tests`
- [x] `just check` passes