### PR TITLE
fuzzer fix: require semicolon or newline before 'do' in for loops

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8640,7 +8640,7 @@ class Parser {
 	}
 
 	parseFor() {
-		let body, brace_group, var_name, var_word, word, words;
+		let body, brace_group, saw_delimiter, var_name, var_word, word, words;
 		if (!this.consumeWord("for")) {
 			return null;
 		}
@@ -8678,8 +8678,14 @@ class Parser {
 		words = null;
 		if (this.peekWord() === "in") {
 			this.consumeWord("in");
+			this.skipWhitespace();
+			// Check for immediate delimiter (;, newline) after 'in'
+			saw_delimiter = _isSemicolonOrNewline(this.peek());
+			if (this.peek() === ";") {
+				this.advance();
+			}
 			this.skipWhitespaceAndNewlines();
-			// Parse words until semicolon, newline, or 'do'
+			// Parse words until semicolon or newline (not 'do' directly)
 			words = [];
 			while (true) {
 				this.skipWhitespace();
@@ -8688,13 +8694,19 @@ class Parser {
 					break;
 				}
 				if (_isSemicolonOrNewline(this.peek())) {
+					saw_delimiter = true;
 					if (this.peek() === ";") {
 						this.advance();
 					}
 					break;
 				}
+				// 'do' only terminates if preceded by delimiter
 				if (this.peekWord() === "do") {
-					break;
+					if (saw_delimiter) {
+						break;
+					}
+					// 'for x in do' or 'for x in a b c do' is invalid
+					throw new ParseError("Expected ';' or newline before 'do'", this.pos);
 				}
 				word = this.parseWord();
 				if (word == null) {

--- a/tests/parable/fuzz-9882.tests
+++ b/tests/parable/fuzz-9882.tests
@@ -1,0 +1,5 @@
+=== for loop with in but missing semicolon before do
+for x in do :;done
+---
+<error>
+---


### PR DESCRIPTION
## Summary
- Fixed bug where Parable incorrectly accepted `for x in do` and `for x in a b c do` without a semicolon or newline before `do`
- MRE: `for x in do :;done` - bash requires `;` or newline before `do`, but Parable was accepting it
- The fix tracks whether a delimiter was seen and only allows `do` to terminate the word list if preceded by a proper delimiter

## Test plan
- [x] New test added to `tests/parable/fuzz-9882.tests`
- [x] `just check` passes