### PR TITLE
fuzzer fix: reject unterminated $[ as syntax error

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6172,8 +6172,7 @@ class Parser {
 			}
 		}
 		if (this.atEnd() || depth !== 0) {
-			this.pos = start;
-			return [null, ""];
+			throw new ParseError("Unterminated $[", start);
 		}
 		content = this.source.slice(content_start, this.pos);
 		this.advance();

--- a/src/parable.py
+++ b/src/parable.py
@@ -5251,8 +5251,7 @@ class Parser:
                 self.advance()
 
         if self.at_end() or depth != 0:
-            self.pos = start
-            return None, ""
+            raise ParseError("Unterminated $[", pos=start)
 
         content = _substring(self.source, content_start, self.pos)
         self.advance()  # consume ]

--- a/tests/parable/fuzz-908.tests
+++ b/tests/parable/fuzz-908.tests
@@ -1,0 +1,5 @@
+=== unterminated $[ arithmetic expansion
+$[
+---
+<error>
+---


### PR DESCRIPTION
## Summary
- Parable incorrectly accepted `$[` without a closing `]` as valid input
- MRE: `$[` → Parable parsed it as a word, but bash requires a matching `]`
- Fix: raise ParseError when `$[` is not properly terminated

## Test plan
- [x] New test added to `tests/parable/fuzz-908.tests`
- [x] `just check` passes