### PR TITLE
fuzzer fix: reject unterminated backtick substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5067,8 +5067,7 @@ class Parser {
 			}
 		}
 		if (this.atEnd()) {
-			this.pos = start;
-			return [null, ""];
+			throw new ParseError("Unterminated backtick substitution", start);
 		}
 		this.advance();
 		text_chars.push("`");

--- a/src/parable.py
+++ b/src/parable.py
@@ -4304,8 +4304,7 @@ class Parser:
                 text_chars.append(ch)
 
         if self.at_end():
-            self.pos = start
-            return None, ""
+            raise ParseError("Unterminated backtick substitution", pos=start)
 
         self.advance()  # consume closing `
         text_chars.append("`")  # closing backtick

--- a/tests/parable/fuzz-10530.tests
+++ b/tests/parable/fuzz-10530.tests
@@ -1,0 +1,5 @@
+=== escaped backtick in backtick substitution should not close
+`\`
+---
+<error>
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `` `\` `` (backtick-backslash-backtick) was incorrectly parsed as a valid word instead of raising a parse error
- The `\`` inside a backtick command substitution escapes the backtick, leaving no closing backtick for the substitution
- MRE: `` `\` ``

## Test plan
- [x] New test added to `tests/parable/fuzz-10530.tests`
- [x] `just check` passes