### PR TITLE
fuzzer fix: handle space between <& and - for close redirect

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1724,6 +1724,10 @@ class Redirect extends Node {
 			if (/^[0-9]+$/.test(target_val)) {
 				return `(redirect "${op}" ${target_val})`;
 			}
+			// Handle close: <& - or >& - (with space before -)
+			if (target_val === "-") {
+				return '(redirect ">&-" 0)';
+			}
 			// Variable fd dup with move indicator (trailing -)
 			target_val = target_val.replace(/[-]+$/, "");
 			return `(redirect "${op}" "${target_val}")`;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1373,6 +1373,9 @@ class Redirect(Node):
         if op == ">&" or op == "<&":
             if target_val.isdigit():
                 return '(redirect "' + op + '" ' + target_val + ")"
+            # Handle close: <& - or >& - (with space before -)
+            if target_val == "-":
+                return '(redirect ">&-" 0)'
             # Variable fd dup with move indicator (trailing -)
             target_val = target_val.rstrip("-")
             return '(redirect "' + op + '" "' + target_val + '")'

--- a/tests/parable/fuzz-30902.tests
+++ b/tests/parable/fuzz-30902.tests
@@ -1,0 +1,5 @@
+=== space between <& and - should close stdin
+a <& -
+---
+(command (word "a") (redirect ">&-" 0))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `<& -` (with space between `<&` and `-`) which should close stdin
- The MRE is `a <& -` - Parable was outputting `(redirect "<&" "")` instead of `(redirect ">&-" 0)`
- Bug was in `to_sexp()`: when op was `<&` and target was `-`, it stripped the `-` thinking it was a move indicator

## Test plan
- [x] New test added to `tests/parable/fuzz-30902.tests`
- [x] `just check` passes