### PR TITLE
fuzzer fix: treat bare '-' in redirects as complete close syntax

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7136,7 +7136,8 @@ class Parser {
 					fd_target += this.advance();
 				}
 				// If more word characters follow, treat the whole target as a word (e.g., <&0=)
-				if (!this.atEnd() && !_isMetachar(this.peek())) {
+				// BUT: bare "-" (close syntax) is always complete - trailing chars are separate words
+				if (fd_target !== "-" && !this.atEnd() && !_isMetachar(this.peek())) {
 					this.pos = word_start;
 					inner_word = this.parseWord();
 					if (inner_word != null) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -6049,7 +6049,8 @@ class Parser:
                 if not self.at_end() and self.peek() == "-":
                     fd_target += self.advance()  # consume the trailing -
                 # If more word characters follow, treat the whole target as a word (e.g., <&0=)
-                if not self.at_end() and not _is_metachar(self.peek()):
+                # BUT: bare "-" (close syntax) is always complete - trailing chars are separate words
+                if fd_target != "-" and not self.at_end() and not _is_metachar(self.peek()):
                     self.pos = word_start
                     inner_word = self.parse_word()
                     if inner_word is not None:

--- a/tests/parable/fuzz-15284.tests
+++ b/tests/parable/fuzz-15284.tests
@@ -1,0 +1,5 @@
+=== close redirect followed by word
+<&-0
+---
+(command (word "0") (redirect ">&-" 0))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of close redirect syntax (`<&-` / `>&-`) when followed by other characters
- MRE: `<&-0` was incorrectly parsed as `(redirect "<&" "-0")` instead of `(redirect ">&-" 0)` followed by word `"0"`
- The bare `-` in redirects now correctly terminates the redirect target

## Test plan
- [x] New test added to `tests/parable/fuzz-15284.tests`
- [x] `just check` passes