### PR TITLE
fuzzer fix: limit \0nnn octal escapes to 3 digits total (#82)

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -310,9 +310,9 @@ class Word extends Node {
 						i += 1;
 					}
 				} else if (c === "0") {
-					// Nul or octal \0 or \0NNN
+					// Nul or octal \0 or \0NN (up to 3 digits total)
 					j = i + 2;
-					while (j < inner.length && j < i + 5 && _isOctalDigit(inner[j])) {
+					while (j < inner.length && j < i + 4 && _isOctalDigit(inner[j])) {
 						j += 1;
 					}
 					if (j > i + 2) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -290,9 +290,9 @@ class Word(Node):
                         result.append(ord(inner[i]))
                         i += 1
                 elif c == "0":
-                    # Nul or octal \0 or \0NNN
+                    # Nul or octal \0 or \0NN (up to 3 digits total)
                     j = i + 2
-                    while j < len(inner) and j < i + 5 and _is_octal_digit(inner[j]):
+                    while j < len(inner) and j < i + 4 and _is_octal_digit(inner[j]):
                         j += 1
                     if j > i + 2:
                         byte_val = int(_substring(inner, i + 1, j), 8)

--- a/tests/parable/fuzz-30261.tests
+++ b/tests/parable/fuzz-30261.tests
@@ -1,0 +1,5 @@
+=== octal escape \0nnn should consume at most 3 digits total
+$'\0007'
+---
+(command (word "''"))
+---


### PR DESCRIPTION
## Summary
- Fix `$'\0nnn'` octal escape parsing to consume at most 3 digits total
- MRE: `$'\0007'` was parsed as BEL (octal 007) instead of NUL + literal '7'
- Changed bound from `i + 5` to `i + 4` to match bash behavior

## Test plan
- [x] New test added to `tests/parable/fuzz-30261.tests`
- [x] `just check` passes