### PR TITLE
fuzzer fix: no space before redirect in compact procsub commands

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2929,6 +2929,7 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		variable,
 		w,
 		word,
+		word_parts,
 		word_vals,
 		words;
 	if (indent == null) {
@@ -2956,6 +2957,12 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		}
 		for (r of node.redirects) {
 			parts.push(_formatRedirect(r, compact_redirects));
+		}
+		// In compact mode with words, don't add space before redirects
+		if (compact_redirects && node.words && node.redirects) {
+			word_parts = parts.slice(0, node.words.length);
+			redirect_parts = parts.slice(node.words.length);
+			return word_parts.join(" ") + redirect_parts.join("");
 		}
 		return parts.join(" ");
 	}

--- a/src/parable.py
+++ b/src/parable.py
@@ -2551,6 +2551,11 @@ def _format_cmdsub_node(
             parts.append(val)
         for r in node.redirects:
             parts.append(_format_redirect(r, compact=compact_redirects))
+        # In compact mode with words, don't add space before redirects
+        if compact_redirects and node.words and node.redirects:
+            word_parts = parts[: len(node.words)]
+            redirect_parts = parts[len(node.words) :]
+            return " ".join(word_parts) + "".join(redirect_parts)
         return " ".join(parts)
     if node.kind == "pipeline":
         # Build list of (cmd, needs_pipe_both_redirect) filtering out PipeBoth markers

--- a/tests/parable/fuzz-19699.tests
+++ b/tests/parable/fuzz-19699.tests
@@ -1,0 +1,5 @@
+=== preserve raw text in process substitution with nested parens
+<((+<1))
+---
+(command (word "<((+<1))"))
+---


### PR DESCRIPTION
## Summary
- Fixed formatting of commands inside process substitutions when `compact_redirects=True`
- When a command has words and redirects, don't add space before redirects (e.g., `<((+<1))` not `<((+ <1))`)
- MRE: `<((+<1))`