### PR TITLE
fuzzer fix: recognize ! as negation before & operator

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3881,7 +3881,7 @@ function _isListTerminator(c) {
 }
 
 function _isNegationBoundary(c) {
-	return _isWhitespace(c) || c === ";" || c === "|" || c === ")";
+	return _isWhitespace(c) || c === ";" || c === "|" || c === ")" || c === "&";
 }
 
 function _isBackslashEscaped(value, idx) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3321,7 +3321,7 @@ def _is_list_terminator(c: str) -> bool:
 
 
 def _is_negation_boundary(c: str) -> bool:
-    return _is_whitespace(c) or c == ";" or c == "|" or c == ")"
+    return _is_whitespace(c) or c == ";" or c == "|" or c == ")" or c == "&"
 
 
 def _is_backslash_escaped(value: str, idx: int) -> bool:

--- a/tests/parable/fuzz-14280.tests
+++ b/tests/parable/fuzz-14280.tests
@@ -1,0 +1,5 @@
+=== negation before background operator
+!&
+---
+(background (negation (command)))
+---


### PR DESCRIPTION
## Summary
- When `!` is followed by `&` (background operator), bash treats `!` as negation with an empty command
- Parable was incorrectly parsing `!` as a command word in this case (e.g., `!&` → `(background (command (word "!")))` instead of `(background (negation (command)))`)
- Fixed by adding `&` to `_is_negation_boundary()` so `!&` is recognized as negation followed by background
- MRE: `!&`

- [x] New test added to `tests/parable/fuzz-14280.tests`
- [x] `just check` passes