### PR TITLE
fuzzer fix: handle ${...} in heredoc delimiters

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7252,6 +7252,24 @@ class Parser {
 					}
 					delimiter_chars.push(this.advance());
 				}
+			} else if (
+				ch === "$" &&
+				this.pos + 1 < this.length &&
+				this.source[this.pos + 1] === "{"
+			) {
+				// Parameter expansion embedded in delimiter
+				delimiter_chars.push(this.advance());
+				delimiter_chars.push(this.advance());
+				depth = 1;
+				while (!this.atEnd() && depth > 0) {
+					c = this.peek();
+					if (c === "{") {
+						depth += 1;
+					} else if (c === "}") {
+						depth -= 1;
+					}
+					delimiter_chars.push(this.advance());
+				}
 			} else {
 				delimiter_chars.push(this.advance());
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -6127,6 +6127,18 @@ class Parser:
                     elif c == ")":
                         depth -= 1
                     delimiter_chars.append(self.advance())
+            elif ch == "$" and self.pos + 1 < self.length and self.source[self.pos + 1] == "{":
+                # Parameter expansion embedded in delimiter
+                delimiter_chars.append(self.advance())  # $
+                delimiter_chars.append(self.advance())  # {
+                depth = 1
+                while not self.at_end() and depth > 0:
+                    c = self.peek()
+                    if c == "{":
+                        depth += 1
+                    elif c == "}":
+                        depth -= 1
+                    delimiter_chars.append(self.advance())
             else:
                 delimiter_chars.append(self.advance())
 

--- a/tests/parable/fuzz-28664.tests
+++ b/tests/parable/fuzz-28664.tests
@@ -1,0 +1,6 @@
+=== heredoc delimiter with parameter expansion containing metachar
+<<${a>}
+${a>}
+---
+(command (redirect "<<" ""))
+---


### PR DESCRIPTION
## Summary
- Fixed heredoc delimiter parsing to handle `${...}` parameter expansions containing metacharacters
- MRE: `<<${a>}\n${a>}` - Parable was stopping at `>` inside `${...}` and treating it as a redirect

## Test plan
- [x] New test added to `tests/parable/fuzz-28664.tests`
- [x] `just check` passes