### PR TITLE
fuzzer fix: handle backslash-newline in unknown param syntax

### DIFF
--- a/tests/parable/fuzz-1342.tests
+++ b/tests/parable/fuzz-1342.tests
@@ -1,0 +1,6 @@
+=== backslash-newline in bad expansion with colon prefix
+${:x-\
+}
+---
+(command (word "${:x-}"))
+---


### PR DESCRIPTION
## Summary
- Fix line continuation handling in unknown parameter syntax like `${:x-\<newline>}`
- The parser now correctly removes backslash-newline sequences in these contexts
- MRE: `${:x-\<newline>}` → was `${:x-\\\n}`, now correctly `${:x-}`

## Test plan
- [x] New test added to `tests/parable/fuzz-1342.tests`
- [x] `just check` passes