### PR TITLE
fuzzer fix: track single parens in arithmetic line continuation stripping

### DIFF
--- a/tests/parable/fuzz-11384.tests
+++ b/tests/parable/fuzz-11384.tests
@@ -1,0 +1,6 @@
+=== line continuation inside arithmetic expression
+>$((1\
+)2)
+---
+(command (redirect ">" "$((1)2)"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_strip_arith_line_continuations` to track single parens instead of `((` and `))` pairs
- MRE: `>$((1\<newline>)2)` - backslash-newline before `)` inside arithmetic was not being stripped
- The function now uses depth=2 for `$((` and tracks `(` and `)` individually, matching the parser

## Test plan
- [x] New test added to `tests/parable/fuzz-11384.tests`
- [x] `just check` passes