### PR TITLE
fuzzer fix: preserve original content in nested subshell process substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1046,7 +1046,6 @@ class Word extends Node {
 			cmdsub_parts,
 			depth,
 			direction,
-			end,
 			extglob_depth,
 			formatted,
 			formatted_inner,
@@ -1059,19 +1058,15 @@ class Word extends Node {
 			in_single,
 			inner,
 			j,
-			k,
-			m,
 			node,
 			p,
 			parsed,
 			parser,
 			prefix,
-			prefix_ws,
 			procsub_idx,
 			procsub_parts,
 			raw_content,
 			result,
-			suffix_ws,
 			terminator;
 		// Collect command substitutions from all parts, including nested ones
 		cmdsub_parts = [];
@@ -1225,25 +1220,11 @@ class Word extends Node {
 				if (node.command.kind === "subshell") {
 					raw_content = value.slice(i + 2, j - 1);
 					if (raw_content.startsWith("(")) {
-						// Preserve leading whitespace after (
-						k = 1;
-						while (k < raw_content.length && _isWhitespace(raw_content[k])) {
-							k += 1;
-						}
-						prefix_ws = raw_content.slice(1, k);
-						if (prefix_ws && formatted.startsWith("(")) {
-							formatted = `(${prefix_ws}${formatted.slice(1)}`;
-						}
-						// Preserve trailing whitespace before )
-						end = raw_content.length - 1;
-						m = end;
-						while (m > 0 && _isWhitespace(raw_content[m - 1])) {
-							m -= 1;
-						}
-						suffix_ws = raw_content.slice(m, end);
-						if (suffix_ws && formatted.endsWith(")")) {
-							formatted = `${formatted.slice(0, -1) + suffix_ws})`;
-						}
+						// Process substitution with nested subshell >((...)): preserve original
+						result.push(`${direction}(${raw_content})`);
+						procsub_idx += 1;
+						i = j;
+						continue;
 					}
 				}
 				result.push(`${direction}(${formatted})`);

--- a/src/parable.py
+++ b/src/parable.py
@@ -970,21 +970,11 @@ class Word(Node):
                 if node.command.kind == "subshell":
                     raw_content = _substring(value, i + 2, j - 1)
                     if raw_content.startswith("("):
-                        # Preserve leading whitespace after (
-                        k = 1
-                        while k < len(raw_content) and _is_whitespace(raw_content[k]):
-                            k += 1
-                        prefix_ws = _substring(raw_content, 1, k)
-                        if prefix_ws and formatted.startswith("("):
-                            formatted = "(" + prefix_ws + formatted[1:]
-                        # Preserve trailing whitespace before )
-                        end = len(raw_content) - 1
-                        m = end
-                        while m > 0 and _is_whitespace(raw_content[m - 1]):
-                            m -= 1
-                        suffix_ws = _substring(raw_content, m, end)
-                        if suffix_ws and formatted.endswith(")"):
-                            formatted = formatted[:-1] + suffix_ws + ")"
+                        # Process substitution with nested subshell >((...)): preserve original
+                        result.append(direction + "(" + raw_content + ")")
+                        procsub_idx += 1
+                        i = j
+                        continue
                 result.append(direction + "(" + formatted + ")")
                 procsub_idx += 1
                 i = j

--- a/tests/parable/fuzz-26163.tests
+++ b/tests/parable/fuzz-26163.tests
@@ -1,0 +1,5 @@
+=== process substitution with subshell redirect preserves original text
+>((1<= 2))
+---
+(command (word ">((1<= 2))"))
+---


### PR DESCRIPTION
## Summary
- When a process substitution contains a nested subshell (e.g., `>((1<= 2))`), preserve the original text instead of reformatting it
- MRE: `>((1<= 2))` was incorrectly output as `>((2 1<=))`

## Test plan
- [x] New test added to `tests/parable/fuzz-26163.tests`
- [x] `just check` passes