### PR TITLE
fuzzer fix: allow } in function names

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3938,6 +3938,31 @@ function _strContains(haystack, needle) {
 	return haystack.indexOf(needle) !== -1;
 }
 
+function _looksLikeAssignment(s) {
+	let c, eq_pos, name;
+	eq_pos = s.indexOf("=");
+	if (eq_pos === -1) {
+		return false;
+	}
+	name = s.slice(0, eq_pos);
+	// Handle NAME+= (array append)
+	if (name.endsWith("+")) {
+		name = name.slice(0, -1);
+	}
+	if (!name) {
+		return false;
+	}
+	if (!(/^[a-zA-Z]$/.test(name[0]) || name[0] === "_")) {
+		return false;
+	}
+	for (c of name.slice(1)) {
+		if (!(/^[a-zA-Z0-9]$/.test(c) || c === "_")) {
+			return false;
+		}
+	}
+	return true;
+}
+
 class Parser {
 	constructor(source) {
 		this.source = source;
@@ -9405,8 +9430,8 @@ class Parser {
 		if (name == null || RESERVED_WORDS.has(name)) {
 			return null;
 		}
-		// Assignment words (containing =) are not function definitions
-		if (_strContains(name, "=")) {
+		// Assignment words (NAME=...) are not function definitions
+		if (_looksLikeAssignment(name)) {
 			return null;
 		}
 		// Save position after the name

--- a/src/parable.py
+++ b/src/parable.py
@@ -3376,6 +3376,25 @@ def _str_contains(haystack: str, needle: str) -> bool:
     return haystack.find(needle) != -1
 
 
+def _looks_like_assignment(s: str) -> bool:
+    """Check if s looks like an assignment (NAME=... or NAME+=...) where NAME is a valid variable name."""
+    eq_pos = s.find("=")
+    if eq_pos == -1:
+        return False
+    name = s[:eq_pos]
+    # Handle NAME+= (array append)
+    if name.endswith("+"):
+        name = name[:-1]
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    for c in name[1:]:
+        if not (c.isalnum() or c == "_"):
+            return False
+    return True
+
+
 class Parser:
     """Recursive descent parser for bash."""
 
@@ -7922,8 +7941,8 @@ class Parser:
         if name is None or name in RESERVED_WORDS:
             return None
 
-        # Assignment words (containing =) are not function definitions
-        if _str_contains(name, "="):
+        # Assignment words (NAME=...) are not function definitions
+        if _looks_like_assignment(name):
             return None
 
         # Save position after the name

--- a/tests/parable/fuzz-23510.tests
+++ b/tests/parable/fuzz-23510.tests
@@ -1,0 +1,6 @@
+=== function name containing }
+}=()
+(x)
+---
+(function "}=" (subshell (command (word "x"))))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of function names containing `}` (e.g., `}=()`)
- Previously, any word containing `=` was rejected as a function definition
- Now we properly check if the string looks like a valid assignment (`NAME=...` or `NAME+=...`) before rejecting

MRE:
```bash
}=()
(x)
```

- [ ] New test added to `tests/parable/fuzz-23510.tests`
- [ ] `just check` passes