### PR TITLE
fuzzer fix: preserve literal $ in quoted patterns inside ${...}

### DIFF
--- a/tests/parable/fuzz-12485.tests
+++ b/tests/parable/fuzz-12485.tests
@@ -1,0 +1,5 @@
+=== literal dollar sign in quoted pattern
+echo ${v#"$"}
+---
+(command (word "echo") (word "${v#\"$\"}"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_strip_locale_string_dollars` incorrectly stripping `$` from patterns like `${v#"$"}`
- The function was treating the `$` before a closing `"` as a locale string `$"..."` marker
- Added separate tracking of quote state inside brace expansions
- MRE: `echo ${v#"$"}` was outputting `${v#""}` instead of `${v#"$"}`