### PR TITLE
fuzzer fix: preserve whitespace in process substitution subshells

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -970,21 +970,36 @@ class Word(Node):
                 if node.command.kind == "subshell":
                     raw_content = _substring(value, i + 2, j - 1)
                     if raw_content.startswith("("):
-                        # Preserve leading whitespace after (
-                        k = 1
-                        while k < len(raw_content) and _is_whitespace(raw_content[k]):
-                            k += 1
-                        prefix_ws = _substring(raw_content, 1, k)
-                        if prefix_ws and formatted.startswith("("):
-                            formatted = "(" + prefix_ws + formatted[1:]
-                        # Preserve trailing whitespace before )
-                        end = len(raw_content) - 1
-                        m = end
-                        while m > 0 and _is_whitespace(raw_content[m - 1]):
-                            m -= 1
-                        suffix_ws = _substring(raw_content, m, end)
-                        if suffix_ws and formatted.endswith(")"):
-                            formatted = formatted[:-1] + suffix_ws + ")"
+                        inner = _substring(raw_content, 1, len(raw_content) - 1)
+                        # Check if inner has substitutions that need formatting
+                        has_subs = (
+                            "$(" in inner
+                            or "`" in inner
+                            or "<(" in inner
+                            or ">(" in inner
+                            or "${ " in inner
+                            or "${|" in inner
+                        )
+                        if not has_subs:
+                            # No nested substitutions, use raw content directly
+                            # to preserve original whitespace around redirects
+                            formatted = raw_content
+                        else:
+                            # Preserve leading whitespace after (
+                            k = 1
+                            while k < len(raw_content) and _is_whitespace(raw_content[k]):
+                                k += 1
+                            prefix_ws = _substring(raw_content, 1, k)
+                            if prefix_ws and formatted.startswith("("):
+                                formatted = "(" + prefix_ws + formatted[1:]
+                            # Preserve trailing whitespace before )
+                            end = len(raw_content) - 1
+                            m = end
+                            while m > 0 and _is_whitespace(raw_content[m - 1]):
+                                m -= 1
+                            suffix_ws = _substring(raw_content, m, end)
+                            if suffix_ws and formatted.endswith(")"):
+                                formatted = formatted[:-1] + suffix_ws + ")"
                 result.append(direction + "(" + formatted + ")")
                 procsub_idx += 1
                 i = j

--- a/tests/parable/fuzz-9238.tests
+++ b/tests/parable/fuzz-9238.tests
@@ -1,0 +1,5 @@
+=== process substitution with arithmetic preserves whitespace around operators
+<((1 < 2))
+---
+(command (word "<((1 < 2))"))
+---


### PR DESCRIPTION
## Summary
- Fixes whitespace being stripped around redirect operators in process substitution subshells like `<((1 < 2))`
- MRE: `<((1 < 2))` was incorrectly producing `<((1<2))` instead of preserving the spaces

When a process substitution contains a subshell with no nested command/process substitutions (e.g., `<((1 < 2))`), we now use the raw content directly instead of reformatting, which preserves the original whitespace around redirect operators.