### PR TITLE
fuzzer fix: error on unclosed nested ${...} in parameter expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6589,6 +6589,14 @@ class Parser {
 							break;
 						}
 						content_chars.push(this.advance());
+					} else if (
+						c === "$" &&
+						this.pos + 1 < this.length &&
+						this.source[this.pos + 1] === "{"
+					) {
+						depth += 1;
+						content_chars.push(this.advance());
+						content_chars.push(this.advance());
 					} else if (c === "\\") {
 						if (
 							this.pos + 1 < this.length &&
@@ -6613,8 +6621,7 @@ class Parser {
 					text = `\${${content}}`;
 					return [new ParamExpansion(content), text];
 				}
-				this.pos = start;
-				return [null, ""];
+				throw new ParseError("Unclosed parameter expansion", start);
 			}
 		}
 		if (this.atEnd()) {
@@ -6811,7 +6818,15 @@ class Parser {
 		}
 		ch = this.peek();
 		// Special parameters
+		// But NOT $ followed by { - that's a nested ${...} expansion
 		if (_isSpecialParam(ch)) {
+			if (
+				ch === "$" &&
+				this.pos + 1 < this.length &&
+				this.source[this.pos + 1] === "{"
+			) {
+				return null;
+			}
 			this.advance();
 			return ch;
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -5613,6 +5613,12 @@ class Parser:
                         if depth == 0:
                             break
                         content_chars.append(self.advance())
+                    elif (
+                        c == "$" and self.pos + 1 < self.length and self.source[self.pos + 1] == "{"
+                    ):
+                        depth += 1
+                        content_chars.append(self.advance())  # $
+                        content_chars.append(self.advance())  # {
                     elif c == "\\":
                         if self.pos + 1 < self.length and self.source[self.pos + 1] == "\n":
                             # Line continuation - skip both backslash and newline
@@ -5629,8 +5635,7 @@ class Parser:
                     self.advance()  # consume final }
                     text = "${" + content + "}"
                     return ParamExpansion(content), text
-                self.pos = start
-                return None, ""
+                raise ParseError("Unclosed parameter expansion", pos=start)
 
         if self.at_end():
             self.pos = start
@@ -5800,7 +5805,10 @@ class Parser:
         ch = self.peek()
 
         # Special parameters
+        # But NOT $ followed by { - that's a nested ${...} expansion
         if _is_special_param(ch):
+            if ch == "$" and self.pos + 1 < self.length and self.source[self.pos + 1] == "{":
+                return None
             self.advance()
             return ch
 

--- a/tests/parable/fuzz-14689.tests
+++ b/tests/parable/fuzz-14689.tests
@@ -1,0 +1,5 @@
+=== unclosed outer brace in nested parameter expansion
+${${x}
+---
+<error>
+---


### PR DESCRIPTION
## Summary
- Fixed parser accepting `${${x}` (missing closing `}` for outer expansion)
- MRE: `${${x}` - should error but was parsed as valid word
- Two changes: (1) don't consume `$` as special param when followed by `{`, (2) raise error instead of returning None when brace depth doesn't reach 0

## Test plan
- [x] New test added to `tests/parable/fuzz-14689.tests`
- [x] `just check` passes