### PR TITLE
fix: handle comments in process substitution, fallback $(((cmd))) to cmdsub

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5174,6 +5174,13 @@ class Parser {
 		depth = 1;
 		while (!this.atEnd() && depth > 0) {
 			c = this.peek();
+			// Comment - skip to end of line (quotes in comments are not special)
+			if (c === "#") {
+				while (!this.atEnd() && this.peek() !== "\n") {
+					this.advance();
+				}
+				continue;
+			}
 			// Single-quoted string
 			if (c === "'") {
 				this.advance();
@@ -5331,7 +5338,13 @@ class Parser {
 		this.advance();
 		text = this.source.slice(start, this.pos);
 		// Parse the arithmetic expression
-		expr = this._parseArithExpr(content);
+		// If parsing fails, this isn't arithmetic (e.g., $(((cmd))) is command sub + subshell)
+		try {
+			expr = this._parseArithExpr(content);
+		} catch (_) {
+			this.pos = start;
+			return [null, ""];
+		}
 		return [new ArithmeticExpansion(expr), text];
 	}
 

--- a/tests/parable/12_command_substitution.tests
+++ b/tests/parable/12_command_substitution.tests
@@ -657,3 +657,10 @@ x=$(for a in b; do for c in d; do echo e; done; done)
 ---
 (command (word "x=$(for a in b;\ndo\n    for c in d;\n    do\n        echo e;\n    done;\ndone)"))
 ---
+
+
+=== subshell inside command substitution
+x=$(((echo hi)))
+---
+(command (word "x=$(((echo hi)))"))
+---

--- a/tests/parable/15_process_substitution.tests
+++ b/tests/parable/15_process_substitution.tests
@@ -227,3 +227,15 @@ read x < <(cmd1|cmd2)
 ---
 (command (word "read") (word "x") (redirect "<" "<(cmd1 | cmd2)"))
 ---
+
+
+=== apostrophe in comment inside process substitution
+f() {
+  cat < <(
+    # it's a comment
+    echo
+  )
+}
+---
+(function "f" (brace-group (command (word "cat") (redirect "<" "<(echo)"))))
+---

--- a/tools/fuzzer/fuzz.py
+++ b/tools/fuzzer/fuzz.py
@@ -1,5 +1,23 @@
 #!/usr/bin/env python3
-"""Phase 1 fuzzer: corpus mutation for differential testing."""
+"""Phase 1 fuzzer: corpus mutation for differential testing.
+
+Mutates inputs from the test corpus (tests/**/*.tests) and compares Parable's
+parse results against bash-oracle to find discrepancies.
+
+Limitations:
+    Single-character mutations struggle to create structural combinations that
+    don't already exist in the corpus. Real-world corpora (like bigtable) find
+    bugs this fuzzer misses because they naturally contain diverse nesting.
+
+Potential improvements:
+
+    | Improvement             | Impact | Difficulty | Notes                          |
+    |-------------------------|--------|------------|--------------------------------|
+    | Targeted seeding        | Medium | Trivial    | Add tricky patterns to corpus  |
+    | Cross-pollination       | High   | Medium     | Graft subtrees between inputs  |
+    | Structural mutations    | High   | Medium     | Wrap exprs in $(), <(), etc.   |
+    | Grammar-aware generation| High   | High       | Different tool entirely        |
+"""
 
 import argparse
 import random


### PR DESCRIPTION
## Summary
- Fix apostrophe in comment inside process substitution being incorrectly parsed as single quote
- Fix `$(((cmd)))` being incorrectly parsed as arithmetic instead of command substitution with subshell
- Add fuzzer documentation noting limitations and potential improvements

Both bugs were found via the bigtable-bash corpus (230 failures → these account for ~100 of them).