### PR TITLE
fix: parse arithmetic as function body

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9528,6 +9528,18 @@ class Parser {
 		if (result) {
 			return result;
 		}
+		// Arithmetic command ((...)) - check before subshell
+		if (
+			!this.atEnd() &&
+			this.peek() === "(" &&
+			this.pos + 1 < this.length &&
+			this.source[this.pos + 1] === "("
+		) {
+			result = this.parseArithmeticCommand();
+			if (result != null) {
+				return result;
+			}
+		}
 		result = this.parseSubshell();
 		if (result) {
 			return result;

--- a/src/parable.py
+++ b/src/parable.py
@@ -8034,6 +8034,17 @@ class Parser:
         if result:
             return result
 
+        # Arithmetic command ((...)) - check before subshell
+        if (
+            not self.at_end()
+            and self.peek() == "("
+            and self.pos + 1 < self.length
+            and self.source[self.pos + 1] == "("
+        ):
+            result = self.parse_arithmetic_command()
+            if result is not None:
+                return result
+
         result = self.parse_subshell()
         if result:
             return result

--- a/tests/parable/fuzz-10754.tests
+++ b/tests/parable/fuzz-10754.tests
@@ -1,0 +1,5 @@
+=== arithmetic as function body
+a()((1))
+---
+(function "a" (arith (word "1")))
+---


### PR DESCRIPTION
## Summary
- Fixed `_parse_compound_command` to try arithmetic command before subshell
- MRE: `a()((1))` was parsed as nested subshells instead of `(arith (word "1"))`

## Test plan
- [x] New test added to `tests/parable/fuzz-10754.tests`
- [x] `just check` passes