### PR TITLE
fix: handle >& -X as close fd plus word

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7287,7 +7287,23 @@ class Parser {
 			}
 		} else {
 			this.skipWhitespace();
-			target = this.parseWord();
+			// Handle >& - or <& - where space precedes the close syntax
+			// If op is >& or <& and next char is -, check for trailing word chars
+			// that should become a separate word (e.g., ">& -b" -> >&- + word "b")
+			if ([">&", "<&"].includes(op) && !this.atEnd() && this.peek() === "-") {
+				if (
+					this.pos + 1 < this.length &&
+					!_isMetachar(this.source[this.pos + 1])
+				) {
+					// Consume just the - as close target, leave rest for next word
+					this.advance();
+					target = new Word("&-");
+				} else {
+					target = this.parseWord();
+				}
+			} else {
+				target = this.parseWord();
+			}
 		}
 		if (target == null) {
 			throw new ParseError(`Expected target for redirect ${op}`, this.pos);

--- a/tests/parable/fuzz-30698.tests
+++ b/tests/parable/fuzz-30698.tests
@@ -1,0 +1,5 @@
+=== close fd redirect with trailing chars becomes word
+a>& -b
+---
+(command (word "a") (word "b") (redirect ">&-" 0))
+---


### PR DESCRIPTION
## Summary
- When `>&` or `<&` is followed by whitespace and then `-X` (dash followed by more word characters), bash treats the `-` as the close operator and remaining characters as a separate word
- MRE: `a>& -b` should parse as `>&-` (close fd) + word `b`
- Parable was incorrectly treating `-X` as the redirect target

## Test plan
- [x] New test added to `tests/parable/fuzz-30698.tests`
- [x] `just check` passes