### PR TITLE
fix: equals inside brackets not an assignment

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5035,9 +5035,10 @@ class Parser {
 	}
 
 	_isAssignmentWord(word) {
-		let ch, i, in_double, in_single;
+		let bracket_depth, ch, i, in_double, in_single;
 		in_single = false;
 		in_double = false;
+		bracket_depth = 0;
 		i = 0;
 		while (i < word.value.length) {
 			ch = word.value[i];
@@ -5048,7 +5049,16 @@ class Parser {
 			} else if (ch === "\\" && !in_single && i + 1 < word.value.length) {
 				i += 1;
 				continue;
-			} else if (ch === "=" && !in_single && !in_double) {
+			} else if (ch === "[" && !in_single && !in_double) {
+				bracket_depth += 1;
+			} else if (ch === "]" && !in_single && !in_double) {
+				bracket_depth -= 1;
+			} else if (
+				ch === "=" &&
+				!in_single &&
+				!in_double &&
+				bracket_depth === 0
+			) {
 				return true;
 			}
 			i += 1;

--- a/src/parable.py
+++ b/src/parable.py
@@ -4282,9 +4282,10 @@ class Parser:
         return _is_word_start_context(prev)
 
     def _is_assignment_word(self, word: "Word") -> bool:
-        """Check if a word is an assignment (contains = outside of quotes)."""
+        """Check if a word is an assignment (contains = outside of quotes and brackets)."""
         in_single = False
         in_double = False
+        bracket_depth = 0
         i = 0
         while i < len(word.value):
             ch = word.value[i]
@@ -4295,7 +4296,11 @@ class Parser:
             elif ch == "\\" and not in_single and i + 1 < len(word.value):
                 i += 1  # Skip next char
                 continue
-            elif ch == "=" and not in_single and not in_double:
+            elif ch == "[" and not in_single and not in_double:
+                bracket_depth += 1
+            elif ch == "]" and not in_single and not in_double:
+                bracket_depth -= 1
+            elif ch == "=" and not in_single and not in_double and bracket_depth == 0:
                 return True
             i += 1
         return False

--- a/tests/parable/fuzz-27654.tests
+++ b/tests/parable/fuzz-27654.tests
@@ -1,0 +1,5 @@
+=== equals inside brackets not an assignment
+a[=] b[ ]=x
+---
+(command (word "a[=]") (word "b[") (word "]=x"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_is_assignment_word` to track bracket depth and not treat `=` inside brackets as an assignment
- MRE: `a[=] b[ ]=x` - Parable was treating `b[ ]=x` as one word instead of splitting it

## Test plan
- [x] New test added to `tests/parable/fuzz-27654.tests`
- [x] `just check` passes