### PR TITLE
fuzzer fix: correct & position and empty body formatting in case cmdsub

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2915,6 +2915,7 @@ function _formatCondBody(node) {
 
 function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 	let body,
+		body_part,
 		cmd,
 		cmds,
 		cond,
@@ -3074,7 +3075,11 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 					result.push("\n");
 				} else if (p.op === "&") {
 					// If previous command has heredoc, insert & before heredoc content
-					if (result.length > 0 && result[result.length - 1].includes("\n")) {
+					if (
+						result.length > 0 &&
+						result[result.length - 1].includes("<<") &&
+						result[result.length - 1].includes("\n")
+					) {
 						last = result[result.length - 1];
 						first_nl = last.indexOf("\n");
 						result[result.length - 1] =
@@ -3187,11 +3192,12 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 			term = p.terminator;
 			pat_indent = " ".repeat(indent + 8);
 			term_indent = " ".repeat(indent + 4);
+			body_part = body ? `${pat_indent + body}\n` : "\n";
 			if (i === 0) {
 				// First pattern on same line as 'in'
-				patterns.push(` ${pat})\n${pat_indent}${body}\n${term_indent}${term}`);
+				patterns.push(` ${pat})\n${body_part}${term_indent}${term}`);
 			} else {
-				patterns.push(`${pat})\n${pat_indent}${body}\n${term_indent}${term}`);
+				patterns.push(`${pat})\n${body_part}${term_indent}${term}`);
 			}
 			i += 1;
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -2651,7 +2651,11 @@ def _format_cmdsub_node(
                     result.append("\n")
                 elif p.op == "&":
                     # If previous command has heredoc, insert & before heredoc content
-                    if result and "\n" in result[len(result) - 1]:
+                    if (
+                        result
+                        and "<<" in result[len(result) - 1]
+                        and "\n" in result[len(result) - 1]
+                    ):
                         last = result[len(result) - 1]
                         first_nl = last.find("\n")
                         result[len(result) - 1] = last[:first_nl] + " &" + last[first_nl:]
@@ -2758,11 +2762,12 @@ def _format_cmdsub_node(
             term = p.terminator  # ;;, ;&, or ;;&
             pat_indent = _repeat_str(" ", indent + 8)
             term_indent = _repeat_str(" ", indent + 4)
+            body_part = pat_indent + body + "\n" if body else "\n"
             if i == 0:
                 # First pattern on same line as 'in'
-                patterns.append(" " + pat + ")\n" + pat_indent + body + "\n" + term_indent + term)
+                patterns.append(" " + pat + ")\n" + body_part + term_indent + term)
             else:
-                patterns.append(pat + ")\n" + pat_indent + body + "\n" + term_indent + term)
+                patterns.append(pat + ")\n" + body_part + term_indent + term)
             i += 1
         pattern_str = ("\n" + _repeat_str(" ", indent + 4)).join(patterns)
         redirects = ""

--- a/tests/parable/fuzz-2016.tests
+++ b/tests/parable/fuzz-2016.tests
@@ -1,0 +1,5 @@
+=== case statement with & after esac in command substitution
+$(case a in b);;esac&)
+---
+(command (word "$(case a in b)\n\n    ;;\nesac &)"))
+---


### PR DESCRIPTION
## Summary
- Fixed `&` operator being incorrectly positioned after case pattern instead of after `esac` in command substitution formatting
- Fixed empty case body formatting to not include unnecessary indentation
- MRE: `$(case a in b);;esac&)`

- [x] New test added to `tests/parable/fuzz-2016.tests`
- [x] `just check` passes