### PR TITLE
fix: handle parens inside arithmetic in _find_cmdsub_end

### DIFF
--- a/tests/parable/fuzz-261.tests
+++ b/tests/parable/fuzz-261.tests
@@ -1,0 +1,5 @@
+=== failed process substitution with trailing content after $((
+>($(()b))
+---
+(command (word ">($(()b))"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_find_cmdsub_end` incorrectly finding closing paren when `$((` arithmetic is inside command/process substitution
- MRE: `>($(()b))` was parsed as `>($(()b))b))` instead of `>($(()b))`
- Root cause: single `)` inside arithmetic was decrementing the outer depth counter

## Test plan
- [x] New test added to `tests/parable/fuzz-261.tests`
- [x] `just check` passes