### PR TITLE
fix: strip only one trailing dash in fd dup targets

### DIFF
--- a/tests/parable/fuzz-26144.tests
+++ b/tests/parable/fuzz-26144.tests
@@ -1,0 +1,5 @@
+=== fd dup with double trailing dash
+:<&0--
+---
+(command (word ":") (redirect "<&" "0-"))
+---


### PR DESCRIPTION
## Summary
- Fixed `to_sexp()` in `Redirect` class to strip only one trailing dash instead of all trailing dashes
- MRE: `:<&0--` should parse target as `"0-"`, not numeric `0`
- Bug was caused by using `rstrip("-")` which strips all trailing dashes

## Test plan
- [x] New test added to `tests/parable/fuzz-26144.tests`
- [x] `just check` passes