### PR TITLE
fix: preserve heredoc trailing newline when semicolon follows

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -2638,6 +2638,14 @@ def _format_cmdsub_node(
             idx += 1
         return result
     if node.kind == "list":
+        # Check if any command in the list has a heredoc redirect
+        has_heredoc = False
+        for p in node.parts:
+            if p.kind == "command" and p.redirects:
+                for r in p.redirects:
+                    if r.kind == "heredoc":
+                        has_heredoc = True
+                        break
         # Join commands with operators
         result = []
         for p in node.parts:
@@ -2663,13 +2671,16 @@ def _format_cmdsub_node(
                 if result and not result[len(result) - 1].endswith((" ", "\n")):
                     result.append(" ")
                 result.append(_format_cmdsub_node(p, indent))
-        # Strip trailing ; or newline
+        # Strip trailing ; or newline (but preserve heredoc's trailing newline)
         s = "".join(result)
         # If we have & with heredoc (& before newline content), preserve trailing newline and add space
         if " &\n" in s and s.endswith("\n"):
             return s + " "
-        while s.endswith(";") or s.endswith("\n"):
+        while s.endswith(";"):
             s = _substring(s, 0, len(s) - 1)
+        if not has_heredoc:
+            while s.endswith("\n"):
+                s = _substring(s, 0, len(s) - 1)
         return s
     if node.kind == "if":
         cond = _format_cmdsub_node(node.condition, indent)

--- a/tests/parable/fuzz-5927.tests
+++ b/tests/parable/fuzz-5927.tests
@@ -1,0 +1,7 @@
+=== heredoc with semicolon preserves trailing newline
+a=$(<<X;
+X
+)
+---
+(command (word "a=$(<<X\nX\n)"))
+---


### PR DESCRIPTION
## Summary
- When a heredoc is followed by a semicolon terminator inside a command substitution (e.g., `a=$(<<X;`), the trailing newline after the heredoc delimiter was incorrectly stripped
- MRE: `a=$(<<X;\nX\n)` produced `a=$(<<X\nX)` instead of `a=$(<<X\nX\n)`
- Fix: track whether the list contains a heredoc and preserve trailing newlines in that case

## Test plan
- [x] New test added to `tests/parable/fuzz-5927.tests`
- [x] `just check` passes