### PR TITLE
fuzzer fix: recognize ! as negation before redirects

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3914,7 +3914,15 @@ function _isListTerminator(c) {
 }
 
 function _isNegationBoundary(c) {
-	return _isWhitespace(c) || c === ";" || c === "|" || c === ")" || c === "&";
+	return (
+		_isWhitespace(c) ||
+		c === ";" ||
+		c === "|" ||
+		c === ")" ||
+		c === "&" ||
+		c === ">" ||
+		c === "<"
+	);
 }
 
 function _isBackslashEscaped(value, idx) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3354,7 +3354,7 @@ def _is_list_terminator(c: str) -> bool:
 
 
 def _is_negation_boundary(c: str) -> bool:
-    return _is_whitespace(c) or c == ";" or c == "|" or c == ")" or c == "&"
+    return _is_whitespace(c) or c == ";" or c == "|" or c == ")" or c == "&" or c == ">" or c == "<"
 
 
 def _is_backslash_escaped(value: str, idx: int) -> bool:

--- a/tests/parable/fuzz-20613.tests
+++ b/tests/parable/fuzz-20613.tests
@@ -1,0 +1,5 @@
+=== negation before redirect
+!>x
+---
+(negation (command (redirect ">" "x")))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `!` immediately followed by a redirect operator (`>` or `<`) was parsed as a word instead of negation
- MRE: `!>x` was parsed as `(command (word "!") (redirect ">" "x"))` instead of `(negation (command (redirect ">" "x")))`
- Added `>` and `<` to the `_is_negation_boundary` function

- [x] New test added to `tests/parable/fuzz-20613.tests`
- [x] `just check` passes