### PR TITLE
fix: format process substitutions inside parameter expansions

### DIFF
--- a/tests/parable/fuzz-32746.tests
+++ b/tests/parable/fuzz-32746.tests
@@ -1,0 +1,5 @@
+=== process substitution in parameter expansion with ||
+${a+$<(b|| c)}
+---
+(command (word "${a+$<(b || c)}"))
+---


### PR DESCRIPTION
## Summary
- Process substitutions like `<(...)` inside parameter expansion arguments were not being formatted
- Added detection for untracked `<(` and `>(` patterns
- Added on-the-fly parsing for process substitutions (like existing support for command subs)
- MRE: `${a+$<(b|| c)}` → `${a+$<(b || c)}`

## Test plan
- [x] New test added to `tests/parable/fuzz-32746.tests`
- [x] `just check` passes