### PR TITLE
fix: handle backticks spanning lines in heredoc line_end calculation

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3615,6 +3615,7 @@ function _skipHeredoc(value, start) {
 	}
 	// Skip to end of line (heredoc content starts on next line)
 	// But track paren depth - if we hit a ) at depth 0, it closes the cmdsub
+	// Must handle quotes and backticks since newlines in them don't end the line
 	paren_depth = 0;
 	while (i < value.length && value[i] !== "\n") {
 		if (value[i] === "(") {
@@ -3625,6 +3626,32 @@ function _skipHeredoc(value, start) {
 				break;
 			}
 			paren_depth -= 1;
+		} else if (value[i] === "'") {
+			// Single-quoted string - skip to closing quote
+			i += 1;
+			while (i < value.length && value[i] !== "'") {
+				i += 1;
+			}
+		} else if (value[i] === '"') {
+			// Double-quoted string - skip to closing quote (with escapes)
+			i += 1;
+			while (i < value.length && value[i] !== '"') {
+				if (value[i] === "\\" && i + 1 < value.length) {
+					i += 2;
+				} else {
+					i += 1;
+				}
+			}
+		} else if (value[i] === "`") {
+			// Backtick command substitution - skip to closing backtick
+			i += 1;
+			while (i < value.length && value[i] !== "`") {
+				if (value[i] === "\\" && i + 1 < value.length) {
+					i += 2;
+				} else {
+					i += 1;
+				}
+			}
 		}
 		i += 1;
 	}
@@ -7457,6 +7484,16 @@ class Parser {
 				// Double-quoted string - skip to closing quote (with escapes)
 				line_end += 1;
 				while (line_end < this.length && this.source[line_end] !== '"') {
+					if (this.source[line_end] === "\\" && line_end + 1 < this.length) {
+						line_end += 2;
+					} else {
+						line_end += 1;
+					}
+				}
+			} else if (ch === "`") {
+				// Backtick command substitution - skip to closing backtick
+				line_end += 1;
+				while (line_end < this.length && this.source[line_end] !== "`") {
 					if (this.source[line_end] === "\\" && line_end + 1 < this.length) {
 						line_end += 2;
 					} else {

--- a/tests/parable/fuzz-13943.tests
+++ b/tests/parable/fuzz-13943.tests
@@ -1,0 +1,7 @@
+=== heredoc with backtick spanning lines
+<<E|`
+`
+E
+---
+(pipe (command (redirect "<<" "")) (command (word "`\n`")))
+---


### PR DESCRIPTION
## Summary
- Fix for heredocs when backtick command substitution spans multiple lines
- MRE: `<<E|\`\n\`\nE` - the backtick cmdsub spans the newline, so heredoc body should be empty
- Added backtick handling to `_parse_heredoc` and `_skip_heredoc` when finding line_end

## Test plan
- [x] New test added to `tests/parable/fuzz-13943.tests`
- [x] `just check` passes