### PR TITLE
fuzzer fix: don't treat <( and >( as process substitution inside double quotes

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1152,11 +1152,12 @@ class Word extends Node {
 				has_untracked_cmdsub = true;
 				break;
 			} else if (
-				_startsWithAt(value, idx, "<(") ||
-				_startsWithAt(value, idx, ">(")
+				(_startsWithAt(value, idx, "<(") || _startsWithAt(value, idx, ">(")) &&
+				!in_double
 			) {
 				// Only treat as process substitution if not preceded by alphanumeric
 				// (e.g., "i<(3)" is arithmetic comparison, not process substitution)
+				// Also don't treat as process substitution inside double quotes
 				if (idx === 0 || !/^[a-zA-Z0-9]$/.test(value[idx - 1])) {
 					has_untracked_procsub = true;
 					break;
@@ -1261,10 +1262,10 @@ class Word extends Node {
 				cmdsub_idx += 1;
 				i = j;
 			} else if (
-				_startsWithAt(value, i, ">(") ||
-				_startsWithAt(value, i, "<(")
+				(_startsWithAt(value, i, ">(") || _startsWithAt(value, i, "<(")) &&
+				!in_double_quote
 			) {
-				// Check for >( or <( process substitution
+				// Check for >( or <( process substitution (not inside double quotes)
 				// Check if this is actually a process substitution or just comparison + parens
 				// Process substitution: not preceded by alphanumeric
 				is_procsub = i === 0 || !/^[a-zA-Z0-9]$/.test(value[i - 1]);

--- a/src/parable.py
+++ b/src/parable.py
@@ -907,9 +907,12 @@ class Word(Node):
             ):
                 has_untracked_cmdsub = True
                 break
-            elif _starts_with_at(value, idx, "<(") or _starts_with_at(value, idx, ">("):
+            elif (
+                _starts_with_at(value, idx, "<(") or _starts_with_at(value, idx, ">(")
+            ) and not in_double:
                 # Only treat as process substitution if not preceded by alphanumeric
                 # (e.g., "i<(3)" is arithmetic comparison, not process substitution)
+                # Also don't treat as process substitution inside double quotes
                 if idx == 0 or not value[idx - 1].isalnum():
                     has_untracked_procsub = True
                     break
@@ -999,8 +1002,10 @@ class Word(Node):
                 result.append(_substring(value, i, j))
                 cmdsub_idx += 1
                 i = j
-            # Check for >( or <( process substitution
-            elif _starts_with_at(value, i, ">(") or _starts_with_at(value, i, "<("):
+            # Check for >( or <( process substitution (not inside double quotes)
+            elif (
+                _starts_with_at(value, i, ">(") or _starts_with_at(value, i, "<(")
+            ) and not in_double_quote:
                 # Check if this is actually a process substitution or just comparison + parens
                 # Process substitution: not preceded by alphanumeric
                 is_procsub = i == 0 or not value[i - 1].isalnum()

--- a/tests/parable/fuzz-32643.tests
+++ b/tests/parable/fuzz-32643.tests
@@ -1,0 +1,5 @@
+=== process substitution syntax inside double quotes is literal
+"<("
+---
+(command (word "\"<(\""))
+---


### PR DESCRIPTION
## Summary
- Inside double-quoted strings, `<(` and `>(` should be literal characters, not process substitution
- MRE: `"<("` was being parsed as `"\"<()"` instead of `"\"<(\""`
- Fixed by checking `in_double_quote` state before treating `<(` / `>(` as process substitution

## Test plan
- [x] New test added to `tests/parable/fuzz-32643.tests`
- [x] `just check` passes