### PR TITLE
fuzzer fix: strip backslash-newline in >(( procsub

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1279,6 +1279,8 @@ class Word extends Node {
 						raw_content = value.slice(i + 2, j - 1);
 						if (raw_content.startsWith("(")) {
 							// Process substitution with nested subshell >((...)): preserve original
+							// Strip line continuations (backslash-newline)
+							raw_content = raw_content.replaceAll("\\\n", "");
 							result.push(`${direction}(${raw_content})`);
 							procsub_idx += 1;
 							i = j;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1019,6 +1019,8 @@ class Word(Node):
                         raw_content = _substring(value, i + 2, j - 1)
                         if raw_content.startswith("("):
                             # Process substitution with nested subshell >((...)): preserve original
+                            # Strip line continuations (backslash-newline)
+                            raw_content = raw_content.replace("\\\n", "")
                             result.append(direction + "(" + raw_content + ")")
                             procsub_idx += 1
                             i = j

--- a/tests/parable/fuzz-4821.tests
+++ b/tests/parable/fuzz-4821.tests
@@ -1,0 +1,6 @@
+=== backslash-newline in >(( process substitution
+>((a\
+))
+---
+(command (word ">((a))"))
+---


### PR DESCRIPTION
## Summary
- Process substitutions with nested subshells like `>((a\<newline>))` were preserving the backslash-newline (line continuation) in the output instead of stripping it
- MRE: `>((a\<newline>))` → Parable: `">((a\\\n))"` vs Oracle: `">((a))"`
- Fix strips line continuations from raw content in `_format_command_substitutions`