### PR TITLE
fuzzer fix: handle subscripts when stripping varfd prefix in redirect output

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1692,7 +1692,7 @@ class Redirect extends Node {
 		let fd_target, j, op, out_val, raw, target_val;
 		// Strip fd prefix from operator (e.g., "2>" -> ">", "{fd}>" -> ">")
 		op = this.op.replace(/^[0123456789]+/, "");
-		// Strip {varname} prefix if present
+		// Strip {varname} or {varname[subscript]} prefix if present
 		if (op.startsWith("{")) {
 			j = 1;
 			if (j < op.length && (/^[a-zA-Z]$/.test(op[j]) || op[j] === "_")) {
@@ -1702,6 +1702,16 @@ class Redirect extends Node {
 					(/^[a-zA-Z0-9]$/.test(op[j]) || op[j] === "_")
 				) {
 					j += 1;
+				}
+				// Handle optional [subscript] part
+				if (j < op.length && op[j] === "[") {
+					j += 1;
+					while (j < op.length && op[j] !== "]") {
+						j += 1;
+					}
+					if (j < op.length && op[j] === "]") {
+						j += 1;
+					}
 				}
 				if (j < op.length && op[j] === "}") {
 					op = op.slice(j + 1, op.length);

--- a/src/parable.py
+++ b/src/parable.py
@@ -1354,13 +1354,20 @@ class Redirect(Node):
     def to_sexp(self) -> str:
         # Strip fd prefix from operator (e.g., "2>" -> ">", "{fd}>" -> ">")
         op = self.op.lstrip("0123456789")
-        # Strip {varname} prefix if present
+        # Strip {varname} or {varname[subscript]} prefix if present
         if op.startswith("{"):
             j = 1
             if j < len(op) and (op[j].isalpha() or op[j] == "_"):
                 j += 1
                 while j < len(op) and (op[j].isalnum() or op[j] == "_"):
                     j += 1
+                # Handle optional [subscript] part
+                if j < len(op) and op[j] == "[":
+                    j += 1
+                    while j < len(op) and op[j] != "]":
+                        j += 1
+                    if j < len(op) and op[j] == "]":
+                        j += 1
                 if j < len(op) and op[j] == "}":
                     op = _substring(op, j + 1, len(op))
         target_val = self.target.value

--- a/tests/parable/fuzz-18901.tests
+++ b/tests/parable/fuzz-18901.tests
@@ -1,0 +1,5 @@
+=== fd var with subscript should not be treated as redirect prefix
+{a[0]}>&x
+---
+(command (redirect ">&" "x"))
+---


### PR DESCRIPTION
## Summary
- Fixed `Redirect.to_sexp()` to handle subscripts in varfd prefixes (e.g., `{a[0]}>`), which was causing incorrect output like `(redirect "{a[0]}>" "x")` instead of `(redirect ">&" "x")`
- MRE: `{a[0]}>&x`

## Test plan
- [x] New test added to `tests/parable/fuzz-18901.tests`
- [x] `just check` passes