### PR TITLE
fuzzer fix: treat [ as literal when bracket won't close before ) or ]]

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8600,6 +8600,7 @@ class Parser {
 		let arith_node,
 			arith_result,
 			arith_text,
+			bracket_will_close,
 			c,
 			ch,
 			chars,
@@ -8612,6 +8613,8 @@ class Parser {
 			paren_depth,
 			parts,
 			parts_arg,
+			sc,
+			scan,
 			start;
 		this._condSkipWhitespace();
 		if (this._condAtEnd()) {
@@ -8665,6 +8668,65 @@ class Parser {
 			// Regex character class [...] - consume until closing ]
 			// Handles [[:alpha:]], [^0-9], []a-z] (] as first char), etc.
 			if (ch === "[") {
+				// Lookahead: check if bracket expression will close properly
+				// before hitting ]] or ) (when inside paren group)
+				scan = this.pos + 1;
+				// Skip ^ for negation
+				if (scan < this.length && this.source[scan] === "^") {
+					scan += 1;
+				}
+				// Skip ] as first char (literal)
+				if (scan < this.length && this.source[scan] === "]") {
+					scan += 1;
+				}
+				bracket_will_close = false;
+				while (scan < this.length) {
+					sc = this.source[scan];
+					// Check for ]] - end of conditional
+					if (
+						sc === "]" &&
+						scan + 1 < this.length &&
+						this.source[scan + 1] === "]"
+					) {
+						break;
+					}
+					// Check for ) when inside paren group
+					if (sc === ")" && paren_depth > 0) {
+						break;
+					}
+					if (sc === "]") {
+						bracket_will_close = true;
+						break;
+					}
+					// Skip POSIX classes [:...:]
+					if (
+						sc === "[" &&
+						scan + 1 < this.length &&
+						this.source[scan + 1] === ":"
+					) {
+						scan += 2;
+						while (
+							scan < this.length &&
+							!(
+								this.source[scan] === ":" &&
+								scan + 1 < this.length &&
+								this.source[scan + 1] === "]"
+							)
+						) {
+							scan += 1;
+						}
+						if (scan < this.length) {
+							scan += 2;
+						}
+						continue;
+					}
+					scan += 1;
+				}
+				if (!bracket_will_close) {
+					// Treat [ as literal
+					chars.push(this.advance());
+					continue;
+				}
 				chars.push(this.advance());
 				// Handle negation [^
 				if (!this.atEnd() && this.peek() === "^") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -7237,6 +7237,44 @@ class Parser:
             # Regex character class [...] - consume until closing ]
             # Handles [[:alpha:]], [^0-9], []a-z] (] as first char), etc.
             if ch == "[":
+                # Lookahead: check if bracket expression will close properly
+                # before hitting ]] or ) (when inside paren group)
+                scan = self.pos + 1  # position after [
+                # Skip ^ for negation
+                if scan < self.length and self.source[scan] == "^":
+                    scan += 1
+                # Skip ] as first char (literal)
+                if scan < self.length and self.source[scan] == "]":
+                    scan += 1
+                bracket_will_close = False
+                while scan < self.length:
+                    sc = self.source[scan]
+                    # Check for ]] - end of conditional
+                    if sc == "]" and scan + 1 < self.length and self.source[scan + 1] == "]":
+                        break  # Won't close before ]]
+                    # Check for ) when inside paren group
+                    if sc == ")" and paren_depth > 0:
+                        break  # Won't close before )
+                    if sc == "]":
+                        bracket_will_close = True
+                        break
+                    # Skip POSIX classes [:...:]
+                    if sc == "[" and scan + 1 < self.length and self.source[scan + 1] == ":":
+                        scan += 2  # skip [:
+                        while scan < self.length and not (
+                            self.source[scan] == ":"
+                            and scan + 1 < self.length
+                            and self.source[scan + 1] == "]"
+                        ):
+                            scan += 1
+                        if scan < self.length:
+                            scan += 2  # skip :]
+                        continue
+                    scan += 1
+                if not bracket_will_close:
+                    # Treat [ as literal
+                    chars.append(self.advance())
+                    continue
                 chars.append(self.advance())  # consume [
                 # Handle negation [^
                 if not self.at_end() and self.peek() == "^":

--- a/tests/parable/fuzz-24796.tests
+++ b/tests/parable/fuzz-24796.tests
@@ -1,0 +1,7 @@
+=== unclosed bracket in regex paren group
+[[ a =~ ([:) ]]
+[[ b =~ [c] ]]
+---
+(cond (cond-binary "=~" (cond-term "a") (cond-term "([:)")))
+(cond (cond-binary "=~" (cond-term "b") (cond-term "[c]")))
+---


### PR DESCRIPTION
## Summary
- When parsing regex operands in `[[ =~ ]]`, an unclosed bracket expression like `([:)` was incorrectly consuming input until finding a `]` elsewhere (potentially on subsequent lines)
- Added lookahead to check if bracket expression will properly close before hitting `)` (when inside a paren group) or `]]` (end of conditional)
- If bracket won't close properly, `[` is now treated as a literal character

MRE:
```bash
[[ a =~ ([:) ]]
[[ b =~ [c] ]]
```

## Test plan
- [x] New test added to `tests/parable/fuzz-24796.tests`
- [x] `just check` passes