### PR TITLE
fuzzer fix: strip line continuation in nested process substitution subshell

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1279,7 +1279,10 @@ class Word extends Node {
 						raw_content = value.slice(i + 2, j - 1);
 						if (raw_content.startsWith("(")) {
 							// Process substitution with nested subshell >((...)): preserve original
-							result.push(`${direction}(${raw_content})`);
+							// Strip line continuations since this is word content
+							result.push(
+								`${direction}(${raw_content.replaceAll("\\\n", "")})`,
+							);
 							procsub_idx += 1;
 							i = j;
 							continue;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1019,7 +1019,8 @@ class Word(Node):
                         raw_content = _substring(value, i + 2, j - 1)
                         if raw_content.startswith("("):
                             # Process substitution with nested subshell >((...)): preserve original
-                            result.append(direction + "(" + raw_content + ")")
+                            # Strip line continuations since this is word content
+                            result.append(direction + "(" + raw_content.replace("\\\n", "") + ")")
                             procsub_idx += 1
                             i = j
                             continue

--- a/tests/parable/fuzz-23775.tests
+++ b/tests/parable/fuzz-23775.tests
@@ -1,0 +1,6 @@
+=== line continuation in failed process substitution
+<((a\
+))
+---
+(command (word "<((a))"))
+---


### PR DESCRIPTION
## Summary
- Fix line continuation not being stripped inside process substitution with nested subshell like `<((a\<newline>))`
- MRE: `<((a\<newline>))` was outputting `<((a\\\n))` instead of `<((a))`

## Test plan
- [x] New test added to `tests/parable/fuzz-23775.tests`
- [x] `just check` passes