### PR TITLE
fuzzer fix: format heredoc redirect order in command substitution

### DIFF
--- a/tests/parable/fuzz-19415.tests
+++ b/tests/parable/fuzz-19415.tests
@@ -1,0 +1,6 @@
+=== heredoc redirect in command substitution
+$(<<E>x
+E)
+---
+(command (word "$(<<E > x\nE\n)"))
+---


### PR DESCRIPTION
## Summary
- Fixed redirect ordering when formatting heredocs in command substitutions
- MRE: `$(<<E>x\nE)` - redirect `>x` should appear after `<<E` but before heredoc body

The bug was that heredocs were being fully formatted (including body) in sequence with other redirects, causing `$(<<E\nE\n > x)` instead of the correct `$(<<E > x\nE\n)`. Now heredoc operators are output inline with other redirects, and heredoc bodies are appended at the end.