### PR TITLE
fuzzer fix: normalize newlines at param expansion boundaries

### DIFF
--- a/tests/parable/fuzz-16651.tests
+++ b/tests/parable/fuzz-16651.tests
@@ -1,0 +1,7 @@
+=== newlines at param expansion boundaries become spaces
+${
+a-
+}
+---
+(command (word "${ a-\n }"))
+---


### PR DESCRIPTION
## Summary
- Fixed handling of newlines at param expansion boundaries
- When there's a newline immediately after `${`, bash converts it to a space and adds a trailing space before `}`
- MRE: `${\na-\n}` should parse as `${ a-\n }` (not `${\na-\n}`)

## Test plan
- [x] New test added to `tests/parable/fuzz-16651.tests`
- [x] `just check` passes