### PR TITLE
fuzzer fix: drop semicolon/newline after heredoc in cmdsub formatting

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3146,10 +3146,19 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		for (p of node.parts) {
 			if (p.kind === "operator") {
 				if (p.op === ";") {
+					// Skip semicolon if previous command ends with heredoc (newline)
+					if (result.length > 0 && result[result.length - 1].endsWith("\n")) {
+						continue;
+					}
 					result.push(";");
 				} else if (p.op === "\n") {
 					// Skip newline if it follows a semicolon (redundant separator)
 					if (result.length > 0 && result[result.length - 1] === ";") {
+						continue;
+					}
+					// If previous ends with heredoc newline, add space instead
+					if (result.length > 0 && result[result.length - 1].endsWith("\n")) {
+						result.push(" ");
 						continue;
 					}
 					result.push("\n");

--- a/src/parable.py
+++ b/src/parable.py
@@ -2701,10 +2701,17 @@ def _format_cmdsub_node(
         for p in node.parts:
             if p.kind == "operator":
                 if p.op == ";":
+                    # Skip semicolon if previous command ends with heredoc (newline)
+                    if result and result[len(result) - 1].endswith("\n"):
+                        continue
                     result.append(";")
                 elif p.op == "\n":
                     # Skip newline if it follows a semicolon (redundant separator)
                     if result and result[len(result) - 1] == ";":
+                        continue
+                    # If previous ends with heredoc newline, add space instead
+                    if result and result[len(result) - 1].endswith("\n"):
+                        result.append(" ")
                         continue
                     result.append("\n")
                 elif p.op == "&":

--- a/tests/parable/fuzz-14916.tests
+++ b/tests/parable/fuzz-14916.tests
@@ -1,0 +1,7 @@
+=== semicolon after heredoc in cmdsub should be dropped
+$(<<X;
+X
+a)
+---
+(command (word "$(<<X\nX\n a)"))
+---


### PR DESCRIPTION
## Summary
- When formatting a list in `_format_cmdsub_node`, semicolon and newline operators after a heredoc were being preserved
- MRE: `$(<<X;\nX\na)` was formatted as `$(<<X\nX\n; a)` instead of `$(<<X\nX\n a)`
- Fix: Skip semicolon when previous result ends with newline (heredoc), and convert newline operators to space when following a heredoc