### PR TITLE
fuzzer fix: treat [ as literal when | follows before ] in case patterns

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2282,6 +2282,9 @@ function _consumeBracketClass(s, start, depth) {
 		if (s[scan_pos] === ")" && depth === 0) {
 			break;
 		}
+		if (s[scan_pos] === "|" && depth === 0) {
+			break;
+		}
 		scan_pos += 1;
 	}
 	if (!is_bracket) {
@@ -9671,8 +9674,8 @@ class Parser {
 						} else if (sc === ")" && scan_depth === 0) {
 							// Hit pattern/extglob closer before finding ]
 							break;
-						} else if (sc === "|" && scan_depth === 0 && extglob_depth > 0) {
-							// Hit alternation in extglob - ] must be in this branch
+						} else if (sc === "|" && scan_depth === 0) {
+							// Hit pattern separator (| in case pattern or extglob alternation)
 							break;
 						}
 						scan_pos += 1;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1898,6 +1898,8 @@ def _consume_bracket_class(s: str, start: int, depth: int) -> tuple:
             break
         if s[scan_pos] == ")" and depth == 0:
             break
+        if s[scan_pos] == "|" and depth == 0:
+            break
         scan_pos += 1
     if not is_bracket:
         return (start + 1, ["["], False)
@@ -8073,8 +8075,8 @@ class Parser:
                         elif sc == ")" and scan_depth == 0:
                             # Hit pattern/extglob closer before finding ]
                             break
-                        elif sc == "|" and scan_depth == 0 and extglob_depth > 0:
-                            # Hit alternation in extglob - ] must be in this branch
+                        elif sc == "|" and scan_depth == 0:
+                            # Hit pattern separator (| in case pattern or extglob alternation)
                             break
                         scan_pos += 1
                     if is_char_class:

--- a/tests/parable/fuzz-20409.tests
+++ b/tests/parable/fuzz-20409.tests
@@ -1,0 +1,5 @@
+=== bracket with pipe in case pattern is split by pattern separator
+case x in [a|b]) ;; esac
+---
+(case (word "x") (pattern ((word "[a") (word "b]")) ()))
+---


### PR DESCRIPTION
## Summary
- In case patterns, `|` is a pattern separator, so `[a|b]` should be parsed as two words `[a` and `b]`, not a single bracket expression
- MRE: `case x in [a|b]) ;; esac`
- Fixed `_consume_bracket_class` to break on `|` at depth 0, matching the existing check for `)`
- Also fixed the case pattern parsing loop to apply the same logic

## Test plan
- [x] New test added to `tests/parable/fuzz-20409.tests`
- [x] `just check` passes