### PR TITLE
fuzzer fix: handle redirects after heredoc in command substitution

### DIFF
--- a/tests/parable/fuzz-774.tests
+++ b/tests/parable/fuzz-774.tests
@@ -1,0 +1,5 @@
+=== heredoc with redirect on same line in command substitution
+"$(<<a <a)"
+---
+(command (word "\"$(<<a < a\na\n)\""))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of heredocs inside command substitutions where other redirects appear on the same line
- MRE: `"$(<<a <a)"` - the `<a` redirect should appear between the heredoc delimiter and content
- Oracle produces: `<<a < a\na\n` but Parable incorrectly produced: `<<a\na\n < a`

## Test plan
- [x] New test added to `tests/parable/fuzz-774.tests`
- [x] `just check` passes