### PR TITLE
fuzzer fix: recognize time -p flag before metacharacters

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -10226,7 +10226,7 @@ class Parser {
 				this.advance();
 				if (!this.atEnd() && this.peek() === "p") {
 					this.advance();
-					if (this.atEnd() || _isWhitespace(this.peek())) {
+					if (this.atEnd() || _isMetachar(this.peek())) {
 						time_posix = true;
 					} else {
 						this.pos = saved;
@@ -10258,7 +10258,7 @@ class Parser {
 					this.advance();
 					if (!this.atEnd() && this.peek() === "p") {
 						this.advance();
-						if (this.atEnd() || _isWhitespace(this.peek())) {
+						if (this.atEnd() || _isMetachar(this.peek())) {
 							time_posix = true;
 						} else {
 							this.pos = saved;

--- a/src/parable.py
+++ b/src/parable.py
@@ -8588,7 +8588,7 @@ class Parser:
                 self.advance()
                 if not self.at_end() and self.peek() == "p":
                     self.advance()
-                    if self.at_end() or _is_whitespace(self.peek()):
+                    if self.at_end() or _is_metachar(self.peek()):
                         time_posix = True
                     else:
                         self.pos = saved
@@ -8612,7 +8612,7 @@ class Parser:
                     self.advance()
                     if not self.at_end() and self.peek() == "p":
                         self.advance()
-                        if self.at_end() or _is_whitespace(self.peek()):
+                        if self.at_end() or _is_metachar(self.peek()):
                             time_posix = True
                         else:
                             self.pos = saved

--- a/tests/parable/fuzz-15947.tests
+++ b/tests/parable/fuzz-15947.tests
@@ -1,0 +1,5 @@
+=== time -p with semicolon should parse -p as flag
+time -p;
+---
+(time -p (command))
+---


### PR DESCRIPTION
## Summary
- Fix: `time -p` flag now recognized when followed by metacharacters (`;`, `&`, etc.)
- MRE: `time -p;` was parsed as `(time (command (word "-p")))` instead of `(time -p (command))`
- Changed whitespace check to use `_is_metachar()` which includes all shell metacharacters