### PR TITLE
fuzzer fix: pass in_procsub flag when formatting list parts

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3284,7 +3284,9 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 				) {
 					result.push(" ");
 				}
-				result.push(_formatCmdsubNode(p, indent));
+				result.push(
+					_formatCmdsubNode(p, indent, in_procsub, compact_redirects),
+				);
 			}
 		}
 		// Strip trailing ; or newline (but preserve heredoc's trailing newline)

--- a/src/parable.py
+++ b/src/parable.py
@@ -2809,7 +2809,7 @@ def _format_cmdsub_node(
             else:
                 if result and not result[len(result) - 1].endswith((" ", "\n")):
                     result.append(" ")
-                result.append(_format_cmdsub_node(p, indent))
+                result.append(_format_cmdsub_node(p, indent, in_procsub, compact_redirects))
         # Strip trailing ; or newline (but preserve heredoc's trailing newline)
         s = "".join(result)
         # If we have & with heredoc (& before newline content), preserve trailing newline and add space

--- a/tests/parable/fuzz-16118.tests
+++ b/tests/parable/fuzz-16118.tests
@@ -1,0 +1,6 @@
+=== subshell in process substitution with newline should not add spaces
+<((a)
+a)
+---
+(command (word "<((a)\na)"))
+---


### PR DESCRIPTION
## Summary
- When formatting list parts inside `_format_cmdsub_node`, the recursive call wasn't passing `in_procsub` and `compact_redirects` flags
- This caused subshells inside process substitution lists to be formatted with spaces (`( a )`) instead of compact (`(a)`)
- MRE: `<((a)\na)` was formatted as `<(( a )\na)` instead of `<((a)\na)`