### PR TITLE
fuzzer fix: preserve trailing newline in brace command substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1422,7 +1422,14 @@ class Word extends Node {
 						if (parsed) {
 							formatted = _formatCmdsubNode(parsed);
 							formatted = formatted.replace(/[;]+$/, "");
-							terminator = formatted.endsWith(" &") ? " }" : "; }";
+							// Preserve trailing newline from original if present
+							if (inner.replace(/[ \t]+$/, "").endsWith("\n")) {
+								terminator = "\n }";
+							} else if (formatted.endsWith(" &")) {
+								terminator = " }";
+							} else {
+								terminator = "; }";
+							}
 							result.push(prefix + formatted + terminator);
 						} else {
 							result.push("${ }");

--- a/src/parable.py
+++ b/src/parable.py
@@ -1143,7 +1143,13 @@ class Word(Node):
                         if parsed:
                             formatted = _format_cmdsub_node(parsed)
                             formatted = formatted.rstrip(";")
-                            terminator = " }" if formatted.endswith(" &") else "; }"
+                            # Preserve trailing newline from original if present
+                            if inner.rstrip(" \t").endswith("\n"):
+                                terminator = "\n }"
+                            elif formatted.endswith(" &"):
+                                terminator = " }"
+                            else:
+                                terminator = "; }"
                             result.append(prefix + formatted + terminator)
                         else:
                             result.append("${ }")

--- a/tests/parable/fuzz-1260.tests
+++ b/tests/parable/fuzz-1260.tests
@@ -1,0 +1,6 @@
+=== brace cmdsub preserves trailing newline
+${ x*
+}a
+---
+(command (word "${ x*\n }a"))
+---


### PR DESCRIPTION
## Summary
- Brace command substitution `${ cmd }` was converting trailing newlines to semicolons
- MRE: `${ x*\n}a` output `${ x*; }a` instead of `${ x*\n }a`
- Fix preserves `\n ` terminator when original had trailing newline before `}`