### PR TITLE
fuzzer fix: preserve leading whitespace in procsub inside arithmetic

### DIFF
--- a/tests/parable/fuzz-3365.tests
+++ b/tests/parable/fuzz-3365.tests
@@ -1,0 +1,5 @@
+=== process substitution preserves leading whitespace in arithmetic
+$((<( a)))
+---
+(command (word "$((<( a)))"))
+---


### PR DESCRIPTION
## Summary
- Process substitution inside arithmetic expansion was losing leading whitespace
- MRE: `$((<( a)))` → Parable output `$((<(a)))` instead of `$((<( a)))`
- Fix preserves leading whitespace when parsing process substitution content on the fly

## Test plan
- [x] New test added to `tests/parable/fuzz-3365.tests`
- [x] `just check` passes