### PR TITLE
fuzzer fix: skip cmdsubs when finding param expansion closing brace

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1438,7 +1438,7 @@ class Word extends Node {
 			) {
 				// Process regular ${...} parameter expansions (recursively format cmdsubs inside)
 				// But not if the $ is escaped by a backslash
-				// Find matching close brace, respecting nesting and quotes
+				// Find matching close brace, respecting nesting, quotes, and cmdsubs
 				j = i + 2;
 				depth = 1;
 				in_single = false;
@@ -1454,6 +1454,14 @@ class Word extends Node {
 					} else if (c === '"' && !in_single) {
 						in_double = !in_double;
 					} else if (!in_single && !in_double) {
+						// Skip over $(...) command substitutions
+						if (
+							_startsWithAt(value, j, "$(") &&
+							!_startsWithAt(value, j, "$((")
+						) {
+							j = _findCmdsubEnd(value, j + 2);
+							continue;
+						}
 						if (c === "{") {
 							depth += 1;
 						} else if (c === "}") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -1153,7 +1153,7 @@ class Word(Node):
             # Process regular ${...} parameter expansions (recursively format cmdsubs inside)
             # But not if the $ is escaped by a backslash
             elif _starts_with_at(value, i, "${") and not _is_backslash_escaped(value, i):
-                # Find matching close brace, respecting nesting and quotes
+                # Find matching close brace, respecting nesting, quotes, and cmdsubs
                 j = i + 2
                 depth = 1
                 in_single = False
@@ -1168,6 +1168,10 @@ class Word(Node):
                     elif c == '"' and not in_single:
                         in_double = not in_double
                     elif not in_single and not in_double:
+                        # Skip over $(...) command substitutions
+                        if _starts_with_at(value, j, "$(") and not _starts_with_at(value, j, "$(("):
+                            j = _find_cmdsub_end(value, j + 2)
+                            continue
                         if c == "{":
                             depth += 1
                         elif c == "}":

--- a/tests/parable/fuzz-31668.tests
+++ b/tests/parable/fuzz-31668.tests
@@ -1,0 +1,5 @@
+=== $(<) file read inside param expansion should include } in filename
+${x:-$(<})}
+---
+(command (word "${x:-$(< })}"))
+---


### PR DESCRIPTION
## Summary
- When `_format_command_substitutions` searches for the closing `}` of a parameter expansion like `${x:-...}`, it now skips over `$(...)` command substitutions to avoid treating `}` inside them as closing the param expansion
- MRE: `${x:-$(<})}` was incorrectly parsed as `${x:-$()})}` instead of `${x:-$(< })}`

## Test plan
- [x] New test added to `tests/parable/fuzz-31668.tests`
- [x] `just check` passes