### PR TITLE
fuzzer fix: preserve ANSI-C quotes in unquoted param expansions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -446,6 +446,7 @@ class Word extends Node {
 			is_ansi_c,
 			j,
 			op,
+			outer_in_dquote,
 			quote_stack,
 			result,
 			result_str;
@@ -543,10 +544,15 @@ class Word extends Node {
 				ansi_str = value.slice(i, j);
 				// Strip the $ and expand escapes
 				expanded = this._expandAnsiCEscapes(ansi_str.slice(1, ansi_str.length));
-				// Inside ${...}, strip quotes for default/alternate value operators
-				// but keep them for pattern replacement operators
+				// Inside ${...} that's itself in double quotes, strip quotes for
+				// default/alternate value operators but keep for pattern operators
+				outer_in_dquote =
+					quote_stack.length > 0
+						? quote_stack[quote_stack.length - 1][1]
+						: false;
 				if (
 					brace_depth > 0 &&
+					outer_in_dquote &&
 					expanded.startsWith("'") &&
 					expanded.endsWith("'")
 				) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -481,9 +481,17 @@ class Word(Node):
                 expanded = self._expand_ansi_c_escapes(
                     _substring(ansi_str, 1, len(ansi_str))
                 )  # Pass 'hello\nworld'
-                # Inside ${...}, strip quotes for default/alternate value operators
-                # but keep them for pattern replacement operators
-                if brace_depth > 0 and expanded.startswith("'") and expanded.endswith("'"):
+                # Inside ${...} that's itself in double quotes, strip quotes for
+                # default/alternate value operators but keep for pattern operators
+                outer_in_dquote = (
+                    quote_stack[len(quote_stack) - 1][1] if len(quote_stack) > 0 else False
+                )
+                if (
+                    brace_depth > 0
+                    and outer_in_dquote
+                    and expanded.startswith("'")
+                    and expanded.endswith("'")
+                ):
                     inner = _substring(expanded, 1, len(expanded) - 1)
                     # Only strip if non-empty and no CTLESC
                     if inner and inner.find("\x01") == -1:

--- a/tests/parable/fuzz-30388.tests
+++ b/tests/parable/fuzz-30388.tests
@@ -1,0 +1,5 @@
+=== ANSI-C string in param expansion default
+${a-$'x'}
+---
+(command (word "${a-'x'}"))
+---


### PR DESCRIPTION
## Summary
- When `$'x'` appears in an unquoted parameter expansion like `${a-$'x'}`, Parable was incorrectly stripping the single quotes, outputting `${a-x}` instead of `${a-'x'}`
- The fix checks if the `${...}` is itself inside double quotes before stripping quotes from ANSI-C strings
- MRE: `${a-$'x'}` should parse to `(command (word "${a-'x'}"))`, not `(command (word "${a-x}"))`