### PR TITLE
fuzzer fix: use compact pipe format in procsub when first command is subshell

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3074,6 +3074,7 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		body_part,
 		cmd,
 		cmds,
+		compact_pipe,
 		cond,
 		else_body,
 		first_nl,
@@ -3185,7 +3186,7 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		idx = 0;
 		while (idx < cmds.length) {
 			[cmd, needs_redirect] = cmds[idx];
-			formatted = _formatCmdsubNode(cmd, indent);
+			formatted = _formatCmdsubNode(cmd, indent, in_procsub);
 			if (needs_redirect) {
 				formatted = `${formatted} 2>&1`;
 			}
@@ -3214,6 +3215,8 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 			idx += 1;
 		}
 		// Join with " | " for commands without heredocs, or just join if heredocs handled
+		// In procsub, if first command is subshell, use compact "|" separator
+		compact_pipe = in_procsub && cmds && cmds[0][0].kind === "subshell";
 		result = "";
 		idx = 0;
 		while (idx < result_parts.length) {
@@ -3222,6 +3225,8 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 				// If previous part ends with heredoc (newline), add indented command
 				if (result.endsWith("\n")) {
 					result = `${result}  ${part}`;
+				} else if (compact_pipe) {
+					result = `${result}|${part}`;
 				} else {
 					result = `${result} | ${part}`;
 				}

--- a/src/parable.py
+++ b/src/parable.py
@@ -2737,7 +2737,7 @@ def _format_cmdsub_node(
         idx = 0
         while idx < len(cmds):
             cmd, needs_redirect = cmds[idx]
-            formatted = _format_cmdsub_node(cmd, indent)
+            formatted = _format_cmdsub_node(cmd, indent, in_procsub)
             if needs_redirect:
                 formatted = formatted + " 2>&1"
             is_last = idx == len(cmds) - 1
@@ -2759,6 +2759,8 @@ def _format_cmdsub_node(
                 result_parts.append(formatted)
             idx += 1
         # Join with " | " for commands without heredocs, or just join if heredocs handled
+        # In procsub, if first command is subshell, use compact "|" separator
+        compact_pipe = in_procsub and cmds and cmds[0][0].kind == "subshell"
         result = ""
         idx = 0
         while idx < len(result_parts):
@@ -2767,6 +2769,8 @@ def _format_cmdsub_node(
                 # If previous part ends with heredoc (newline), add indented command
                 if result.endswith("\n"):
                     result = result + "  " + part
+                elif compact_pipe:
+                    result = result + "|" + part
                 else:
                     result = result + " | " + part
             else:

--- a/tests/parable/fuzz-11573.tests
+++ b/tests/parable/fuzz-11573.tests
@@ -1,0 +1,5 @@
+=== subshell pipe in process substitution
+<((a)|b)
+---
+(command (word "<((a)|b)"))
+---


### PR DESCRIPTION
## Summary
- When formatting pipelines inside process substitution where the first command is a subshell, use compact `|` separator instead of ` | `
- MRE: `<((a)|b)` was formatted as `<(( a ) | b)` but should be `<((a)|b)`
- Also passes `in_procsub` flag through pipeline formatting to recursive calls

## Test plan
- [x] New test added to `tests/parable/fuzz-11573.tests`
- [x] `just check` passes