### PR TITLE
fuzzer fix: skip command substitutions when finding param expansion close brace

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1453,11 +1453,23 @@ class Word extends Node {
 						in_single = !in_single;
 					} else if (c === '"' && !in_single) {
 						in_double = !in_double;
-					} else if (!in_single && !in_double) {
-						if (c === "{") {
-							depth += 1;
-						} else if (c === "}") {
-							depth -= 1;
+					} else if (!in_single) {
+						// Skip over $(...) command substitution (} inside is not closing brace)
+						if (
+							c === "$" &&
+							j + 1 < value.length &&
+							value[j + 1] === "(" &&
+							!(j + 2 < value.length && value[j + 2] === "(")
+						) {
+							j = _findCmdsubEnd(value, j + 2);
+							continue;
+						}
+						if (!in_double) {
+							if (c === "{") {
+								depth += 1;
+							} else if (c === "}") {
+								depth -= 1;
+							}
 						}
 					}
 					j += 1;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1167,11 +1167,21 @@ class Word(Node):
                         in_single = not in_single
                     elif c == '"' and not in_single:
                         in_double = not in_double
-                    elif not in_single and not in_double:
-                        if c == "{":
-                            depth += 1
-                        elif c == "}":
-                            depth -= 1
+                    elif not in_single:
+                        # Skip over $(...) command substitution (} inside is not closing brace)
+                        if (
+                            c == "$"
+                            and j + 1 < len(value)
+                            and value[j + 1] == "("
+                            and not (j + 2 < len(value) and value[j + 2] == "(")
+                        ):
+                            j = _find_cmdsub_end(value, j + 2)
+                            continue
+                        if not in_double:
+                            if c == "{":
+                                depth += 1
+                            elif c == "}":
+                                depth -= 1
                     j += 1
                 # Recursively format any cmdsubs inside the param expansion
                 inner = _substring(value, i + 2, j - 1)

--- a/tests/parable/fuzz-17377.tests
+++ b/tests/parable/fuzz-17377.tests
@@ -1,0 +1,5 @@
+=== closing brace inside command substitution within parameter expansion
+${a-$(}a)}
+---
+(command (word "${a-$(}a)}"))
+---


### PR DESCRIPTION
## Summary
- When `_format_command_substitutions` processes `${...}` parameter expansions, it needs to find the matching `}`. The loop was not accounting for `$(...)` command substitutions, so a `}` inside a command substitution would incorrectly be treated as closing the parameter expansion.
- MRE: `${a-$(}a)}` was formatted as `${a-$()}a)}` instead of `${a-$(}a)}`

## Test plan
- [x] New test added to `tests/parable/fuzz-17377.tests`
- [x] `just check` passes