### PR TITLE
fuzzer fix: handle quotes in arithmetic command parsing

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8115,7 +8115,34 @@ class Parser {
 		depth = 1;
 		while (!this.atEnd() && depth > 0) {
 			c = this.peek();
-			if (c === "(") {
+			// Skip single-quoted strings (parens inside don't count)
+			if (c === "'") {
+				this.advance();
+				while (!this.atEnd() && this.peek() !== "'") {
+					this.advance();
+				}
+				if (!this.atEnd()) {
+					this.advance();
+				}
+			} else if (c === '"') {
+				// Skip double-quoted strings (parens inside don't count)
+				this.advance();
+				while (!this.atEnd()) {
+					if (this.peek() === "\\" && this.pos + 1 < this.length) {
+						this.advance();
+						this.advance();
+					} else if (this.peek() === '"') {
+						this.advance();
+						break;
+					} else {
+						this.advance();
+					}
+				}
+			} else if (c === "\\" && this.pos + 1 < this.length) {
+				// Handle backslash escapes outside quotes
+				this.advance();
+				this.advance();
+			} else if (c === "(") {
 				depth += 1;
 				this.advance();
 			} else if (c === ")") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -6826,8 +6826,30 @@ class Parser:
 
         while not self.at_end() and depth > 0:
             c = self.peek()
-
-            if c == "(":
+            # Skip single-quoted strings (parens inside don't count)
+            if c == "'":
+                self.advance()
+                while not self.at_end() and self.peek() != "'":
+                    self.advance()
+                if not self.at_end():
+                    self.advance()  # consume closing '
+            # Skip double-quoted strings (parens inside don't count)
+            elif c == '"':
+                self.advance()
+                while not self.at_end():
+                    if self.peek() == "\\" and self.pos + 1 < self.length:
+                        self.advance()
+                        self.advance()
+                    elif self.peek() == '"':
+                        self.advance()
+                        break
+                    else:
+                        self.advance()
+            # Handle backslash escapes outside quotes
+            elif c == "\\" and self.pos + 1 < self.length:
+                self.advance()
+                self.advance()
+            elif c == "(":
                 depth += 1
                 self.advance()
             elif c == ")":

--- a/tests/parable/fuzz-32627.tests
+++ b/tests/parable/fuzz-32627.tests
@@ -1,0 +1,5 @@
+=== arithmetic with quoted process substitution start
+(( '<(' ))
+---
+(arith (word " '<(' "))
+---


### PR DESCRIPTION
## Summary
- Fix: arithmetic commands like `(( '<(' ))` were incorrectly parsed as nested subshells
- Root cause: `parse_arithmetic_command` didn't skip over quoted strings when scanning for closing `))`, so `(` inside quotes was counted as a nested paren
- MRE: `(( '<(' ))` - expected `(arith ...)`, got `(subshell (subshell ...))`

## Test plan
- [x] New test added to `tests/parable/fuzz-32627.tests`
- [x] `just check` passes