### PR TITLE
fuzzer fix: ! followed by process substitution should be a word

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4372,6 +4372,18 @@ class Parser {
 		return ch;
 	}
 
+	_isBangFollowedByProcsub() {
+		let next_char;
+		if (this.pos + 2 >= this.length) {
+			return false;
+		}
+		next_char = this.source[this.pos + 1];
+		if (next_char !== ">" && next_char !== "<") {
+			return false;
+		}
+		return this.source[this.pos + 2] === "(";
+	}
+
 	skipWhitespace() {
 		let ch;
 		while (!this.atEnd()) {
@@ -10376,8 +10388,9 @@ class Parser {
 			// Check for ! after time
 			if (!this.atEnd() && this.peek() === "!") {
 				if (
-					this.pos + 1 >= this.length ||
-					_isNegationBoundary(this.source[this.pos + 1])
+					(this.pos + 1 >= this.length ||
+						_isNegationBoundary(this.source[this.pos + 1])) &&
+					!this._isBangFollowedByProcsub()
 				) {
 					this.advance();
 					prefix_order = "time_negation";
@@ -10387,8 +10400,9 @@ class Parser {
 		} else if (!this.atEnd() && this.peek() === "!") {
 			// Check for '!' negation prefix (if no time yet)
 			if (
-				this.pos + 1 >= this.length ||
-				_isNegationBoundary(this.source[this.pos + 1])
+				(this.pos + 1 >= this.length ||
+					_isNegationBoundary(this.source[this.pos + 1])) &&
+				!this._isBangFollowedByProcsub()
 			) {
 				this.advance();
 				this.skipWhitespace();

--- a/src/parable.py
+++ b/src/parable.py
@@ -3733,6 +3733,15 @@ class Parser:
         self.pos += 1
         return ch
 
+    def _is_bang_followed_by_procsub(self) -> bool:
+        """Check if ! at current position is followed by >( or <( process substitution."""
+        if self.pos + 2 >= self.length:
+            return False
+        next_char = self.source[self.pos + 1]
+        if next_char != ">" and next_char != "<":
+            return False
+        return self.source[self.pos + 2] == "("
+
     def skip_whitespace(self) -> None:
         """Skip spaces, tabs, comments, and backslash-newline continuations."""
         while not self.at_end():
@@ -8718,14 +8727,18 @@ class Parser:
             self.skip_whitespace()
             # Check for ! after time
             if not self.at_end() and self.peek() == "!":
-                if self.pos + 1 >= self.length or _is_negation_boundary(self.source[self.pos + 1]):
+                if (
+                    self.pos + 1 >= self.length or _is_negation_boundary(self.source[self.pos + 1])
+                ) and not self._is_bang_followed_by_procsub():
                     self.advance()
                     prefix_order = "time_negation"
                     self.skip_whitespace()
 
         # Check for '!' negation prefix (if no time yet)
         elif not self.at_end() and self.peek() == "!":
-            if self.pos + 1 >= self.length or _is_negation_boundary(self.source[self.pos + 1]):
+            if (
+                self.pos + 1 >= self.length or _is_negation_boundary(self.source[self.pos + 1])
+            ) and not self._is_bang_followed_by_procsub():
                 self.advance()
                 self.skip_whitespace()
                 # Recursively parse pipeline to handle ! ! cmd, ! time cmd, etc.

--- a/tests/parable/fuzz-31206.tests
+++ b/tests/parable/fuzz-31206.tests
@@ -1,0 +1,6 @@
+=== exclamation in process substitution with line continuation
+!>($(a\
+))
+---
+(command (word "!>($(a))"))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `!>(...)` and `!<(...)` which were incorrectly treated as negation
- MRE: `!>($(a\<newline>))` was parsed as `(negation (command ...))` instead of `(command (word "!>($(a))"))`
- Added `_is_bang_followed_by_procsub()` helper to detect when `!` is followed by `>( or <(` process substitution