### PR TITLE
fuzzer fix: strip line continuations from failed process substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5610,6 +5610,8 @@ class Parser {
 		content = this.source.slice(content_start, this.pos);
 		this.advance();
 		text = this.source.slice(start, this.pos);
+		// Strip line continuations (backslash-newline) from text used for word construction
+		text = text.replaceAll("\\\n", "");
 		// Parse the content as a command list
 		sub_parser = new Parser(content);
 		cmd = sub_parser.parseList();

--- a/src/parable.py
+++ b/src/parable.py
@@ -4753,6 +4753,8 @@ class Parser:
         self.advance()  # consume final )
 
         text = _substring(self.source, start, self.pos)
+        # Strip line continuations (backslash-newline) from text used for word construction
+        text = text.replace("\\\n", "")
 
         # Parse the content as a command list
         sub_parser = Parser(content)

--- a/tests/parable/fuzz-8849.tests
+++ b/tests/parable/fuzz-8849.tests
@@ -1,0 +1,6 @@
+=== backslash-newline in nested parens
+$>((1\
+)2)
+---
+(command (word "$>((1)2)"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where backslash-newline (line continuation) was preserved when process substitution parsing fails
- MRE: `$>((1\<newline>)2)` was producing `$>((1\<newline>)2)` instead of `$>((1)2)`
- Fix: Strip `\<newline>` from the text returned by `_parse_process_substitution`

- [x] New test added to `tests/parable/fuzz-8849.tests`
- [x] `just check` passes