### PR TITLE
fuzzer fix: backslash-newline in heredoc delimiter

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3861,13 +3861,16 @@ function _skipHeredoc(value, start) {
 	let delim_start,
 		delimiter,
 		i,
+		j,
 		line,
 		line_end,
 		line_start,
+		next_line_start,
 		paren_depth,
 		quote_char,
 		stripped,
-		tabs_stripped;
+		tabs_stripped,
+		trailing_bs;
 	i = start + 2;
 	// Handle <<- (strip tabs)
 	if (i < value.length && value[i] === "-") {
@@ -3964,6 +3967,28 @@ function _skipHeredoc(value, start) {
 			line_end += 1;
 		}
 		line = value.slice(line_start, line_end);
+		// Handle backslash-newline continuation (join continued lines)
+		while (line_end < value.length) {
+			trailing_bs = 0;
+			for (j = line.length - 1; j > -1; j--) {
+				if (line[j] === "\\") {
+					trailing_bs += 1;
+				} else {
+					break;
+				}
+			}
+			if (trailing_bs % 2 === 0) {
+				break;
+			}
+			// Odd backslashes - line continuation
+			line = line.slice(0, -1);
+			line_end += 1;
+			next_line_start = line_end;
+			while (line_end < value.length && value[line_end] !== "\n") {
+				line_end += 1;
+			}
+			line = line + value.slice(next_line_start, line_end);
+		}
 		// Check if this line is the delimiter (possibly with leading tabs for <<-)
 		if (start + 2 < value.length && value[start + 2] === "-") {
 			stripped = line.replace(/^[\t]+/, "");

--- a/src/parable.py
+++ b/src/parable.py
@@ -3368,6 +3368,23 @@ def _skip_heredoc(value: str, start: int) -> int:
         while line_end < len(value) and value[line_end] != "\n":
             line_end += 1
         line = _substring(value, line_start, line_end)
+        # Handle backslash-newline continuation (join continued lines)
+        while line_end < len(value):
+            trailing_bs = 0
+            for j in range(len(line) - 1, -1, -1):
+                if line[j] == "\\":
+                    trailing_bs += 1
+                else:
+                    break
+            if trailing_bs % 2 == 0:
+                break  # Even backslashes (including 0) - no continuation
+            # Odd backslashes - line continuation
+            line = line[:-1]  # Remove trailing backslash
+            line_end += 1  # Skip newline
+            next_line_start = line_end
+            while line_end < len(value) and value[line_end] != "\n":
+                line_end += 1
+            line = line + _substring(value, next_line_start, line_end)
         # Check if this line is the delimiter (possibly with leading tabs for <<-)
         if start + 2 < len(value) and value[start + 2] == "-":
             stripped = line.lstrip("\t")

--- a/tests/parable/fuzz-13264.tests
+++ b/tests/parable/fuzz-13264.tests
@@ -1,0 +1,7 @@
+=== backslash-newline after heredoc delimiter in process substitution
+<(<<a
+a\
+)!
+---
+(command (word "<(<<a\na\n)!"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_skip_heredoc()` to handle backslash-newline continuation when scanning for the heredoc delimiter line
- MRE: `<(<<a\na\\\n)!` - the `!` after `)` was being dropped because the delimiter `a\` followed by newline wasn't recognized as matching `a`

## Test plan
- [x] New test added to `tests/parable/fuzz-13264.tests`
- [x] `just check` passes