### PR TITLE
fuzzer fix: handle brace characters in arithmetic expressions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6283,7 +6283,8 @@ class Parser {
 		}
 		// Check for end of expression or operators - bash allows missing operands
 		// (defers validation to runtime), so we return an empty node
-		if (this._arithAtEnd() || ")]:,?|&<>=!+-*/%^~".includes(c)) {
+		// Include {} which bash accepts syntactically but fails at runtime
+		if (this._arithAtEnd() || ")]:,?|&<>=!+-*/%^~{}".includes(c)) {
 			return new ArithEmpty();
 		}
 		// Number or variable

--- a/src/parable.py
+++ b/src/parable.py
@@ -5329,7 +5329,8 @@ class Parser:
 
         # Check for end of expression or operators - bash allows missing operands
         # (defers validation to runtime), so we return an empty node
-        if self._arith_at_end() or c in ")]:,?|&<>=!+-*/%^~":
+        # Include {} which bash accepts syntactically but fails at runtime
+        if self._arith_at_end() or c in ")]:,?|&<>=!+-*/%^~{}":
             return ArithEmpty()
 
         # Number or variable

--- a/tests/parable/fuzz-25833.tests
+++ b/tests/parable/fuzz-25833.tests
@@ -1,0 +1,5 @@
+=== arithmetic with brace and command substitution
+$((}a $()))
+---
+(command (word "$((}a $()))"))
+---


### PR DESCRIPTION
## Summary
- Add `{}` to characters that return ArithEmpty() in arithmetic parsing
- Fixes `$((}a $()))` being incorrectly parsed as command substitution instead of arithmetic expansion
- MRE: `$((}a $()))`

- [x] New test added to `tests/parable/fuzz-25833.tests`
- [x] `just check` passes