### PR TITLE
fuzzer fix: mid-word bracket should not preserve newlines in arrays

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -984,10 +984,13 @@ class Word extends Node {
 					i += 1;
 				}
 			} else if (ch === "[") {
-				// Start of subscript [...] - preserve whitespace inside
+				// Only start subscript tracking if at word start (for [key]=val patterns)
+				// Mid-word [ like a[ is literal, not a subscript
+				if (in_whitespace) {
+					bracket_depth += 1;
+				}
 				in_whitespace = false;
 				normalized.push(ch);
-				bracket_depth += 1;
 				i += 1;
 			} else if (ch === "]" && bracket_depth > 0) {
 				// End of subscript

--- a/src/parable.py
+++ b/src/parable.py
@@ -812,10 +812,12 @@ class Word(Node):
                 while i < len(inner) and inner[i] != "\n":
                     i += 1
             elif ch == "[":
-                # Start of subscript [...] - preserve whitespace inside
+                # Only start subscript tracking if at word start (for [key]=val patterns)
+                # Mid-word [ like a[ is literal, not a subscript
+                if in_whitespace:
+                    bracket_depth += 1
                 in_whitespace = False
                 normalized.append(ch)
-                bracket_depth += 1
                 i += 1
             elif ch == "]" and bracket_depth > 0:
                 # End of subscript

--- a/tests/parable/fuzz-760.tests
+++ b/tests/parable/fuzz-760.tests
@@ -1,0 +1,6 @@
+=== newline after bracket in array should be converted to space
+a=(a[
+b)
+---
+(command (word "a=(a[ b)"))
+---


### PR DESCRIPTION
## Summary
- Inside array assignments like `a=(a[\nb)`, a `[` mid-word should not start subscript tracking
- Only `[` at word start (for `[key]=val` patterns) should preserve whitespace inside brackets
- MRE: `a=(a[\nb)` - newline should be converted to space, not preserved