### PR TITLE
fuzzer fix: process substitution syntax inside $[] should not be special

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -1009,6 +1009,7 @@ class Word(Node):
         procsub_idx = 0
         in_double_quote = False
         extglob_depth = 0
+        deprecated_arith_depth = 0  # Track $[...] depth
         while i < len(value):
             # Check for extglob start: @( ?( *( +( !(
             if (
@@ -1024,6 +1025,17 @@ class Word(Node):
             # Track ) that closes extglob (but not inside cmdsub/procsub)
             if value[i] == ")" and extglob_depth > 0:
                 extglob_depth -= 1
+                result.append(value[i])
+                i += 1
+                continue
+            # Track deprecated arithmetic $[...] - inside it, >( and <( are not procsub
+            if _starts_with_at(value, i, "$[") and not _is_backslash_escaped(value, i):
+                deprecated_arith_depth += 1
+                result.append(value[i])
+                i += 1
+                continue
+            if value[i] == "]" and deprecated_arith_depth > 0:
+                deprecated_arith_depth -= 1
                 result.append(value[i])
                 i += 1
                 continue
@@ -1079,10 +1091,12 @@ class Word(Node):
                 result.append(_substring(value, i, j))
                 cmdsub_idx += 1
                 i = j
-            # Check for >( or <( process substitution (not inside double quotes)
+            # Check for >( or <( process substitution (not inside double quotes or $[...])
             elif (
-                _starts_with_at(value, i, ">(") or _starts_with_at(value, i, "<(")
-            ) and not in_double_quote:
+                (_starts_with_at(value, i, ">(") or _starts_with_at(value, i, "<("))
+                and not in_double_quote
+                and deprecated_arith_depth == 0
+            ):
                 # Check if this is actually a process substitution or just comparison + parens
                 # Process substitution: not preceded by alphanumeric
                 is_procsub = i == 0 or not value[i - 1].isalnum()

--- a/tests/parable/fuzz-26709.tests
+++ b/tests/parable/fuzz-26709.tests
@@ -1,0 +1,5 @@
+=== process substitution syntax inside $[] arithmetic should not be special
+$[>(]
+---
+(command (word "$[>(]"))
+---


### PR DESCRIPTION
## Summary
- Inside deprecated arithmetic `$[...]`, `>(` and `<(` should be treated as literal characters, not process substitution
- MRE: `$[>(]` was being output as `$[>()]` instead of `$[>(]`
- Fix tracks `$[...]` depth in `_format_command_substitutions` and skips process substitution handling when inside

## Test plan
- [x] New test added to `tests/parable/fuzz-26709.tests`
- [x] `just check` passes