### PR TITLE
Fix arithmetic parsing of # after operators

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6341,8 +6341,8 @@ class Parser {
 		}
 		// Check for end of expression or operators - bash allows missing operands
 		// (defers validation to runtime), so we return an empty node
-		// Include {} which bash accepts syntactically but fails at runtime
-		if (this._arithAtEnd() || ")]:,?|&<>=!+-*/%^~{}".includes(c)) {
+		// Include #{} which bash accepts syntactically but fails at runtime
+		if (this._arithAtEnd() || ")]:,?|&<>=!+-*/%^~#{}".includes(c)) {
 			return new ArithEmpty();
 		}
 		// Number or variable

--- a/src/parable.py
+++ b/src/parable.py
@@ -5373,8 +5373,8 @@ class Parser:
 
         # Check for end of expression or operators - bash allows missing operands
         # (defers validation to runtime), so we return an empty node
-        # Include {} which bash accepts syntactically but fails at runtime
-        if self._arith_at_end() or c in ")]:,?|&<>=!+-*/%^~{}":
+        # Include #{} which bash accepts syntactically but fails at runtime
+        if self._arith_at_end() or c in ")]:,?|&<>=!+-*/%^~#{}":
             return ArithEmpty()
 
         # Number or variable

--- a/tests/parable/fuzz-25950.tests
+++ b/tests/parable/fuzz-25950.tests
@@ -1,0 +1,5 @@
+=== arithmetic with cmdsub followed by operator and hash
+$(($(a)+#))
+---
+(command (word "$(($(a)+#))"))
+---


### PR DESCRIPTION
## Summary
- When `#` appears after an operator (like `+#` or `-#`) in arithmetic, treat it as an empty operand
- This matches bash-oracle's behavior which defers validation to runtime
- Previously, `$(($(a)+#))` would incorrectly fall back to command substitution parsing

MRE: `$(($(a)+#))`