### PR TITLE
fuzzer fix: handle quotes in backtick command substitution in heredoc delimiter

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7865,6 +7865,51 @@ class Parser {
 					}
 					delimiter_chars.push(this.advance());
 				}
+			} else if (ch === "`") {
+				// Backtick command substitution embedded in delimiter
+				// Note: In bash, backtick closes command sub even with unclosed quotes inside
+				delimiter_chars.push(this.advance());
+				while (!this.atEnd() && this.peek() !== "`") {
+					c = this.peek();
+					if (c === "'") {
+						// Single-quoted string inside backtick - skip to closing quote or `
+						delimiter_chars.push(this.advance());
+						while (
+							!this.atEnd() &&
+							this.peek() !== "'" &&
+							this.peek() !== "`"
+						) {
+							delimiter_chars.push(this.advance());
+						}
+						if (!this.atEnd() && this.peek() === "'") {
+							delimiter_chars.push(this.advance());
+						}
+					} else if (c === '"') {
+						// Double-quoted string inside backtick - skip to closing quote or `
+						delimiter_chars.push(this.advance());
+						while (
+							!this.atEnd() &&
+							this.peek() !== '"' &&
+							this.peek() !== "`"
+						) {
+							if (this.peek() === "\\" && this.pos + 1 < this.length) {
+								delimiter_chars.push(this.advance());
+							}
+							delimiter_chars.push(this.advance());
+						}
+						if (!this.atEnd() && this.peek() === '"') {
+							delimiter_chars.push(this.advance());
+						}
+					} else if (c === "\\" && this.pos + 1 < this.length) {
+						delimiter_chars.push(this.advance());
+						delimiter_chars.push(this.advance());
+					} else {
+						delimiter_chars.push(this.advance());
+					}
+				}
+				if (!this.atEnd()) {
+					delimiter_chars.push(this.advance());
+				}
 			} else {
 				delimiter_chars.push(this.advance());
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -6604,6 +6604,35 @@ class Parser:
                     elif c == "}":
                         depth -= 1
                     delimiter_chars.append(self.advance())
+            elif ch == "`":
+                # Backtick command substitution embedded in delimiter
+                # Note: In bash, backtick closes command sub even with unclosed quotes inside
+                delimiter_chars.append(self.advance())  # `
+                while not self.at_end() and self.peek() != "`":
+                    c = self.peek()
+                    if c == "'":
+                        # Single-quoted string inside backtick - skip to closing quote or `
+                        delimiter_chars.append(self.advance())  # '
+                        while not self.at_end() and self.peek() != "'" and self.peek() != "`":
+                            delimiter_chars.append(self.advance())
+                        if not self.at_end() and self.peek() == "'":
+                            delimiter_chars.append(self.advance())  # closing '
+                    elif c == '"':
+                        # Double-quoted string inside backtick - skip to closing quote or `
+                        delimiter_chars.append(self.advance())  # "
+                        while not self.at_end() and self.peek() != '"' and self.peek() != "`":
+                            if self.peek() == "\\" and self.pos + 1 < self.length:
+                                delimiter_chars.append(self.advance())  # backslash
+                            delimiter_chars.append(self.advance())
+                        if not self.at_end() and self.peek() == '"':
+                            delimiter_chars.append(self.advance())  # closing "
+                    elif c == "\\" and self.pos + 1 < self.length:
+                        delimiter_chars.append(self.advance())  # backslash
+                        delimiter_chars.append(self.advance())  # escaped char
+                    else:
+                        delimiter_chars.append(self.advance())
+                if not self.at_end():
+                    delimiter_chars.append(self.advance())  # closing `
             else:
                 delimiter_chars.append(self.advance())
 

--- a/tests/parable/fuzz-16513.tests
+++ b/tests/parable/fuzz-16513.tests
@@ -1,0 +1,9 @@
+=== heredoc with quote in backtick command substitution
+: <<`'
+`
+
+
+---
+(command (word ":") (redirect "<<" "
+"))
+---


### PR DESCRIPTION
## Summary
- Fixed heredoc delimiter parsing to properly handle backtick command substitution containing quotes
- When a quote appears inside a backtick command sub, the closing backtick now terminates the command sub even if the quote is unclosed (matching bash behavior)
- MRE: `: <<`'\n`\n\n`

## Test plan
- [x] New test added to `tests/parable/fuzz-16513.tests`
- [x] `just check` passes