### PR TITLE
fuzzer fix: preserve raw process substitutions inside extglobs

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1358,6 +1358,16 @@ class Word extends Node {
 				// Check if this is actually a process substitution or just comparison + parens
 				// Process substitution: not preceded by alphanumeric
 				is_procsub = i === 0 || !/^[a-zA-Z0-9]$/.test(value[i - 1]);
+				// Inside extglob: don't format, just copy raw content
+				if (extglob_depth > 0) {
+					j = _findCmdsubEnd(value, i + 2);
+					result.push(value.slice(i, j));
+					if (procsub_idx < procsub_parts.length) {
+						procsub_idx += 1;
+					}
+					i = j;
+					continue;
+				}
 				if (procsub_idx < procsub_parts.length) {
 					// Have parsed AST node - use it
 					direction = value[i];

--- a/src/parable.py
+++ b/src/parable.py
@@ -1086,6 +1086,14 @@ class Word(Node):
                 # Check if this is actually a process substitution or just comparison + parens
                 # Process substitution: not preceded by alphanumeric
                 is_procsub = i == 0 or not value[i - 1].isalnum()
+                # Inside extglob: don't format, just copy raw content
+                if extglob_depth > 0:
+                    j = _find_cmdsub_end(value, i + 2)
+                    result.append(_substring(value, i, j))
+                    if procsub_idx < len(procsub_parts):
+                        procsub_idx += 1
+                    i = j
+                    continue
                 if procsub_idx < len(procsub_parts):
                     # Have parsed AST node - use it
                     direction = value[i]

--- a/tests/parable/fuzz-24370.tests
+++ b/tests/parable/fuzz-24370.tests
@@ -1,0 +1,5 @@
+=== extglob with process substitution containing redirect
+*(<(<a))
+---
+(command (word "*(<(<a))"))
+---


### PR DESCRIPTION
## Summary
- Process substitutions `<()` and `>()` inside extglob patterns like `*(<(<a))` were incorrectly formatted
- The redirect inside was getting a space added (`< a` instead of `<a`)
- Added same `extglob_depth > 0` check that already exists for command substitutions

MRE: `*(<(<a))`
- Before: `(command (word "*(<(< a))"))`
- After: `(command (word "*(<(<a))"))`