### PR TITLE
fuzzer fix: handle braces inside subscript in variable fd parsing

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7530,6 +7530,7 @@ class Parser {
 			fd,
 			fd_chars,
 			fd_target,
+			in_bracket,
 			inner_word,
 			is_valid_varfd,
 			left,
@@ -7556,18 +7557,20 @@ class Parser {
 			saved = this.pos;
 			this.advance();
 			varname_chars = [];
-			while (
-				!this.atEnd() &&
-				this.peek() !== "}" &&
-				!_isRedirectChar(this.peek())
-			) {
+			in_bracket = false;
+			while (!this.atEnd() && !_isRedirectChar(this.peek())) {
 				ch = this.peek();
-				if (
-					/^[a-zA-Z0-9]$/.test(ch) ||
-					ch === "_" ||
-					ch === "[" ||
-					ch === "]"
-				) {
+				if (ch === "}" && !in_bracket) {
+					break;
+				} else if (ch === "[") {
+					in_bracket = true;
+					varname_chars.push(this.advance());
+				} else if (ch === "]") {
+					in_bracket = false;
+					varname_chars.push(this.advance());
+				} else if (/^[a-zA-Z0-9]$/.test(ch) || ch === "_") {
+					varname_chars.push(this.advance());
+				} else if (in_bracket) {
 					varname_chars.push(this.advance());
 				} else {
 					break;

--- a/src/parable.py
+++ b/src/parable.py
@@ -6386,9 +6386,20 @@ class Parser:
             saved = self.pos
             self.advance()  # consume {
             varname_chars = []
-            while not self.at_end() and (self.peek() != "}" and not _is_redirect_char(self.peek())):
+            in_bracket = False
+            while not self.at_end() and not _is_redirect_char(self.peek()):
                 ch = self.peek()
-                if ch.isalnum() or (ch == "_" or ch == "[" or ch == "]"):
+                if ch == "}" and not in_bracket:
+                    break
+                elif ch == "[":
+                    in_bracket = True
+                    varname_chars.append(self.advance())
+                elif ch == "]":
+                    in_bracket = False
+                    varname_chars.append(self.advance())
+                elif ch.isalnum() or ch == "_":
+                    varname_chars.append(self.advance())
+                elif in_bracket:
                     varname_chars.append(self.advance())
                 else:
                     break

--- a/tests/parable/fuzz-11599.tests
+++ b/tests/parable/fuzz-11599.tests
@@ -1,0 +1,5 @@
+=== brace inside subscript in variable fd
+{a[{]}>y
+---
+(command (redirect ">" "y"))
+---


### PR DESCRIPTION
## Summary
- When parsing `{varname[subscript]}>file` patterns, braces (`{` and `}`) inside the subscript were incorrectly breaking the parse loop
- MRE: `{a[{]}>y` - oracle returns `(command (redirect ">" "y"))` but parable was returning `(command (word "{a[{]}") (redirect ">" "y"))`
- Fix: Track bracket depth and allow any character (including braces) when inside `[...]`

## Test plan
- [x] New test added to `tests/parable/fuzz-11599.tests`
- [x] `just check` passes