### PR TITLE
fuzzer fix: equals-prefixed words should not enable array bracket tracking

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5466,6 +5466,13 @@ class Parser {
 
 	_isAssignmentWord(word) {
 		let bracket_depth, ch, i, in_double, in_single;
+		// Assignment must start with identifier (letter or underscore), not quoted
+		if (
+			!word.value ||
+			!(/^[a-zA-Z]$/.test(word.value[0]) || word.value[0] === "_")
+		) {
+			return false;
+		}
 		in_single = false;
 		in_double = false;
 		bracket_depth = 0;

--- a/src/parable.py
+++ b/src/parable.py
@@ -4623,7 +4623,10 @@ class Parser:
         return _is_word_start_context(prev)
 
     def _is_assignment_word(self, word: "Word") -> bool:
-        """Check if a word is an assignment (contains = outside of quotes and brackets)."""
+        """Check if a word is an assignment (name=value) where name is a valid identifier."""
+        # Assignment must start with identifier (letter or underscore), not quoted
+        if not word.value or not (word.value[0].isalpha() or word.value[0] == "_"):
+            return False
         in_single = False
         in_double = False
         bracket_depth = 0

--- a/tests/parable/fuzz-14056.tests
+++ b/tests/parable/fuzz-14056.tests
@@ -1,0 +1,7 @@
+=== bracket after space following equals-prefixed word should not preserve newlines
+= b[
+c
+---
+(command (word "=") (word "b["))
+(command (word "c"))
+---


### PR DESCRIPTION
## Summary
- Words starting with `=` (like `=` or `=value`) were incorrectly treated as assignment words, causing `_is_assignment_word` to return True for them
- This caused subsequent words with brackets to be parsed with `at_command_start=True`, enabling array bracket tracking that incorrectly preserved newlines
- MRE: `= b[\nc` was parsed as one command `(command (word "=") (word "b[\nc"))` instead of two commands

## Test plan
- [x] New test added to `tests/parable/fuzz-14056.tests`
- [x] `just check` passes