### PR TITLE
fuzzer fix: strip backslash-newline inside extglobs

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4987,9 +4987,18 @@ class Parser {
 						chars.push(this.advance());
 						extglob_depth += 1;
 					} else if (c === "\\") {
-						chars.push(this.advance());
-						if (!this.atEnd()) {
+						if (
+							this.pos + 1 < this.length &&
+							this.source[this.pos + 1] === "\n"
+						) {
+							// Backslash-newline is line continuation - skip both
+							this.advance();
+							this.advance();
+						} else {
 							chars.push(this.advance());
+							if (!this.atEnd()) {
+								chars.push(this.advance());
+							}
 						}
 					} else if (c === "'") {
 						chars.push(this.advance());

--- a/src/parable.py
+++ b/src/parable.py
@@ -4226,9 +4226,14 @@ class Parser:
                         chars.append(self.advance())
                         extglob_depth += 1
                     elif c == "\\":
-                        chars.append(self.advance())
-                        if not self.at_end():
+                        if self.pos + 1 < self.length and self.source[self.pos + 1] == "\n":
+                            # Backslash-newline is line continuation - skip both
+                            self.advance()  # backslash
+                            self.advance()  # newline
+                        else:
                             chars.append(self.advance())
+                            if not self.at_end():
+                                chars.append(self.advance())
                     elif c == "'":
                         chars.append(self.advance())
                         while not self.at_end() and self.peek() != "'":

--- a/tests/parable/fuzz-8341.tests
+++ b/tests/parable/fuzz-8341.tests
@@ -1,0 +1,5 @@
+=== backslash-newline inside extglob should be stripped
+<*(\
+)
+---
+(command (redirect "<" "*()"))


### PR DESCRIPTION
## Summary
- Backslash-newline (line continuation) inside extglob patterns like `*()` was being preserved instead of stripped
- MRE: `<*(\<backslash><newline>)` was parsed as `<*(\<newline>)` instead of `<*()`
- Fixed by checking for newline after backslash and skipping both characters in extglob parsing

## Test plan
- [x] New test added to `tests/parable/fuzz-8341.tests`
- [x] `just check` passes