### PR TITLE
fuzzer fix: handle ANSI-C quoting $'...' in heredoc delimiters

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7854,6 +7854,8 @@ class Parser {
 			delimiter,
 			delimiter_chars,
 			depth,
+			esc,
+			esc_val,
 			heredoc_end,
 			i,
 			line,
@@ -7900,6 +7902,38 @@ class Parser {
 						quoted = true;
 						delimiter_chars.push(this.advance());
 					}
+				}
+			} else if (
+				ch === "$" &&
+				this.pos + 1 < this.length &&
+				this.source[this.pos + 1] === "'"
+			) {
+				// ANSI-C quoting $'...' - skip $ and quotes, expand escapes
+				quoted = true;
+				this.advance();
+				this.advance();
+				while (!this.atEnd() && this.peek() !== "'") {
+					c = this.peek();
+					if (c === "\\" && this.pos + 1 < this.length) {
+						this.advance();
+						esc = this.peek();
+						// Handle ANSI-C escapes using the lookup table
+						esc_val = _getAnsiEscape(esc);
+						if (esc_val >= 0) {
+							delimiter_chars.push(String.fromCodePoint(esc_val));
+							this.advance();
+						} else if (esc === "'") {
+							delimiter_chars.push(this.advance());
+						} else {
+							// Other escapes - just use the escaped char
+							delimiter_chars.push(this.advance());
+						}
+					} else {
+						delimiter_chars.push(this.advance());
+					}
+				}
+				if (!this.atEnd()) {
+					this.advance();
 				}
 			} else if (
 				ch === "$" &&

--- a/tests/parable/fuzz-23015.tests
+++ b/tests/parable/fuzz-23015.tests
@@ -1,0 +1,8 @@
+=== heredoc with ANSI-C quoted delimiter $'...'
+<<$'E'
+a
+E
+---
+(command (redirect "<<" "a
+"))
+---


### PR DESCRIPTION
## Summary
- Heredoc delimiters using `$'...'` ANSI-C quoting (e.g., `<<$'EOF'`) were not being parsed correctly
- Parable was treating `$'E'` as delimiter `$E` instead of just `E`
- Added handling for ANSI-C quoting in the heredoc delimiter parsing code, including escape sequence expansion
- MRE: `<<$'E'\na\nE`

## Test plan
- [x] New test added to `tests/parable/fuzz-23015.tests`
- [x] `just check` passes