### PR TITLE
fuzzer fix: strip line continuations in extglob patterns

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5131,9 +5131,18 @@ class Parser {
 						chars.push(this.advance());
 						extglob_depth += 1;
 					} else if (c === "\\") {
-						chars.push(this.advance());
-						if (!this.atEnd()) {
+						// Skip line continuation (backslash-newline)
+						if (
+							this.pos + 1 < this.length &&
+							this.source[this.pos + 1] === "\n"
+						) {
+							this.advance();
+							this.advance();
+						} else {
 							chars.push(this.advance());
+							if (!this.atEnd()) {
+								chars.push(this.advance());
+							}
 						}
 					} else if (c === "'") {
 						chars.push(this.advance());

--- a/src/parable.py
+++ b/src/parable.py
@@ -4346,9 +4346,14 @@ class Parser:
                         chars.append(self.advance())
                         extglob_depth += 1
                     elif c == "\\":
-                        chars.append(self.advance())
-                        if not self.at_end():
+                        # Skip line continuation (backslash-newline)
+                        if self.pos + 1 < self.length and self.source[self.pos + 1] == "\n":
+                            self.advance()  # skip backslash
+                            self.advance()  # skip newline
+                        else:
                             chars.append(self.advance())
+                            if not self.at_end():
+                                chars.append(self.advance())
                     elif c == "'":
                         chars.append(self.advance())
                         while not self.at_end() and self.peek() != "'":

--- a/tests/parable/fuzz-17460.tests
+++ b/tests/parable/fuzz-17460.tests
@@ -1,0 +1,6 @@
+=== line continuation in double-paren glob pattern
+*((\
+))
+---
+(command (word "*(())"))
+---


### PR DESCRIPTION
## Summary
- Strip backslash-newline (line continuation) inside extglob patterns like `*(())`
- MRE: `*((\<newline>))` was parsed as `*((\<newline>))` instead of `*(())`

## Test plan
- [x] New test added to `tests/parable/fuzz-17460.tests`
- [x] `just check` passes