### PR TITLE
fuzzer fix: insert || and && before heredoc body in cmdsub formatting

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3181,6 +3181,7 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 		else_body,
 		first_nl,
 		formatted,
+		formatted_cmd,
 		h,
 		has_heredoc,
 		heredocs,
@@ -3395,6 +3396,16 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 					} else {
 						result.push(" &");
 					}
+				} else if (
+					result.length > 0 &&
+					result[result.length - 1].includes("<<") &&
+					result[result.length - 1].includes("\n")
+				) {
+					// For || and &&, insert before heredoc content like we do for &
+					last = result[result.length - 1];
+					first_nl = last.indexOf("\n");
+					result[result.length - 1] =
+						`${last.slice(0, first_nl)} ${p.op} ${last.slice(first_nl)}`;
 				} else {
 					result.push(` ${p.op}`);
 				}
@@ -3408,9 +3419,20 @@ function _formatCmdsubNode(node, indent, in_procsub, compact_redirects) {
 				) {
 					result.push(" ");
 				}
-				result.push(
-					_formatCmdsubNode(p, indent, in_procsub, compact_redirects),
+				formatted_cmd = _formatCmdsubNode(
+					p,
+					indent,
+					in_procsub,
+					compact_redirects,
 				);
+				// After heredoc with || or && inserted, add leading space to next command
+				if (result.length > 0) {
+					last = result[result.length - 1];
+					if (last.includes(" || \n") || last.includes(" && \n")) {
+						formatted_cmd = ` ${formatted_cmd}`;
+					}
+				}
+				result.push(formatted_cmd);
 			}
 		}
 		// Strip trailing ; or newline (but preserve heredoc's trailing newline)

--- a/tests/parable/fuzz-5941.tests
+++ b/tests/parable/fuzz-5941.tests
@@ -1,0 +1,7 @@
+=== heredoc with || after delimiter in command substitution
+$(<<E ||
+E
+c)
+---
+(command (word "$(<<E || \nE\n c)"))
+---


### PR DESCRIPTION
## Summary
- When formatting heredocs with `||` or `&&` in command substitutions, the operator was incorrectly placed after the heredoc body instead of after the delimiter line
- MRE: `$(<<E ||\nE\nc)` - the `||` should appear on the same line as `<<E`, not after the heredoc closes

## Test plan
- [x] New test added to `tests/parable/fuzz-5941.tests`
- [x] `just check` passes