### PR TITLE
fuzzer fix: skip whitespace before heredoc content in process substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4173,6 +4173,10 @@ function _findHeredocContentEnd(source, start, delimiters) {
 	}
 	pos = start;
 	for ([delimiter, strip_tabs] of delimiters) {
+		// Skip whitespace on the same line (e.g., tabs/spaces after closing paren)
+		while (pos < source.length && " \t".includes(source[pos])) {
+			pos += 1;
+		}
 		if (pos >= source.length || source[pos] !== "\n") {
 			break;
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -3540,6 +3540,9 @@ def _find_heredoc_content_end(source: str, start: int, delimiters: list[tuple[st
         return start
     pos = start
     for delimiter, strip_tabs in delimiters:
+        # Skip whitespace on the same line (e.g., tabs/spaces after closing paren)
+        while pos < len(source) and source[pos] in " \t":
+            pos += 1
         if pos >= len(source) or source[pos] != "\n":
             break
         pos += 1

--- a/tests/parable/fuzz-23554.tests
+++ b/tests/parable/fuzz-23554.tests
@@ -1,0 +1,7 @@
+=== heredoc in process substitution with whitespace before newline
+<(<<D)	
+x
+D
+---
+(command (word "<(<<D\nx\nD\n)"))
+---


### PR DESCRIPTION
## Summary
- When a process substitution with a heredoc has whitespace (tabs/spaces) between `)` and the newline, the heredoc content was being lost
- MRE: `<(<<D)\t\nx\nD` - expected the `x` to be part of heredoc content
- Fixed by skipping whitespace before checking for the newline in `_find_heredoc_content_end`