### PR TITLE
fuzzer fix: format process substitutions in redirect targets

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3671,6 +3671,8 @@ function _formatRedirect(r, compact, heredoc_op_only) {
 	target = r.target._expandAllAnsiCQuotes(target);
 	// Strip $ from locale strings $"..."
 	target = r.target._stripLocaleStringDollars(target);
+	// Format command/process substitutions
+	target = r.target._formatCommandSubstitutions(target);
 	// For fd duplication (target starts with &), handle normalization
 	if (target.startsWith("&")) {
 		// Normalize N<&- to N>&- (close always uses >)

--- a/src/parable.py
+++ b/src/parable.py
@@ -3150,6 +3150,8 @@ def _format_redirect(
     target = r.target._expand_all_ansi_c_quotes(target)
     # Strip $ from locale strings $"..."
     target = r.target._strip_locale_string_dollars(target)
+    # Format command/process substitutions
+    target = r.target._format_command_substitutions(target)
     # For fd duplication (target starts with &), handle normalization
     if target.startswith("&"):
         # Normalize N<&- to N>&- (close always uses >)

--- a/tests/parable/fuzz-17674.tests
+++ b/tests/parable/fuzz-17674.tests
@@ -1,0 +1,5 @@
+=== strip leading whitespace in process substitution used as redirect target
+$(><( a))
+---
+(command (word "$(> <(a))"))
+---


### PR DESCRIPTION
## Summary
- `_format_redirect` was missing a call to `_format_command_substitutions`, so process substitutions used as redirect targets inside command substitutions weren't being formatted properly
- MRE: `$(><( a))` was formatting as `$(> <( a))` instead of `$(> <(a))`

## Test plan
- [x] New test added to `tests/parable/fuzz-17674.tests`
- [x] `just check` passes