### PR TITLE
fuzzer fix: handle backslash-escaped metacharacters in peek_word

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4731,6 +4731,12 @@ class Parser {
 			) {
 				break;
 			}
+			// Handle backslash escaping next character (even metacharacters)
+			if (ch === "\\" && this.pos + 1 < this.length) {
+				chars.push(this.advance());
+				chars.push(this.advance());
+				continue;
+			}
 			chars.push(this.advance());
 		}
 		if (chars) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -4013,6 +4013,11 @@ class Parser:
             # Stop at backslash-newline (line continuation)
             if ch == "\\" and self.pos + 1 < self.length and self.source[self.pos + 1] == "\n":
                 break
+            # Handle backslash escaping next character (even metacharacters)
+            if ch == "\\" and self.pos + 1 < self.length:
+                chars.append(self.advance())  # backslash
+                chars.append(self.advance())  # escaped char
+                continue
             chars.append(self.advance())
 
         if chars:

--- a/tests/parable/fuzz-12600.tests
+++ b/tests/parable/fuzz-12600.tests
@@ -1,0 +1,5 @@
+=== backslash-escaped semicolon in for loop variable name
+for \; do :; done
+---
+(for (word "\\;") (in (word "\"$@\"")) (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- `peek_word` was not handling backslash escapes, causing `for \; do :; done` to parse `\` as the variable name instead of `\;`
- Added handling for backslash-escaped characters in `peek_word` so that when a backslash precedes a metacharacter, both are included in the word
- MRE: `for \; do :; done`