### PR TITLE
fuzzer fix: preserve subshell spacing in process substitutions

### DIFF
--- a/tests/parable/fuzz-5965.tests
+++ b/tests/parable/fuzz-5965.tests
@@ -1,0 +1,5 @@
+=== subshell spacing preserved in process substitution
+a<(b;( x ))
+---
+(command (word "a<(b; ( x ))"))
+---


### PR DESCRIPTION
## Summary
- When a subshell appears inside a process substitution but not at the start, preserve the spacing
- MRE: `a<(b;( x ))` was producing `a<(b; (x))` instead of `a<(b; ( x ))`
- Added `procsub_first` parameter to track when a subshell is at the start of procsub content

## Test plan
- [x] New test added to `tests/parable/fuzz-5965.tests`
- [x] `just check` passes