### PR TITLE
fuzzer fix: preserve leading whitespace before subshell in process substitution

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -1182,11 +1182,25 @@ class Word(Node):
                     formatted = _format_cmdsub_node(node.command, in_procsub=True)
                     if node.command.kind == "subshell":
                         raw_content = _substring(value, i + 2, j - 1)
-                        if raw_content.startswith("("):
-                            # Process substitution with nested subshell >((...)): preserve original
-                            # Strip line continuations (backslash-newline)
-                            raw_content = raw_content.replace("\\\n", "")
-                            result.append(direction + "(" + raw_content + ")")
+                        # Extract leading whitespace
+                        leading_ws_end = 0
+                        while (
+                            leading_ws_end < len(raw_content)
+                            and raw_content[leading_ws_end] in " \t\n"
+                        ):
+                            leading_ws_end += 1
+                        leading_ws = raw_content[:leading_ws_end]
+                        stripped = raw_content[leading_ws_end:]
+                        if stripped.startswith("("):
+                            if leading_ws:
+                                # Leading whitespace before subshell: normalize ws + format subshell with spaces
+                                normalized_ws = leading_ws.replace("\n", " ").replace("\t", " ")
+                                spaced = _format_cmdsub_node(node.command, in_procsub=False)
+                                result.append(direction + "(" + normalized_ws + spaced + ")")
+                            else:
+                                # No leading whitespace - preserve original raw content
+                                raw_content = raw_content.replace("\\\n", "")
+                                result.append(direction + "(" + raw_content + ")")
                             procsub_idx += 1
                             i = j
                             continue

--- a/tests/parable/fuzz-7335.tests
+++ b/tests/parable/fuzz-7335.tests
@@ -1,0 +1,5 @@
+=== process substitution with leading whitespace before subshell
+<( (a))
+---
+(command (word "<( ( a ))"))
+---


### PR DESCRIPTION
## Summary
- Fixed process substitution formatting when there's leading whitespace before a subshell
- MRE: `<( (a))` was incorrectly formatted as `<((a))` instead of `<( ( a ))`
- Leading whitespace is now preserved and newlines/tabs are normalized to spaces

## Test plan
- [x] New test added to `tests/parable/fuzz-7335.tests`
- [x] `just check` passes