### PR TITLE
fuzzer fix: skip comment content when finding heredoc line end

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8328,7 +8328,13 @@ class Parser {
 		line_end = this.pos;
 		while (line_end < this.length && this.source[line_end] !== "\n") {
 			ch = this.source[line_end];
-			if (ch === "'") {
+			if (ch === "#") {
+				// Comment - skip to end of line (don't parse quotes in comments)
+				while (line_end < this.length && this.source[line_end] !== "\n") {
+					line_end += 1;
+				}
+				break;
+			} else if (ch === "'") {
 				// Single-quoted string - skip to closing quote (no escapes)
 				line_end += 1;
 				while (line_end < this.length && this.source[line_end] !== "'") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -6960,7 +6960,12 @@ class Parser:
         line_end = self.pos
         while line_end < self.length and self.source[line_end] != "\n":
             ch = self.source[line_end]
-            if ch == "'":
+            if ch == "#":
+                # Comment - skip to end of line (don't parse quotes in comments)
+                while line_end < self.length and self.source[line_end] != "\n":
+                    line_end += 1
+                break
+            elif ch == "'":
                 # Single-quoted string - skip to closing quote (no escapes)
                 line_end += 1
                 while line_end < self.length and self.source[line_end] != "'":

--- a/tests/parable/character-fuzzer/fuzz-bd13f4630af020f6371a0cb2b3bdd9f7.tests
+++ b/tests/parable/character-fuzzer/fuzz-bd13f4630af020f6371a0cb2b3bdd9f7.tests
@@ -1,0 +1,7 @@
+=== heredoc with trailing single quote in comment
+x<< y #'
+z
+---
+(command (word "x") (redirect "<<" "z
+"))
+---


### PR DESCRIPTION
## Summary
- When scanning for the end of the command line after a heredoc delimiter, the parser was incorrectly trying to parse quotes inside comments
- A single quote in a comment (like `# can't`) would cause the parser to look for a closing quote, scanning past the end of line and missing the heredoc body
- MRE: `x<< y #'\nz` - Parable produced empty heredoc body instead of `z\n`