### PR TITLE
fuzzer fix: use compact redirect formatting when procsub starts with subshell (#162)

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-ff67b79a71186fc212bec9d6f60e20c0.tests
+++ b/tests/parable/character-fuzzer/fuzz-ff67b79a71186fc212bec9d6f60e20c0.tests
@@ -1,0 +1,6 @@
+=== preserve no space after redirect in process substitution
+<((0)
+>x)
+---
+(command (word "<((0)\n>x)"))
+---


### PR DESCRIPTION
## Summary
- When a process substitution starts with a subshell (e.g., `<((0)\n>x)`), redirects should use compact formatting (no space between operator and target)
- Added `_starts_with_subshell()` helper to detect this case
- MRE: `<((0)\n>x)` was being formatted as `<((0)\n> x)` but should be `<((0)\n>x)`