### PR TITLE
fuzzer fix: preserve tabs in double-quoted expansions inside array assignments (#162)

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-60e7bee1ddbc38e303ecc478afd38caa.tests
+++ b/tests/parable/character-fuzzer/fuzz-60e7bee1ddbc38e303ecc478afd38caa.tests
@@ -1,0 +1,5 @@
+=== tab in quoted array subscript inside array assignment
+a=("${b["	"]}")
+---
+(command (word "a=(\"${b[\"\t\"]}\")"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where tabs inside `${...}` expansions within double-quoted strings in array assignments were being normalized to spaces
- MRE: `a=("${b["\t"]}")` was producing `a=("${b[" "]}")` instead of preserving the tab
- The fix tracks `${...}` nesting depth in the double-quote handler within `_normalize_array_inner`, so that nested quotes inside expansions don't prematurely end the outer double-quoted string