### PR TITLE
fuzzer fix: don't parse extglob patterns as function definitions (#162)

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -10463,7 +10463,7 @@ class Parser {
 	}
 
 	parseFunction() {
-		let body, name, name_start, saved_pos;
+		let body, has_whitespace, name, name_start, pos_after_name, saved_pos;
 		this.skipWhitespace();
 		if (this.atEnd()) {
 			return null;
@@ -10527,7 +10527,15 @@ class Parser {
 			return null;
 		}
 		// Check for () - whitespace IS allowed between name and (
+		// But if name ends with extglob prefix (*?@+!) and () is adjacent,
+		// it's an extglob pattern, not a function definition
+		pos_after_name = this.pos;
 		this.skipWhitespace();
+		has_whitespace = this.pos > pos_after_name;
+		if (!has_whitespace && name && "*?@+!".includes(name[name.length - 1])) {
+			this.pos = saved_pos;
+			return null;
+		}
 		if (this.atEnd() || this.peek() !== "(") {
 			this.pos = saved_pos;
 			return null;

--- a/src/parable.py
+++ b/src/parable.py
@@ -8790,7 +8790,15 @@ class Parser:
             return None
 
         # Check for () - whitespace IS allowed between name and (
+        # But if name ends with extglob prefix (*?@+!) and () is adjacent,
+        # it's an extglob pattern, not a function definition
+        pos_after_name = self.pos
         self.skip_whitespace()
+        has_whitespace = self.pos > pos_after_name
+        if not has_whitespace and name and name[len(name) - 1] in "*?@+!":
+            self.pos = saved_pos
+            return None
+
         if self.at_end() or self.peek() != "(":
             self.pos = saved_pos
             return None

--- a/tests/parable/character-fuzzer/fuzz-8ab4db8e8e32c6f02d7044e7dcf8056e.tests
+++ b/tests/parable/character-fuzzer/fuzz-8ab4db8e8e32c6f02d7044e7dcf8056e.tests
@@ -1,0 +1,7 @@
+=== extglob pattern a*() not parsed as function
+a*()
+{ :; }
+---
+(command (word "a*()"))
+(brace-group (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- When a name ends with an extglob prefix character (`*?@+!`) and `()` is immediately adjacent (no whitespace), bash treats it as an extglob pattern, not a function definition
- MRE: `a*()\n{ :; }` - oracle parses as command `a*()` + brace-group, Parable was incorrectly parsing as function `a*`
- Fix: check for extglob prefix at end of name when no whitespace before `()`