### PR TITLE
fuzzer fix: handle heredoc in cmdsub with immediate closing paren

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5574,6 +5574,11 @@ class Parser {
 				}
 				delimiter = delimiter_chars.join("");
 				if (delimiter) {
+					// Check if ) immediately follows (closes cmdsub with empty heredoc)
+					if (!this.atEnd() && this.peek() === ")") {
+						// Heredoc has no content - will be resolved later
+						continue;
+					}
 					// Skip to end of current line
 					while (!this.atEnd() && this.peek() !== "\n") {
 						this.advance();

--- a/src/parable.py
+++ b/src/parable.py
@@ -4690,6 +4690,10 @@ class Parser:
                                 delimiter_chars.append(self.advance())
                 delimiter = "".join(delimiter_chars)
                 if delimiter:
+                    # Check if ) immediately follows (closes cmdsub with empty heredoc)
+                    if not self.at_end() and self.peek() == ")":
+                        # Heredoc has no content - will be resolved later
+                        continue
                     # Skip to end of current line
                     while not self.at_end() and self.peek() != "\n":
                         self.advance()

--- a/tests/parable/character-fuzzer/fuzz-18e4377b3994174f045532d4d2ce6bd6.tests
+++ b/tests/parable/character-fuzzer/fuzz-18e4377b3994174f045532d4d2ce6bd6.tests
@@ -1,0 +1,5 @@
+=== heredoc in command sub within double quotes followed by second command sub
+"$(<<a)$(x)"
+---
+(command (word "\"$(<<a\na\n)$(x)\""))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `$(<<DELIM)` where `)` immediately follows heredoc delimiter
- Parser was skipping past `)` looking for newline, causing MRE `"$(<<a)$(x)"` to incorrectly parse as `"$(x)$(x)"`
- Fix: check for immediate `)` after heredoc delimiter and let main loop close the cmdsub