### PR TITLE
fuzzer fix: detect invalid $((;)) as cmdsub in _find_cmdsub_end (#162)

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-fc0d20c4d4eb4723937167793b5516db.tests
+++ b/tests/parable/character-fuzzer/fuzz-fc0d20c4d4eb4723937167793b5516db.tests
@@ -1,0 +1,5 @@
+=== arithmetic with semicolon in nested command substitution
+$(($($((1);))+1))
+---
+(command (word "$(($($((1);))+1))"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_find_cmdsub_end` to detect when `$((` is not valid arithmetic (when there's `;` before `))` at top level)
- When invalid, treats `$(` as nested cmdsub instead of arithmetic start
- MRE: `$(($($((1);))+1))`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-fc0d20c4d4eb4723937167793b5516db.tests`
- [x] `just check` passes