### PR TITLE
fuzzer fix: && and || terminate regex even inside bracket expressions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9491,6 +9491,21 @@ class Parser {
 					if (sc === ")" && paren_depth > 0) {
 						break;
 					}
+					// Check for && or || - these terminate the regex even inside brackets
+					if (
+						sc === "&" &&
+						scan + 1 < this.length &&
+						this.source[scan + 1] === "&"
+					) {
+						break;
+					}
+					if (
+						sc === "|" &&
+						scan + 1 < this.length &&
+						this.source[scan + 1] === "|"
+					) {
+						break;
+					}
 					if (sc === "]") {
 						bracket_will_close = true;
 						break;

--- a/src/parable.py
+++ b/src/parable.py
@@ -7892,6 +7892,11 @@ class Parser:
                     # Check for ) when inside paren group
                     if sc == ")" and paren_depth > 0:
                         break  # Won't close before )
+                    # Check for && or || - these terminate the regex even inside brackets
+                    if sc == "&" and scan + 1 < self.length and self.source[scan + 1] == "&":
+                        break  # Won't close before &&
+                    if sc == "|" and scan + 1 < self.length and self.source[scan + 1] == "|":
+                        break  # Won't close before ||
                     if sc == "]":
                         bracket_will_close = True
                         break

--- a/tests/parable/character-fuzzer/fuzz-20c89c72dedc156287937f1886170b1f.tests
+++ b/tests/parable/character-fuzzer/fuzz-20c89c72dedc156287937f1886170b1f.tests
@@ -1,0 +1,5 @@
+=== && in unquoted regex pattern terminates the regex
+[[ x =~ [&&] ]]
+---
+(cond (cond-and (cond-binary "=~" (cond-term "x") (cond-term "[")) (cond-unary "-n" (cond-term "]"))))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `&&` and `||` inside unquoted regex bracket expressions in `[[ ]]` conditionals
- MRE: `[[ x =~ [&&] ]]` - bash interprets `&&` as logical AND even inside `[...]`, but Parable was treating it as part of the pattern
- Added lookahead checks for `&&` and `||` when scanning for bracket expression closure

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-20c89c72dedc156287937f1886170b1f.tests`
- [x] `just check` passes