### PR TITLE
fuzzer fix: allow redirect after opening brace in brace-group

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9721,11 +9721,12 @@ class Parser {
 		if (this.atEnd() || this.peek() !== "{") {
 			return null;
 		}
-		// Check that { is followed by whitespace or ( (it's a reserved word)
+		// Check that { is followed by whitespace or a valid command starter
 		// {( is valid: brace group containing a subshell
+		// {< and {> are valid: brace group starting with a redirect
 		if (this.pos + 1 < this.length) {
 			next_ch = this.source[this.pos + 1];
-			if (!_isWhitespace(next_ch) && next_ch !== "(") {
+			if (!_isWhitespace(next_ch) && !"(<>".includes(next_ch)) {
 				return null;
 			}
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -8062,11 +8062,12 @@ class Parser:
         if self.at_end() or self.peek() != "{":
             return None
 
-        # Check that { is followed by whitespace or ( (it's a reserved word)
+        # Check that { is followed by whitespace or a valid command starter
         # {( is valid: brace group containing a subshell
+        # {< and {> are valid: brace group starting with a redirect
         if self.pos + 1 < self.length:
             next_ch = self.source[self.pos + 1]
-            if not _is_whitespace(next_ch) and next_ch != "(":
+            if not _is_whitespace(next_ch) and next_ch not in "(<>":
                 return None
 
         self.advance()  # consume {

--- a/tests/parable/character-fuzzer/fuzz-168bb270210b669f9db46144243e0f79.tests
+++ b/tests/parable/character-fuzzer/fuzz-168bb270210b669f9db46144243e0f79.tests
@@ -1,0 +1,5 @@
+=== brace-group with redirect immediately after opening brace
+case x in a){<b;};& c)d;;esac
+---
+(case (word "x") (pattern ((word "a")) (brace-group (command (redirect "<" "b")))) (pattern ((word "c")) (command (word "d"))))
+---


### PR DESCRIPTION
## Summary
- Fix: Parable now recognizes `{<` and `{>` as starting a brace-group (not just `{(` and `{ `)
- MRE: `case x in a){<b;};& c)d;;esac` - the `{<b;}` should be parsed as a brace-group containing a redirect