### PR TITLE
fuzzer fix: handle escaped dollar before ANSI-C quoting

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -67,10 +67,21 @@ function _startsWithAt(s, pos, prefix) {
 }
 
 function _countConsecutiveDollarsBefore(s, pos) {
-	let count, k;
+	let bs_count, count, j, k;
 	count = 0;
 	k = pos - 1;
 	while (k >= 0 && s[k] === "$") {
+		// Check if this dollar is escaped by counting preceding backslashes
+		bs_count = 0;
+		j = k - 1;
+		while (j >= 0 && s[j] === "\\") {
+			bs_count += 1;
+			j -= 1;
+		}
+		if (bs_count % 2 === 1) {
+			// Odd number of backslashes means the dollar is escaped, stop counting
+			break;
+		}
 		count += 1;
 		k -= 1;
 	}

--- a/src/parable.py
+++ b/src/parable.py
@@ -74,10 +74,23 @@ def _starts_with_at(s: str, pos: int, prefix: str) -> bool:
 
 
 def _count_consecutive_dollars_before(s: str, pos: int) -> int:
-    """Count consecutive '$' characters immediately before pos."""
+    """Count consecutive '$' characters immediately before pos.
+
+    Stops counting when hitting a '$' that is preceded by an unescaped backslash,
+    since escaped dollars don't participate in dollar sequences like $$.
+    """
     count = 0
     k = pos - 1
     while k >= 0 and s[k] == "$":
+        # Check if this dollar is escaped by counting preceding backslashes
+        bs_count = 0
+        j = k - 1
+        while j >= 0 and s[j] == "\\":
+            bs_count += 1
+            j -= 1
+        if bs_count % 2 == 1:
+            # Odd number of backslashes means the dollar is escaped, stop counting
+            break
         count += 1
         k -= 1
     return count

--- a/tests/parable/character-fuzzer/fuzz-491fc1cad5961bf12335d1287b3531e4.tests
+++ b/tests/parable/character-fuzzer/fuzz-491fc1cad5961bf12335d1287b3531e4.tests
@@ -1,0 +1,5 @@
+=== backslash-escaped dollar followed by ANSI-C quoting
+\$$''
+---
+(command (word "\\$''"))
+---


### PR DESCRIPTION
## Summary
- Fix `_count_consecutive_dollars_before` to stop counting when hitting a dollar that is preceded by an unescaped backslash
- This allows `\$$'...'` to correctly recognize the `$'...'` as ANSI-C quoting
- MRE: `\$$''` - expected `(command (word "\\$''"))`, was `(command (word "\\$$''"))`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-491fc1cad5961bf12335d1287b3531e4.tests`
- [x] `just check` passes