### PR TITLE
fuzzer fix: process substitution syntax <( and >( is literal in heredoc delimiters

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8247,8 +8247,31 @@ class Parser {
 		// Parse the delimiter, handling quoting (can be mixed like 'EOF'"2")
 		quoted = false;
 		delimiter_chars = [];
-		while (!this.atEnd() && !_isMetachar(this.peek())) {
+		while (!this.atEnd()) {
 			ch = this.peek();
+			// Check for process substitution syntax <( or >( first - these are literal in delimiters
+			if (
+				(ch === "<" || ch === ">") &&
+				this.pos + 1 < this.length &&
+				this.source[this.pos + 1] === "("
+			) {
+				delimiter_chars.push(this.advance());
+				delimiter_chars.push(this.advance());
+				depth = 1;
+				while (!this.atEnd() && depth > 0) {
+					c = this.peek();
+					if (c === "(") {
+						depth += 1;
+					} else if (c === ")") {
+						depth -= 1;
+					}
+					delimiter_chars.push(this.advance());
+				}
+				continue;
+			}
+			if (_isMetachar(ch)) {
+				break;
+			}
 			if (ch === '"') {
 				quoted = true;
 				this.advance();

--- a/src/parable.py
+++ b/src/parable.py
@@ -6900,8 +6900,27 @@ class Parser:
         quoted = False
         delimiter_chars = []
 
-        while not self.at_end() and not _is_metachar(self.peek()):
+        while not self.at_end():
             ch = self.peek()
+            # Check for process substitution syntax <( or >( first - these are literal in delimiters
+            if (
+                (ch == "<" or ch == ">")
+                and self.pos + 1 < self.length
+                and self.source[self.pos + 1] == "("
+            ):
+                delimiter_chars.append(self.advance())  # < or >
+                delimiter_chars.append(self.advance())  # (
+                depth = 1
+                while not self.at_end() and depth > 0:
+                    c = self.peek()
+                    if c == "(":
+                        depth += 1
+                    elif c == ")":
+                        depth -= 1
+                    delimiter_chars.append(self.advance())
+                continue
+            if _is_metachar(ch):
+                break
             if ch == '"':
                 quoted = True
                 self.advance()

--- a/tests/parable/character-fuzzer/fuzz-b05a09c5cdb9397d5ccb82d1edb05c72.tests
+++ b/tests/parable/character-fuzzer/fuzz-b05a09c5cdb9397d5ccb82d1edb05c72.tests
@@ -1,0 +1,5 @@
+=== process substitution syntax in here-doc delimiter is literal
+<<a<()
+---
+(command (redirect "<<" ""))
+---


### PR DESCRIPTION
## Summary
- Process substitution syntax `<(` and `>(` was incorrectly treated as starting a process substitution when appearing in heredoc delimiter words
- MRE: `<<a<()` - Parable parsed this as heredoc with delimiter `a` followed by process substitution `<()`, but bash parses the entire `a<()` as the delimiter
- Fix: In heredoc delimiter parsing, handle `<(` and `>(` as literal text with parenthesis balancing, before checking for metachars

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-b05a09c5cdb9397d5ccb82d1edb05c72.tests`
- [x] `just check` passes