### PR TITLE
fuzzer fix: octal escape overflow should wrap modulo 256

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -439,7 +439,7 @@ class Word extends Node {
 						j += 1;
 					}
 					if (j > i + 2) {
-						byte_val = parseInt(inner.slice(i + 1, j), 8);
+						byte_val = parseInt(inner.slice(i + 1, j), 8) & 255;
 						if (byte_val === 0) {
 							// NUL truncates string
 							return `'${new TextDecoder().decode(new Uint8Array(result))}'`;
@@ -451,12 +451,12 @@ class Word extends Node {
 						return `'${new TextDecoder().decode(new Uint8Array(result))}'`;
 					}
 				} else if (c >= "1" && c <= "7") {
-					// Octal escape \NNN (1-3 digits) - raw byte
+					// Octal escape \NNN (1-3 digits) - raw byte, wraps at 256
 					j = i + 1;
 					while (j < inner.length && j < i + 4 && _isOctalDigit(inner[j])) {
 						j += 1;
 					}
-					byte_val = parseInt(inner.slice(i + 1, j), 8);
+					byte_val = parseInt(inner.slice(i + 1, j), 8) & 255;
 					if (byte_val === 0) {
 						// NUL truncates string
 						return `'${new TextDecoder().decode(new Uint8Array(result))}'`;

--- a/src/parable.py
+++ b/src/parable.py
@@ -408,7 +408,7 @@ class Word(Node):
                     while j < len(inner) and j < i + 4 and _is_octal_digit(inner[j]):
                         j += 1
                     if j > i + 2:
-                        byte_val = int(_substring(inner, i + 1, j), 8)
+                        byte_val = int(_substring(inner, i + 1, j), 8) & 0xFF
                         if byte_val == 0:
                             # NUL truncates string
                             return "'" + result.decode("utf-8", errors="replace") + "'"
@@ -418,11 +418,11 @@ class Word(Node):
                         # Just \0 - NUL truncates string
                         return "'" + result.decode("utf-8", errors="replace") + "'"
                 elif c >= "1" and c <= "7":
-                    # Octal escape \NNN (1-3 digits) - raw byte
+                    # Octal escape \NNN (1-3 digits) - raw byte, wraps at 256
                     j = i + 1
                     while j < len(inner) and j < i + 4 and _is_octal_digit(inner[j]):
                         j += 1
-                    byte_val = int(_substring(inner, i + 1, j), 8)
+                    byte_val = int(_substring(inner, i + 1, j), 8) & 0xFF
                     if byte_val == 0:
                         # NUL truncates string
                         return "'" + result.decode("utf-8", errors="replace") + "'"

--- a/tests/parable/character-fuzzer/fuzz-ea876de903b4a4e7ecb4cbe68af818eb.tests
+++ b/tests/parable/character-fuzzer/fuzz-ea876de903b4a4e7ecb4cbe68af818eb.tests
@@ -1,0 +1,5 @@
+=== octal escape overflow wraps modulo 256
+$'\555'
+---
+(command (word "'m'"))
+---


### PR DESCRIPTION
## Summary
- ANSI-C quoted octal escapes like `$'\555'` (365 decimal) caused a crash because they exceed byte range
- Bash wraps these values modulo 256, so `\555` becomes `m` (109)
- MRE: `$'\555'`

- [x] New test added to `tests/parable/character-fuzzer/fuzz-ea876de903b4a4e7ecb4cbe68af818eb.tests`
- [x] `just check` passes