### PR TITLE
fuzzer fix: include fd in heredoc output inside command substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3794,6 +3794,9 @@ function _formatRedirect(r, compact, heredoc_op_only) {
 		} else {
 			op = "<<";
 		}
+		if (r.fd != null && r.fd !== 0) {
+			op = String(r.fd) + op;
+		}
 		if (r.quoted) {
 			delim = `'${r.delimiter}'`;
 		} else {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3234,6 +3234,8 @@ def _format_redirect(
             op = "<<-"
         else:
             op = "<<"
+        if r.fd is not None and r.fd != 0:
+            op = str(r.fd) + op
         if r.quoted:
             delim = "'" + r.delimiter + "'"
         else:

--- a/tests/parable/character-fuzzer/fuzz-16caca4862ed6a5bc156a11de874137f.tests
+++ b/tests/parable/character-fuzzer/fuzz-16caca4862ed6a5bc156a11de874137f.tests
@@ -1,0 +1,7 @@
+=== heredoc with explicit fd inside command substitution
+$(2<<E
+E
+)
+---
+(command (word "$(2<<E\nE\n)"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_format_redirect` to include explicit file descriptor in heredoc output
- When a heredoc has a non-default fd (e.g., `2<<E`), it was being dropped during command substitution formatting
- MRE: `$(2<<E\nE\n)` was formatted as `$(<<E\nE\n)` instead of `$(2<<E\nE\n)`