### PR TITLE
fuzzer fix: handle whitespace after heredoc in process substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4359,18 +4359,26 @@ function _extractHeredocDelimiters(content) {
 }
 
 function _findHeredocContentEnd(source, start, delimiters) {
-	let delimiter, line, line_end, line_start, line_stripped, pos, strip_tabs;
+	let delimiter,
+		line,
+		line_end,
+		line_start,
+		line_stripped,
+		pos,
+		strip_tabs,
+		ws_start;
 	if (!delimiters) {
 		return start;
 	}
 	pos = start;
 	for ([delimiter, strip_tabs] of delimiters) {
 		// Skip whitespace on the same line (e.g., tabs/spaces after closing paren)
+		ws_start = pos;
 		while (pos < source.length && " \t".includes(source[pos])) {
 			pos += 1;
 		}
 		if (pos >= source.length || source[pos] !== "\n") {
-			break;
+			return ws_start;
 		}
 		pos += 1;
 		while (pos < source.length) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3683,10 +3683,11 @@ def _find_heredoc_content_end(source: str, start: int, delimiters: list[tuple[st
     pos = start
     for delimiter, strip_tabs in delimiters:
         # Skip whitespace on the same line (e.g., tabs/spaces after closing paren)
+        ws_start = pos
         while pos < len(source) and source[pos] in " \t":
             pos += 1
         if pos >= len(source) or source[pos] != "\n":
-            break
+            return ws_start
         pos += 1
         while pos < len(source):
             line_start = pos

--- a/tests/parable/character-fuzzer/fuzz-ba7d34157e160362e9f23c95cfcf26a6.tests
+++ b/tests/parable/character-fuzzer/fuzz-ba7d34157e160362e9f23c95cfcf26a6.tests
@@ -1,0 +1,5 @@
+=== process substitution with heredoc followed by tab and word
+<(<<E)	x
+---
+(command (word "<(<<E\nE\n)") (word "x"))
+---


### PR DESCRIPTION
## Summary
- Fixed parser bug where whitespace after a heredoc in a process substitution was incorrectly consumed, causing the next word to be appended to the process substitution instead of being treated separately
- MRE: `<(<<E)\tx` (where `\t` is a tab) - should parse as two words: `<(<<E\nE\n)` and `x`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-ba7d34157e160362e9f23c95cfcf26a6.tests`
- [x] `just check` passes