### PR TITLE
fuzzer fix: heredoc in process sub terminated by delimiter at EOF

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8242,6 +8242,7 @@ class Parser {
 			next_line_start,
 			quoted,
 			scan_pos,
+			tabs_stripped,
 			trailing_bs;
 		this.skipWhitespace();
 		// Parse the delimiter, handling quoting (can be mixed like 'EOF'"2")
@@ -8530,6 +8531,15 @@ class Parser {
 				// Store the heredoc info and let the command parser handle it
 				break;
 			}
+			// At EOF with line starting with delimiter - heredoc terminates (process sub case)
+			// e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
+			if (line_end >= this.length && check_line.startsWith(delimiter)) {
+				// Adjust line_end to point just past the delimiter, not the whole line
+				// This allows remaining content after delimiter to be parsed
+				tabs_stripped = line.length - check_line.length;
+				line_end = line_start + tabs_stripped + delimiter.length;
+				break;
+			}
 			// Add line to content (with newline, since we consumed continuations above)
 			if (strip_tabs) {
 				line = line.replace(/^[\t]+/, "");
@@ -8563,7 +8573,7 @@ class Parser {
 		// Store the position where heredoc content ends so we can skip it later
 		// line_end points to the end of the delimiter line (after any continuations)
 		heredoc_end = line_end;
-		if (heredoc_end < this.length) {
+		if (heredoc_end < this.length && this.source[heredoc_end] === "\n") {
 			heredoc_end += 1;
 		}
 		// Register this heredoc's end position

--- a/src/parable.py
+++ b/src/parable.py
@@ -7125,6 +7125,15 @@ class Parser:
                 # Store the heredoc info and let the command parser handle it
                 break
 
+            # At EOF with line starting with delimiter - heredoc terminates (process sub case)
+            # e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
+            if line_end >= self.length and check_line.startswith(delimiter):
+                # Adjust line_end to point just past the delimiter, not the whole line
+                # This allows remaining content after delimiter to be parsed
+                tabs_stripped = len(line) - len(check_line)
+                line_end = line_start + tabs_stripped + len(delimiter)
+                break
+
             # Add line to content (with newline, since we consumed continuations above)
             if strip_tabs:
                 line = line.lstrip("\t")
@@ -7153,7 +7162,7 @@ class Parser:
         # Store the position where heredoc content ends so we can skip it later
         # line_end points to the end of the delimiter line (after any continuations)
         heredoc_end = line_end
-        if heredoc_end < self.length:
+        if heredoc_end < self.length and self.source[heredoc_end] == "\n":
             heredoc_end += 1  # past the newline
 
         # Register this heredoc's end position

--- a/tests/parable/character-fuzzer/fuzz-9cadae0b5a7eaca48d3fa44e39c3ce23.tests
+++ b/tests/parable/character-fuzzer/fuzz-9cadae0b5a7eaca48d3fa44e39c3ce23.tests
@@ -1,0 +1,6 @@
+=== heredoc in process substitution terminated by ) on delimiter line
+<(<<a
+a )
+---
+(command (word "<(<<a\na\n)"))
+---


### PR DESCRIPTION
## Summary
- Fixed heredoc parsing inside process substitution when delimiter line is at EOF
- When a heredoc is inside `<(...)` and we reach the closing `)`, if a line starts with the delimiter, the heredoc should terminate even if there's trailing content
- MRE: `<(<<a\na )`