### PR TITLE
fuzzer fix: preserve spacing in redirects inside subshells within process substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3728,7 +3728,7 @@ function _formatCmdsubNode(
 		return `function ${name} () \n{ \n${inner_sp}${body}\n}`;
 	}
 	if (node.kind === "subshell") {
-		body = _formatCmdsubNode(node.body, indent, in_procsub, in_procsub);
+		body = _formatCmdsubNode(node.body, indent, in_procsub, compact_redirects);
 		redirects = "";
 		if (node.redirects && node.redirects.length) {
 			redirect_parts = [];

--- a/src/parable.py
+++ b/src/parable.py
@@ -3191,7 +3191,7 @@ def _format_cmdsub_node(
         body = _format_cmdsub_node(inner_body, indent + 4).rstrip(";")
         return f"function {name} () \n{{ \n{inner_sp}{body}\n}}"
     if node.kind == "subshell":
-        body = _format_cmdsub_node(node.body, indent, in_procsub, compact_redirects=in_procsub)
+        body = _format_cmdsub_node(node.body, indent, in_procsub, compact_redirects)
         redirects = ""
         if node.redirects:
             redirect_parts = []

--- a/tests/parable/character-fuzzer/fuzz-da43c0b637714599024c83ec50f46a84.tests
+++ b/tests/parable/character-fuzzer/fuzz-da43c0b637714599024c83ec50f46a84.tests
@@ -1,0 +1,5 @@
+=== process substitution with subshell and redirect preserves spacing
+a<(b;( >>x ))
+---
+(command (word "a<(b; ( >> x ))"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where redirects inside subshells within process substitutions were losing spacing between the redirect operator and target. The MRE is: `a<(b;( >>x ))`
- The issue was that `compact_redirects` was being overridden with `in_procsub` when formatting subshell bodies, causing all redirects in subshells inside process substitutions to be formatted compactly regardless of the intended formatting.

## Test plan
- New test added to `tests/parable/character-fuzzer/fuzz-da43c0b637714599024c83ec50f46a84.tests`
- `just check` passes