### PR TITLE
fuzzer fix: strip dollar sign from locale strings in parameter expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7575,9 +7575,21 @@ class Parser {
 		// Parse operator
 		op = this._consumeParamOperator();
 		if (op == null) {
-			// Unknown operator - bash still parses these (fails at runtime)
-			// Treat the current char as the operator
-			op = this.advance();
+			// Check for $" or $' which should have $ stripped (locale/ANSI-C quotes)
+			if (
+				!this.atEnd() &&
+				this.peek() === "$" &&
+				this.pos + 1 < this.length &&
+				['"', "'"].includes(this.source[this.pos + 1])
+			) {
+				// Skip the $ and treat the rest as an unknown operator
+				this.advance();
+				op = "";
+			} else {
+				// Unknown operator - bash still parses these (fails at runtime)
+				// Treat the current char as the operator
+				op = this.advance();
+			}
 		}
 		// Parse argument (everything until closing brace)
 		// Track quote state and nesting
@@ -7616,6 +7628,17 @@ class Parser {
 				// Nested ${...} - increase depth (outside single quotes)
 				depth += 1;
 				arg_chars.push(this.advance());
+				arg_chars.push(this.advance());
+			} else if (
+				c === "$" &&
+				!in_single_quote &&
+				!in_double_quote &&
+				this.pos + 1 < this.length &&
+				this.source[this.pos + 1] === '"'
+			) {
+				// Locale string $"..." - strip $ and enter double quote
+				this.advance();
+				in_double_quote = true;
 				arg_chars.push(this.advance());
 			} else if (
 				c === "$" &&

--- a/src/parable.py
+++ b/src/parable.py
@@ -6384,9 +6384,20 @@ class Parser:
         # Parse operator
         op = self._consume_param_operator()
         if op is None:
-            # Unknown operator - bash still parses these (fails at runtime)
-            # Treat the current char as the operator
-            op = self.advance()
+            # Check for $" or $' which should have $ stripped (locale/ANSI-C quotes)
+            if (
+                not self.at_end()
+                and self.peek() == "$"
+                and self.pos + 1 < self.length
+                and self.source[self.pos + 1] in ('"', "'")
+            ):
+                # Skip the $ and treat the rest as an unknown operator
+                self.advance()  # skip $
+                op = ""  # empty operator means no operator
+            else:
+                # Unknown operator - bash still parses these (fails at runtime)
+                # Treat the current char as the operator
+                op = self.advance()
 
         # Parse argument (everything until closing brace)
         # Track quote state and nesting
@@ -6424,6 +6435,17 @@ class Parser:
                 depth += 1
                 arg_chars.append(self.advance())  # $
                 arg_chars.append(self.advance())  # {
+            # Locale string $"..." - strip $ and enter double quote
+            elif (
+                c == "$"
+                and not in_single_quote
+                and not in_double_quote
+                and self.pos + 1 < self.length
+                and self.source[self.pos + 1] == '"'
+            ):
+                self.advance()  # skip $
+                in_double_quote = True
+                arg_chars.append(self.advance())  # append "
             # Command substitution $(...) - scan to matching )
             elif (
                 c == "$"

--- a/tests/parable/character-fuzzer/fuzz-3a1593e4d8c11125ae54fad8ed089214.tests
+++ b/tests/parable/character-fuzzer/fuzz-3a1593e4d8c11125ae54fad8ed089214.tests
@@ -1,0 +1,5 @@
+=== dollar sign before double quote inside parameter expansion
+"${x$"y"}"
+---
+(command (word "\"${x\"y\"}\""))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of locale strings `$"..."` inside parameter expansions `${...}`
- The dollar sign should be stripped from `$"` just like it is outside parameter expansions  
- MRE: `"${x$"y"}"` should parse as `${x"y"}` (without the `$`)

## Test plan
- New test added to `tests/parable/character-fuzzer/fuzz-3a1593e4d8c11125ae54fad8ed089214.tests`
- `just check` passes