### PR TITLE
fuzzer fix: heredoc delimiter matching at EOF requires word boundary

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8246,6 +8246,7 @@ class Parser {
 		let add_newline,
 			c,
 			ch,
+			char_after_delim,
 			check_line,
 			content,
 			content_lines,
@@ -8555,12 +8556,21 @@ class Parser {
 			}
 			// At EOF with line starting with delimiter - heredoc terminates (process sub case)
 			// e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
+			// Only match if there's a word boundary after the delimiter (whitespace or metachar)
 			if (line_end >= this.length && check_line.startsWith(delimiter)) {
-				// Adjust line_end to point just past the delimiter, not the whole line
-				// This allows remaining content after delimiter to be parsed
-				tabs_stripped = line.length - check_line.length;
-				line_end = line_start + tabs_stripped + delimiter.length;
-				break;
+				// Check if there's a proper word boundary after the delimiter
+				char_after_delim = null;
+				if (check_line.length > delimiter.length) {
+					char_after_delim = check_line[delimiter.length];
+				}
+				// Only treat as delimiter if followed by whitespace/metachar or is exact match
+				if (char_after_delim == null || _isMetachar(char_after_delim)) {
+					// Adjust line_end to point just past the delimiter, not the whole line
+					// This allows remaining content after delimiter to be parsed
+					tabs_stripped = line.length - check_line.length;
+					line_end = line_start + tabs_stripped + delimiter.length;
+					break;
+				}
 			}
 			// Add line to content (with newline, since we consumed continuations above)
 			if (strip_tabs) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -7143,12 +7143,19 @@ class Parser:
 
             # At EOF with line starting with delimiter - heredoc terminates (process sub case)
             # e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
+            # Only match if there's a word boundary after the delimiter (whitespace or metachar)
             if line_end >= self.length and check_line.startswith(delimiter):
-                # Adjust line_end to point just past the delimiter, not the whole line
-                # This allows remaining content after delimiter to be parsed
-                tabs_stripped = len(line) - len(check_line)
-                line_end = line_start + tabs_stripped + len(delimiter)
-                break
+                # Check if there's a proper word boundary after the delimiter
+                char_after_delim = None
+                if len(check_line) > len(delimiter):
+                    char_after_delim = check_line[len(delimiter)]
+                # Only treat as delimiter if followed by whitespace/metachar or is exact match
+                if char_after_delim is None or _is_metachar(char_after_delim):
+                    # Adjust line_end to point just past the delimiter, not the whole line
+                    # This allows remaining content after delimiter to be parsed
+                    tabs_stripped = len(line) - len(check_line)
+                    line_end = line_start + tabs_stripped + len(delimiter)
+                    break
 
             # Add line to content (with newline, since we consumed continuations above)
             if strip_tabs:

--- a/tests/parable/character-fuzzer/fuzz-46e79987ed353fc48502e2f58ef3adb5.tests
+++ b/tests/parable/character-fuzzer/fuzz-46e79987ed353fc48502e2f58ef3adb5.tests
@@ -1,0 +1,7 @@
+=== heredoc delimiter followed by tab and content
+cat <<E
+EOF
+---
+(command (word "cat") (redirect "<<" "EOF
+"))
+---


### PR DESCRIPTION
## Summary
Fixed a bug where heredoc delimiter matching at EOF was too permissive. When a heredoc delimiter is followed by whitespace (like `<<E<TAB>`), and the content contains text starting with the delimiter (like `EOF`), Parable was incorrectly treating the prefix as a delimiter match, leaving the rest as a separate command.

MRE: `cat <<E<TAB>\nEOF`
- Expected: heredoc content includes `EOF\n`
- Was getting: empty heredoc + separate command `OF`

The fix ensures that at EOF, delimiter matching only occurs when followed by a word boundary (whitespace/metachar), preventing false matches like `E` matching the `E` in `EOF`.

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-46e79987ed353fc48502e2f58ef3adb5.tests`
- [x] `just check` passes