### PR TITLE
fuzzer fix: heredoc delimiter must match exactly, not as prefix

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8263,6 +8263,7 @@ class Parser {
 			next_ch,
 			next_line_start,
 			quoted,
+			rest,
 			scan_pos,
 			tabs_stripped,
 			trailing_bs;
@@ -8556,11 +8557,15 @@ class Parser {
 			// At EOF with line starting with delimiter - heredoc terminates (process sub case)
 			// e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
 			if (line_end >= this.length && check_line.startsWith(delimiter)) {
-				// Adjust line_end to point just past the delimiter, not the whole line
-				// This allows remaining content after delimiter to be parsed
-				tabs_stripped = line.length - check_line.length;
-				line_end = line_start + tabs_stripped + delimiter.length;
-				break;
+				// Only match if delimiter is exact or followed by whitespace then ) (for process sub)
+				rest = check_line.slice(delimiter.length).trimStart();
+				if (rest === "" || (rest.length > 0 && rest[0] === ")")) {
+					// Adjust line_end to point just past the delimiter, not the whole line
+					// This allows remaining content after delimiter to be parsed
+					tabs_stripped = line.length - check_line.length;
+					line_end = line_start + tabs_stripped + delimiter.length;
+					break;
+				}
 			}
 			// Add line to content (with newline, since we consumed continuations above)
 			if (strip_tabs) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -7144,11 +7144,14 @@ class Parser:
             # At EOF with line starting with delimiter - heredoc terminates (process sub case)
             # e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
             if line_end >= self.length and check_line.startswith(delimiter):
-                # Adjust line_end to point just past the delimiter, not the whole line
-                # This allows remaining content after delimiter to be parsed
-                tabs_stripped = len(line) - len(check_line)
-                line_end = line_start + tabs_stripped + len(delimiter)
-                break
+                # Only match if delimiter is exact or followed by whitespace then ) (for process sub)
+                rest = check_line[len(delimiter) :].lstrip()
+                if rest == "" or (rest and rest[0] == ")"):
+                    # Adjust line_end to point just past the delimiter, not the whole line
+                    # This allows remaining content after delimiter to be parsed
+                    tabs_stripped = len(line) - len(check_line)
+                    line_end = line_start + tabs_stripped + len(delimiter)
+                    break
 
             # Add line to content (with newline, since we consumed continuations above)
             if strip_tabs:

--- a/tests/parable/character-fuzzer/fuzz-e882490bc212c9e27ede564e10a25247.tests
+++ b/tests/parable/character-fuzzer/fuzz-e882490bc212c9e27ede564e10a25247.tests
@@ -1,0 +1,9 @@
+=== heredoc delimiter must match exactly, not as prefix
+cat <<EO
+hello
+EOF
+---
+(command (word "cat") (redirect "<<" "hello
+EOF
+"))
+---


### PR DESCRIPTION
## Summary
Fixed heredoc delimiter matching to require exact match, not just prefix match. When a heredoc delimiter is EO, a line containing EOF should not terminate the heredoc.

MRE: cat <<EO then hello then EOF (each on separate lines)

Before: Parable incorrectly matched EOF as delimiter EO, producing two commands.
After: Parable correctly treats EOF as content, matching bash behavior.