### PR TITLE
fuzzer fix: handle $[...] in heredoc delimiters (#182)

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8396,6 +8396,24 @@ class Parser {
 						}
 						delimiter_chars.push(this.advance());
 					}
+				} else if (
+					ch === "$" &&
+					this.pos + 1 < this.length &&
+					this.source[this.pos + 1] === "["
+				) {
+					// Arithmetic expansion $[...] embedded in delimiter
+					delimiter_chars.push(this.advance());
+					delimiter_chars.push(this.advance());
+					depth = 1;
+					while (!this.atEnd() && depth > 0) {
+						c = this.peek();
+						if (c === "[") {
+							depth += 1;
+						} else if (c === "]") {
+							depth -= 1;
+						}
+						delimiter_chars.push(this.advance());
+					}
 				} else if (ch === "`") {
 					// Backtick command substitution embedded in delimiter
 					// Note: In bash, backtick closes command sub even with unclosed quotes inside

--- a/src/parable.py
+++ b/src/parable.py
@@ -7014,6 +7014,18 @@ class Parser:
                         elif c == "}":
                             depth -= 1
                         delimiter_chars.append(self.advance())
+                elif ch == "$" and self.pos + 1 < self.length and self.source[self.pos + 1] == "[":
+                    # Arithmetic expansion $[...] embedded in delimiter
+                    delimiter_chars.append(self.advance())  # $
+                    delimiter_chars.append(self.advance())  # [
+                    depth = 1
+                    while not self.at_end() and depth > 0:
+                        c = self.peek()
+                        if c == "[":
+                            depth += 1
+                        elif c == "]":
+                            depth -= 1
+                        delimiter_chars.append(self.advance())
                 elif ch == "`":
                     # Backtick command substitution embedded in delimiter
                     # Note: In bash, backtick closes command sub even with unclosed quotes inside

--- a/tests/parable/character-fuzzer/fuzz-e6907e0195e85f3cf5336fc6bea16029.tests
+++ b/tests/parable/character-fuzzer/fuzz-e6907e0195e85f3cf5336fc6bea16029.tests
@@ -1,0 +1,5 @@
+=== heredoc delimiter with $[...] containing redirect operators
+<< $[>&]
+---
+(command (redirect "<<" ""))
+---


### PR DESCRIPTION
## Summary
Fixed parser bug where `$[...]` arithmetic expansion in heredoc delimiters was incorrectly parsed. The parser was treating redirect operators like `>&` inside `$[...]` as actual redirects instead of part of the delimiter.

MRE: `<< $[>&]`

The fix adds handling for `$[...]` in the heredoc delimiter parsing, similar to the existing handling for `$(...)`, `${...}`, and backticks.