### PR TITLE
fuzzer fix: || in regex pattern should not be parsed as conditional OR

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9576,18 +9576,11 @@ class Parser {
 					if (sc === ")" && paren_depth > 0) {
 						break;
 					}
-					// Check for && or || - these terminate the regex even inside brackets
+					// Check for && - this terminates the regex even inside brackets
 					if (
 						sc === "&" &&
 						scan + 1 < this.length &&
 						this.source[scan + 1] === "&"
-					) {
-						break;
-					}
-					if (
-						sc === "|" &&
-						scan + 1 < this.length &&
-						this.source[scan + 1] === "|"
 					) {
 						break;
 					}
@@ -9713,7 +9706,7 @@ class Parser {
 				}
 				continue;
 			}
-			// Word terminators - space/tab ends the regex (unless inside parens), as do && and ||
+			// Word terminators - space/tab ends the regex (unless inside parens), as does &&
 			if (_isWhitespace(ch) && paren_depth === 0) {
 				break;
 			}
@@ -9726,13 +9719,6 @@ class Parser {
 				ch === "&" &&
 				this.pos + 1 < this.length &&
 				this.source[this.pos + 1] === "&"
-			) {
-				break;
-			}
-			if (
-				ch === "|" &&
-				this.pos + 1 < this.length &&
-				this.source[this.pos + 1] === "|"
 			) {
 				break;
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -7964,11 +7964,9 @@ class Parser:
                     # Check for ) when inside paren group
                     if sc == ")" and paren_depth > 0:
                         break  # Won't close before )
-                    # Check for && or || - these terminate the regex even inside brackets
+                    # Check for && - this terminates the regex even inside brackets
                     if sc == "&" and scan + 1 < self.length and self.source[scan + 1] == "&":
                         break  # Won't close before &&
-                    if sc == "|" and scan + 1 < self.length and self.source[scan + 1] == "|":
-                        break  # Won't close before ||
                     if sc == "]":
                         bracket_will_close = True
                         break
@@ -8053,7 +8051,7 @@ class Parser:
                         chars.append(self.advance())
                 continue
 
-            # Word terminators - space/tab ends the regex (unless inside parens), as do && and ||
+            # Word terminators - space/tab ends the regex (unless inside parens), as does &&
             if _is_whitespace(ch) and paren_depth == 0:
                 break
             if _is_whitespace(ch) and paren_depth > 0:
@@ -8061,8 +8059,6 @@ class Parser:
                 chars.append(self.advance())
                 continue
             if ch == "&" and self.pos + 1 < self.length and self.source[self.pos + 1] == "&":
-                break
-            if ch == "|" and self.pos + 1 < self.length and self.source[self.pos + 1] == "|":
                 break
 
             # Single-quoted string

--- a/tests/parable/character-fuzzer/fuzz-8d321089c60d84a1db1c622a66a276e2.tests
+++ b/tests/parable/character-fuzzer/fuzz-8d321089c60d84a1db1c622a66a276e2.tests
@@ -1,0 +1,5 @@
+=== regex pattern with || should not be parsed as conditional OR
+[[ a =~ x||$ ]]
+---
+(cond (cond-binary "=~" (cond-term "a") (cond-term "x||$")))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `||` in regex patterns was incorrectly parsed as conditional OR operator
- MRE: `[[ a =~ x||$ ]]` should parse `x||$` as a single regex pattern, not `x` followed by `|| $`
- Bash treats `&&` and `||` asymmetrically in regex contexts: `&&` terminates the regex, but `||` does not

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-8d321089c60d84a1db1c622a66a276e2.tests`
- [x] `just check` passes