### PR TITLE
fuzzer fix: heredoc in process sub followed by non-whitespace char on same line

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-f0c36667fa9b95acc369d5fb9056f7a3.tests
+++ b/tests/parable/character-fuzzer/fuzz-f0c36667fa9b95acc369d5fb9056f7a3.tests
@@ -1,0 +1,7 @@
+=== heredoc in process sub followed by [ should include heredoc content
+<(<<D)[
+x
+D
+---
+(command (word "<(<<D\nx\nD\n)["))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where heredoc content in process substitutions was not parsed when there was a non-whitespace character (like `[`) on the same line after the closing `)` but before the newline
- MRE: `<(<<D)[\nx\nD`

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-f0c36667fa9b95acc369d5fb9056f7a3.tests`
- [ ] `just check` passes