### PR TITLE
fuzzer fix: handle heredocs in process substitutions with content after closing paren

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-2d1b5569801fe96993e64c994b216986.tests
+++ b/tests/parable/character-fuzzer/fuzz-2d1b5569801fe96993e64c994b216986.tests
@@ -1,0 +1,7 @@
+=== process substitution with heredoc and tab-indented content
+<(<<D)@
+	a
+D
+---
+(command (word "<(<<D\n\ta\nD\n)@"))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug where heredocs inside process substitutions were not found when there was non-whitespace content after the closing `)` on the same line
- The original code only skipped whitespace (spaces/tabs) after the `)` before looking for heredoc content, and would return early if it encountered other characters like `@`
- The fix changes `_find_heredoc_content_end` to skip to the end of the current line (including non-whitespace), then find the heredoc content on the next line
- Uses the `_pending_heredoc_end` mechanism to defer skipping the heredoc content until after the current line is fully parsed

MRE: `<(<<D)@\n\ta\nD` where the heredoc content `\ta\n` was not being included in the process substitution output.