### PR TITLE
fuzzer fix: command sub with malformed arithmetic in outer arithmetic

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4028,6 +4028,10 @@ function _findCmdsubEnd(value, start) {
 						scan_paren -= 1;
 					} else if (scan_i + 1 < value.length && value[scan_i + 1] === ")") {
 						break;
+					} else {
+						// Single ) at top level without following ) - not valid arithmetic
+						is_valid_arith = false;
+						break;
 					}
 				} else if (scan_c === ";" && scan_paren === 0) {
 					is_valid_arith = false;

--- a/src/parable.py
+++ b/src/parable.py
@@ -3428,6 +3428,10 @@ def _find_cmdsub_end(value: str, start: int) -> int:
                         scan_paren -= 1
                     elif scan_i + 1 < len(value) and value[scan_i + 1] == ")":
                         break  # Found )) at top level, valid arithmetic
+                    else:
+                        # Single ) at top level without following ) - not valid arithmetic
+                        is_valid_arith = False
+                        break
                 elif scan_c == ";" and scan_paren == 0:
                     is_valid_arith = False
                     break

--- a/tests/parable/character-fuzzer/fuzz-3f72720bfef840a1aa0676258228bea6.tests
+++ b/tests/parable/character-fuzzer/fuzz-3f72720bfef840a1aa0676258228bea6.tests
@@ -1,0 +1,5 @@
+=== nested arith expansion with command sub and invalid syntax
+$(($($((0)0))))
+---
+(command (word "$(($($((0)0))))"))
+---


### PR DESCRIPTION
## Summary
Fixed parsing of nested command substitutions containing malformed arithmetic expressions within outer arithmetic expressions. The MRE is `$(($($((0)0))))`.

The bug was in `_find_cmdsub_end`: when scanning to determine if `$((` starts valid arithmetic, it would incorrectly accept patterns like `$((0)0))` as valid arithmetic by matching the final `))` even though there was junk (`0`) between the first `)` and the closing `))`. 

The fix checks that when we encounter a single `)` at top paren depth, it must be immediately followed by another `)` to form a valid closing `))`, otherwise the arithmetic is malformed.

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-3f72720bfef840a1aa0676258228bea6.tests`
- [x] `just check` passes