### PR TITLE
fuzzer fix: handle backslash-newline in parameter expansions (#a3da4dcc11f4219e5c995ace8458be03)

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -266,6 +266,10 @@ class Word extends Node {
 				while (i < value.length && depth > 0) {
 					ch = value[i];
 					if (ch === "\\" && i + 1 < value.length && !in_single) {
+						if (value[i + 1] === "\n") {
+							i += 2;
+							continue;
+						}
 						result.push(ch);
 						result.push(value[i + 1]);
 						i += 2;

--- a/src/parable.py
+++ b/src/parable.py
@@ -276,6 +276,9 @@ class Word(Node):
                 while i < len(value) and depth > 0:
                     ch = value[i]
                     if ch == "\\" and i + 1 < len(value) and not in_single:
+                        if value[i + 1] == "\n":
+                            i += 2
+                            continue
                         result.append(ch)
                         result.append(value[i + 1])
                         i += 2

--- a/tests/parable/character-fuzzer/fuzz-a3da4dcc11f4219e5c995ace8458be03.tests
+++ b/tests/parable/character-fuzzer/fuzz-a3da4dcc11f4219e5c995ace8458be03.tests
@@ -1,0 +1,6 @@
+=== backslash-newline in parameter expansion
+${a\
+}
+---
+(command (word "${a}"))
+---


### PR DESCRIPTION
## Summary
Backslash-newline inside parameter expansions should be treated as line continuation and removed. Previously, Parable was preserving the `\n` in the output.

MRE: `${a\<newline>}` should parse as `${a}` not `${a\<newline>}`