### PR TITLE
fuzzer fix: strip dollar sign from locale strings in parameter expansion subscripts

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-5ec6a827cb785c264e0d39068d49a8ee.tests
+++ b/tests/parable/character-fuzzer/fuzz-5ec6a827cb785c264e0d39068d49a8ee.tests
@@ -1,0 +1,5 @@
+=== parameter expansion with $"..." in subscript should strip dollar sign
+"${ev[$"ev1"]}"
+---
+(command (word "\"${ev[\"ev1\"]}\""))
+---


### PR DESCRIPTION
## Summary
Inside parameter expansion subscripts like `${arr[$"key"]}`, locale strings `$"..."` should have the dollar sign stripped to match bash behavior. The bug occurred because `_strip_locale_string_dollars()` wasn't tracking bracket depth for subscripts, so it didn't recognize that quotes inside `[...]` are independent of outer quote contexts.

MRE: `"${ev[$"ev1"]}"`

- New test added to `tests/parable/character-fuzzer/fuzz-5ec6a827cb785c264e0d39068d49a8ee.tests`
- `just check` passes