### PR TITLE
fuzzer fix: heredoc delimiter must match exactly, not with trailing space

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4754,12 +4754,16 @@ function _looksLikeAssignment(s) {
 }
 
 class Parser {
-	constructor(source) {
+	constructor(source, in_process_sub) {
+		if (in_process_sub == null) {
+			in_process_sub = false;
+		}
 		this.source = source;
 		this.pos = 0;
 		this.length = source.length;
 		this._pending_heredoc_end = null;
 		this._saw_newline_in_single_quote = false;
+		this._in_process_sub = in_process_sub;
 	}
 
 	atEnd() {
@@ -6095,7 +6099,7 @@ class Parser {
 		// Use comment-aware stripping to preserve newlines that terminate comments
 		text = _stripLineContinuationsCommentAware(text);
 		// Parse the content as a command list
-		sub_parser = new Parser(content);
+		sub_parser = new Parser(content, true);
 		cmd = sub_parser.parseList();
 		if (cmd == null) {
 			cmd = new Empty();
@@ -8610,10 +8614,19 @@ class Parser {
 			}
 			// At EOF with line starting with delimiter - heredoc terminates (process sub case)
 			// e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
-			if (line_end >= this.length && check_line.startsWith(delimiter)) {
-				// Only match if delimiter is exact or followed by whitespace then ) (for process sub)
-				rest = check_line.slice(delimiter.length).trimStart();
-				if (rest === "" || (rest.length > 0 && rest[0] === ")")) {
+			if (
+				line_end >= this.length &&
+				check_line.startsWith(delimiter) &&
+				this._in_process_sub
+			) {
+				// Only match if delimiter is exact or followed by whitespace/punctuation
+				rest = check_line.slice(delimiter.length);
+				// In process sub, accept: exact match, whitespace only, or whitespace + )
+				if (
+					rest === "" ||
+					rest.trimStart() === "" ||
+					rest.trimStart().startsWith(")")
+				) {
 					// Adjust line_end to point just past the delimiter, not the whole line
 					// This allows remaining content after delimiter to be parsed
 					tabs_stripped = line.length - check_line.length;

--- a/src/parable.py
+++ b/src/parable.py
@@ -4028,12 +4028,13 @@ def _looks_like_assignment(s: str) -> bool:
 class Parser:
     """Recursive descent parser for bash."""
 
-    def __init__(self, source: str):
+    def __init__(self, source: str, in_process_sub: bool = False):
         self.source = source
         self.pos = 0
         self.length = len(source)
         self._pending_heredoc_end = None
         self._saw_newline_in_single_quote = False
+        self._in_process_sub = in_process_sub
 
     def at_end(self) -> bool:
         """Check if we've reached the end of input."""
@@ -5124,7 +5125,7 @@ class Parser:
         text = _strip_line_continuations_comment_aware(text)
 
         # Parse the content as a command list
-        sub_parser = Parser(content)
+        sub_parser = Parser(content, in_process_sub=True)
         cmd = sub_parser.parse_list()
         if cmd is None:
             cmd = Empty()
@@ -7191,10 +7192,15 @@ class Parser:
 
             # At EOF with line starting with delimiter - heredoc terminates (process sub case)
             # e.g. <(<<a\na ) - the "a " line starts with delimiter "a" and we're at EOF
-            if line_end >= self.length and check_line.startswith(delimiter):
-                # Only match if delimiter is exact or followed by whitespace then ) (for process sub)
-                rest = check_line[len(delimiter) :].lstrip()
-                if rest == "" or (rest and rest[0] == ")"):
+            if (
+                line_end >= self.length
+                and check_line.startswith(delimiter)
+                and self._in_process_sub
+            ):
+                # Only match if delimiter is exact or followed by whitespace/punctuation
+                rest = check_line[len(delimiter) :]
+                # In process sub, accept: exact match, whitespace only, or whitespace + )
+                if rest == "" or rest.lstrip() == "" or rest.lstrip().startswith(")"):
                     # Adjust line_end to point just past the delimiter, not the whole line
                     # This allows remaining content after delimiter to be parsed
                     tabs_stripped = len(line) - len(check_line)

--- a/tests/parable/character-fuzzer/fuzz-6160c986548120feb0c7d8c2b6051fbf.tests
+++ b/tests/parable/character-fuzzer/fuzz-6160c986548120feb0c7d8c2b6051fbf.tests
@@ -1,0 +1,7 @@
+=== heredoc delimiter must match exactly, not with trailing space
+x<<E
+E 
+---
+(command (word "x") (redirect "<<" "E 
+"))
+---


### PR DESCRIPTION
## Summary
Fixes heredoc delimiter matching to require exact match, not prefix match with trailing whitespace.

**MRE:**
```bash
x<<E
E 
```

The heredoc delimiter `E` should not match the line `E ` (with trailing space). The line should be treated as heredoc content, not as a delimiter.

**Root cause:** At EOF in heredoc parsing, the code was treating delimiter + trailing whitespace as a match when it should only match delimiter + whitespace + `)` (for process substitution case).

**Fix:** Added `_in_process_sub` flag to Parser to distinguish process substitution heredocs (where trailing space + `)` is valid) from regular heredocs (where delimiter must match exactly).

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-6160c986548120feb0c7d8c2b6051fbf.tests`
- [x] `just check` passes (4412 tests pass)
