### PR TITLE
fuzzer fix: add space before command after heredoc in command sub with semicolon

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3602,6 +3602,11 @@ function _formatCmdsubNode(
 						formatted_cmd = ` ${formatted_cmd}`;
 					}
 				}
+				// When semicolon was skipped due to heredoc, add leading space
+				if (skipped_semi) {
+					formatted_cmd = ` ${formatted_cmd}`;
+					skipped_semi = false;
+				}
 				result.push(formatted_cmd);
 				cmd_count += 1;
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -3069,6 +3069,10 @@ def _format_cmdsub_node(
                     last = result[len(result) - 1]
                     if " || \n" in last or " && \n" in last:
                         formatted_cmd = " " + formatted_cmd
+                # When semicolon was skipped due to heredoc, add leading space
+                if skipped_semi:
+                    formatted_cmd = " " + formatted_cmd
+                    skipped_semi = False
                 result.append(formatted_cmd)
                 cmd_count += 1
         # Strip trailing ; or newline (but preserve heredoc's trailing newline)

--- a/tests/parable/character-fuzzer/fuzz-a17566e114d400afb932932d11914014.tests
+++ b/tests/parable/character-fuzzer/fuzz-a17566e114d400afb932932d11914014.tests
@@ -1,0 +1,8 @@
+=== heredoc delimiter in command sub with commands after redirect
+echo "$(cat<<X a; echo b
+line
+X
+)"
+---
+(command (word "echo") (word "\"$(cat a <<X\nline\nX\n echo b)\""))
+---


### PR DESCRIPTION
## Summary
When a heredoc appears in a command substitution followed by a semicolon and another command (e.g., `cat<<X a; echo b`), the formatter skips the semicolon because the heredoc ends with a newline. However, it wasn't adding a space before the next command, causing the output to be `echo b` instead of ` echo b`.

MRE: `echo "$(cat<<X a; echo b\nline\nX\n)"`

Fixed by tracking when a semicolon is skipped due to a heredoc and adding a leading space to the next command.

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-a17566e114d400afb932932d11914014.tests`
- [x] `just check` passes