### PR TITLE
fuzzer fix: don't parse command substitution as function definition

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -10837,10 +10837,12 @@ class Parser {
 		// Check for () - whitespace IS allowed between name and (
 		// But if name ends with extglob prefix (*?@+!) and () is adjacent,
 		// it's an extglob pattern, not a function definition
+		// Similarly, if name ends with $ and () is adjacent, it's a command
+		// substitution, not a function definition
 		pos_after_name = this.pos;
 		this.skipWhitespace();
 		has_whitespace = this.pos > pos_after_name;
-		if (!has_whitespace && name && "*?@+!".includes(name[name.length - 1])) {
+		if (!has_whitespace && name && "*?@+!$".includes(name[name.length - 1])) {
 			this.pos = saved_pos;
 			return null;
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -9034,10 +9034,12 @@ class Parser:
         # Check for () - whitespace IS allowed between name and (
         # But if name ends with extglob prefix (*?@+!) and () is adjacent,
         # it's an extglob pattern, not a function definition
+        # Similarly, if name ends with $ and () is adjacent, it's a command
+        # substitution, not a function definition
         pos_after_name = self.pos
         self.skip_whitespace()
         has_whitespace = self.pos > pos_after_name
-        if not has_whitespace and name and name[len(name) - 1] in "*?@+!":
+        if not has_whitespace and name and name[len(name) - 1] in "*?@+!$":
             self.pos = saved_pos
             return None
 

--- a/tests/parable/character-fuzzer/fuzz-b2d8d412dc58e83ea1f4696e77f6c1f8.tests
+++ b/tests/parable/character-fuzzer/fuzz-b2d8d412dc58e83ea1f4696e77f6c1f8.tests
@@ -1,0 +1,7 @@
+=== invalid function name with dollar sign should be parsed as command
+a$()
+{ :; }
+---
+(command (word "a$()"))
+(brace-group (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- Fixed parser incorrectly treating `a$()` as a function definition when it should be parsed as a command word containing a command substitution
- MRE: `a$()\n{ :; }` was being parsed as `(function "a$" ...)` instead of `(command (word "a$()")) ...`
- The fix adds `$` to the set of characters that, when appearing at the end of a potential function name with no whitespace before `()`, indicates it's not a function definition (similar to existing extglob pattern check)

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-b2d8d412dc58e83ea1f4696e77f6c1f8.tests`
- [x] `just check` passes