### PR TITLE
fuzzer fix: remove empty word after stripping trailing backslash

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -11507,6 +11507,10 @@ class Parser {
 		last_word = this._findLastWord(last_node);
 		if (last_word && last_word.value.endsWith("\\")) {
 			last_word.value = last_word.value.slice(0, last_word.value.length - 1);
+			// If the word is now empty, remove it from the command
+			if (!last_word.value && last_node instanceof Command && last_node.words) {
+				last_node.words.pop();
+			}
 		}
 	}
 

--- a/src/parable.py
+++ b/src/parable.py
@@ -9631,6 +9631,9 @@ class Parser:
         last_word = self._find_last_word(last_node)
         if last_word and last_word.value.endswith("\\"):
             last_word.value = _substring(last_word.value, 0, len(last_word.value) - 1)
+            # If the word is now empty, remove it from the command
+            if not last_word.value and isinstance(last_node, Command) and last_node.words:
+                last_node.words.pop()
 
     def _find_last_word(self, node: Node) -> Word | None:
         """Recursively find the last Word in a node structure."""

--- a/tests/parable/character-fuzzer/fuzz-07f9d6e78f6a7bff0ee8b954918cd070.tests
+++ b/tests/parable/character-fuzzer/fuzz-07f9d6e78f6a7bff0ee8b954918cd070.tests
@@ -1,0 +1,6 @@
+=== trailing backslash after single-quoted newline with space
+'
+'a \
+---
+(command (word "'\n'a"))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug where Parable was creating an empty word after stripping a trailing backslash when the input contained a newline inside single quotes
- MRE: `'\n'a \` (single quote, newline, single quote, 'a', space, backslash)
- Expected: `(command (word "'\n'a"))`
- Before fix: `(command (word "'\n'a") (word ""))`
- After fix: `(command (word "'\n'a"))`