### PR TITLE
fuzzer fix: validate identifier characters in assignment detection

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5930,6 +5930,14 @@ class Parser {
 				bracket_depth === 0
 			) {
 				return true;
+			} else if (
+				!in_single &&
+				!in_double &&
+				bracket_depth === 0 &&
+				!(/^[a-zA-Z0-9]$/.test(ch) || ch === "_")
+			) {
+				// Invalid char in identifier part before =
+				return false;
 			}
 			i += 1;
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -4982,6 +4982,14 @@ class Parser:
                 bracket_depth -= 1
             elif ch == "=" and not in_single and not in_double and bracket_depth == 0:
                 return True
+            elif (
+                not in_single
+                and not in_double
+                and bracket_depth == 0
+                and not (ch.isalnum() or ch == "_")
+            ):
+                # Invalid char in identifier part before =
+                return False
             i += 1
         return False
 

--- a/tests/parable/character-fuzzer/fuzz-d8b524025992d4dd364cab1609bee13a.tests
+++ b/tests/parable/character-fuzzer/fuzz-d8b524025992d4dd364cab1609bee13a.tests
@@ -1,0 +1,5 @@
+=== unmatched bracket with brace should split words correctly
+A}= a[b c
+---
+(command (word "A}=") (word "a[b") (word "c"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where words with invalid variable name characters (like `A}=`) were incorrectly treated as assignments
- This caused subsequent words starting with `[` to incorrectly enter bracket-tracking mode, consuming spaces that should be word boundaries
- MRE: `A}= a[b c` - Parable parsed as 2 words but bash correctly parses as 3 words

The fix validates that identifier parts of assignment words only contain valid characters (alphanumeric and underscore) before the `=` sign.

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-d8b524025992d4dd364cab1609bee13a.tests`
- [x] `just check` passes