### PR TITLE
fuzzer fix: don't treat pipe inside brackets as part of variable fd

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8134,7 +8134,7 @@ class Parser {
 					varname_chars.push(this.advance());
 				} else if (/^[a-zA-Z0-9]$/.test(ch) || ch === "_") {
 					varname_chars.push(this.advance());
-				} else if (in_bracket) {
+				} else if (in_bracket && !_isMetachar(ch)) {
 					varname_chars.push(this.advance());
 				} else {
 					break;

--- a/src/parable.py
+++ b/src/parable.py
@@ -6836,7 +6836,7 @@ class Parser:
                     varname_chars.append(self.advance())
                 elif ch.isalnum() or ch == "_":
                     varname_chars.append(self.advance())
-                elif in_bracket:
+                elif in_bracket and not _is_metachar(ch):
                     varname_chars.append(self.advance())
                 else:
                     break

--- a/tests/parable/character-fuzzer/fuzz-f605bc954a487d2a1065bfe6f52e977d.tests
+++ b/tests/parable/character-fuzzer/fuzz-f605bc954a487d2a1065bfe6f52e977d.tests
@@ -1,0 +1,5 @@
+=== pipe in parameter expansion subscript with redirect
+{x[|]}>a
+---
+(pipe (command (word "{x[")) (command (word "]}") (redirect ">" "a")))
+---


### PR DESCRIPTION
## Summary
- Fixed incorrect parsing of `{x[|]}>a` where the parser was treating `{x[|]}` as a variable file descriptor instead of recognizing the pipe operator
- The bug was in `parse_redirect()` which unconditionally consumed all characters inside brackets when looking for variable fds like `{varname[subscript]}>file`
- Now correctly rejects metacharacters (like `|`) inside brackets, causing the parser to match bash behavior

MRE: `{x[|]}>a`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-f605bc954a487d2a1065bfe6f52e977d.tests`
- [x] `just check` passes