### PR TITLE
fuzzer fix: don't increment depth for bare braces in parameter expansion unknown syntax handler

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7606,10 +7606,7 @@ class Parser {
 						content_chars.push(this.advance());
 						continue;
 					}
-					if (c === "{") {
-						depth += 1;
-						content_chars.push(this.advance());
-					} else if (c === "}") {
+					if (c === "}") {
 						depth -= 1;
 						if (depth === 0) {
 							break;

--- a/src/parable.py
+++ b/src/parable.py
@@ -6404,10 +6404,7 @@ class Parser:
                             raise ParseError("Unterminated backtick", pos=backtick_start)
                         content_chars.append(self.advance())
                         continue
-                    if c == "{":
-                        depth += 1
-                        content_chars.append(self.advance())
-                    elif c == "}":
+                    if c == "}":
                         depth -= 1
                         if depth == 0:
                             break

--- a/tests/parable/character-fuzzer/fuzz-0321319bd905097a55f3a16c0348d784.tests
+++ b/tests/parable/character-fuzzer/fuzz-0321319bd905097a55f3a16c0348d784.tests
@@ -1,0 +1,5 @@
+=== parameter expansion with ] in default value, followed by braces and unquoted text
+echo ${]a:-G]{} K }
+---
+(command (word "echo") (word "${]a:-G]{}") (word "K") (word "}"))
+---


### PR DESCRIPTION
## Summary
- Fixed parameter expansion parsing for unknown syntax (e.g., parameter names starting with `]`)
- The bug: bare `{` characters incorrectly incremented brace depth in the unknown syntax handler
- The fix: remove special handling for bare `{` - only `${` should increment depth
- MRE: `echo ${]a:-G]{} K }` should parse as three words, not one