### PR TITLE
fuzzer fix: function syntax inside unclosed parameter expansion

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-d2266024cae5a1ad18c370fb6030b295.tests
+++ b/tests/parable/character-fuzzer/fuzz-d2266024cae5a1ad18c370fb6030b295.tests
@@ -1,0 +1,5 @@
+=== function syntax inside unclosed parameter expansion
+a${:b() { c; }
+---
+(command (word "a${:b() { c; }"))
+---


### PR DESCRIPTION
## Summary
- Fix parser incorrectly treating `()` as function definition syntax when inside unclosed parameter expansion
- Fix parameter expansion parser incorrectly tracking standalone `{` as increasing nesting depth

The issue was that `a${:b() { c; }` was being parsed as a function definition with name `a${:b`, when it should be parsed as a command with a word containing a malformed parameter expansion.

Two fixes were needed:
1. In function parsing: detect unclosed parameter expansions in the function name and backtrack
2. In parameter expansion parsing: only track `${` nesting, not standalone `{` nesting

MRE: `a${:b() { c; }`

## Test plan
- New test added to `tests/parable/character-fuzzer/fuzz-d2266024cae5a1ad18c370fb6030b295.tests`
- `just check` passes