### PR TITLE
fuzzer fix: don't detect assignments after redirects

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8823,6 +8823,7 @@ class Parser {
 			// Otherwise parse a word
 			// Allow array assignments like a[1 + 2]= in prefix position (before first non-assignment)
 			// Check if all previous words were assignments (contain = not inside quotes)
+			// and no redirects have been seen (redirects break assignment context)
 			all_assignments = true;
 			for (w of words) {
 				if (!this._isAssignmentWord(w)) {
@@ -8830,7 +8831,9 @@ class Parser {
 					break;
 				}
 			}
-			word = this.parseWord(!words || all_assignments);
+			word = this.parseWord(
+				!words || (all_assignments && redirects.length === 0),
+			);
 			if (word == null) {
 				break;
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -7357,12 +7357,15 @@ class Parser:
             # Otherwise parse a word
             # Allow array assignments like a[1 + 2]= in prefix position (before first non-assignment)
             # Check if all previous words were assignments (contain = not inside quotes)
+            # and no redirects have been seen (redirects break assignment context)
             all_assignments = True
             for w in words:
                 if not self._is_assignment_word(w):
                     all_assignments = False
                     break
-            word = self.parse_word(at_command_start=not words or all_assignments)
+            word = self.parse_word(
+                at_command_start=not words or (all_assignments and len(redirects) == 0)
+            )
             if word is None:
                 break
             words.append(word)

--- a/tests/parable/character-fuzzer/fuzz-ff7aef255a4ef1f1ce06cf8d29d0a251.tests
+++ b/tests/parable/character-fuzzer/fuzz-ff7aef255a4ef1f1ce06cf8d29d0a251.tests
@@ -1,0 +1,5 @@
+=== assignment detection stops after redirect
+a[ ]= <x a[ ]=
+---
+(command (word "a[ ]=") (word "a[") (word "]=") (redirect "<" "x"))
+---


### PR DESCRIPTION
## Summary
Fixed a parser bug where array assignments with spaces in brackets (like `a[ ]=`) were incorrectly detected as assignments after a redirect. Assignment detection should stop after encountering redirects.

MRE: `a[ ]= <x a[ ]=`

The bug was that after parsing a redirect, Parable continued to use assignment detection mode for subsequent words. Bash correctly treats subsequent words as regular words (splitting on spaces), not assignments.