### PR TITLE
fuzzer fix: don't parse >( as process substitution after quotes

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1355,10 +1355,14 @@ class Word extends Node {
 				(_startsWithAt(value, idx, "<(") || _startsWithAt(value, idx, ">(")) &&
 				!in_double
 			) {
-				// Only treat as process substitution if not preceded by alphanumeric
+				// Only treat as process substitution if not preceded by alphanumeric or quote
 				// (e.g., "i<(3)" is arithmetic comparison, not process substitution)
-				// Also don't treat as process substitution inside double quotes
-				if (idx === 0 || !/^[a-zA-Z0-9]$/.test(value[idx - 1])) {
+				// Also don't treat as process substitution inside double quotes or after quotes
+				if (
+					idx === 0 ||
+					(!/^[a-zA-Z0-9]$/.test(value[idx - 1]) &&
+						!"\"'".includes(value[idx - 1]))
+				) {
 					has_untracked_procsub = true;
 					break;
 				}
@@ -1520,8 +1524,11 @@ class Word extends Node {
 			) {
 				// Check for >( or <( process substitution (not inside double quotes, $[...], or $((...)))
 				// Check if this is actually a process substitution or just comparison + parens
-				// Process substitution: not preceded by alphanumeric
-				is_procsub = i === 0 || !/^[a-zA-Z0-9]$/.test(value[i - 1]);
+				// Process substitution: not preceded by alphanumeric or quote
+				is_procsub =
+					i === 0 ||
+					(!/^[a-zA-Z0-9]$/.test(value[i - 1]) &&
+						!"\"'".includes(value[i - 1]));
 				// Inside extglob: don't format, just copy raw content
 				if (extglob_depth > 0) {
 					j = _findCmdsubEnd(value, i + 2);

--- a/src/parable.py
+++ b/src/parable.py
@@ -1079,10 +1079,10 @@ class Word(Node):
             elif (
                 _starts_with_at(value, idx, "<(") or _starts_with_at(value, idx, ">(")
             ) and not in_double:
-                # Only treat as process substitution if not preceded by alphanumeric
+                # Only treat as process substitution if not preceded by alphanumeric or quote
                 # (e.g., "i<(3)" is arithmetic comparison, not process substitution)
-                # Also don't treat as process substitution inside double quotes
-                if idx == 0 or not value[idx - 1].isalnum():
+                # Also don't treat as process substitution inside double quotes or after quotes
+                if idx == 0 or (not value[idx - 1].isalnum() and value[idx - 1] not in "\"'"):
                     has_untracked_procsub = True
                     break
                 idx += 1
@@ -1220,8 +1220,8 @@ class Word(Node):
                 and arith_depth == 0
             ):
                 # Check if this is actually a process substitution or just comparison + parens
-                # Process substitution: not preceded by alphanumeric
-                is_procsub = i == 0 or not value[i - 1].isalnum()
+                # Process substitution: not preceded by alphanumeric or quote
+                is_procsub = i == 0 or (not value[i - 1].isalnum() and value[i - 1] not in "\"'")
                 # Inside extglob: don't format, just copy raw content
                 if extglob_depth > 0:
                     j = _find_cmdsub_end(value, i + 2)

--- a/tests/parable/character-fuzzer/fuzz-2d85d976fd264aad348a02294abbf108.tests
+++ b/tests/parable/character-fuzzer/fuzz-2d85d976fd264aad348a02294abbf108.tests
@@ -1,0 +1,5 @@
+=== process substitution after escaped quote in dollar-quoted string
+$'\'>('
+---
+(command (word "''\\''>('"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `>(` and `<(` were incorrectly treated as process substitutions when they appeared immediately after quote characters
- MRE: `$'\'>('` was incorrectly parsed as `''\\''>()"` instead of `''\\''>('"`

## Test plan
- New test added to `tests/parable/character-fuzzer/fuzz-2d85d976fd264aad348a02294abbf108.tests`
- `just check` passes