### PR TITLE
fuzzer fix: preserve escaped backslash before newline in arithmetic

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1109,7 +1109,15 @@ class Word extends Node {
 	}
 
 	_stripArithLineContinuations(value) {
-		let arith_content, content, depth, first_close_idx, i, result, start;
+		let arith_content,
+			content,
+			depth,
+			first_close_idx,
+			i,
+			j,
+			num_backslashes,
+			result,
+			start;
 		result = [];
 		i = 0;
 		while (i < value.length) {
@@ -1143,8 +1151,22 @@ class Word extends Node {
 						i + 1 < value.length &&
 						value[i + 1] === "\n"
 					) {
-						// Skip backslash-newline (line continuation)
-						i += 2;
+						// Count preceding backslashes in arith_content
+						num_backslashes = 0;
+						j = arith_content.length - 1;
+						while (j >= 0 && arith_content[j] === "\\") {
+							num_backslashes += 1;
+							j -= 1;
+						}
+						// If odd number of preceding backslashes, this backslash is escaped
+						if (num_backslashes % 2 === 1) {
+							arith_content.push("\\");
+							arith_content.push("\n");
+							i += 2;
+						} else {
+							// Skip backslash-newline (line continuation)
+							i += 2;
+						}
 						if (depth === 1) {
 							first_close_idx = null;
 						}

--- a/src/parable.py
+++ b/src/parable.py
@@ -950,8 +950,20 @@ class Word(Node):
                             arith_content.append(")")
                         i += 1
                     elif value[i] == "\\" and i + 1 < len(value) and value[i + 1] == "\n":
-                        # Skip backslash-newline (line continuation)
-                        i += 2
+                        # Count preceding backslashes in arith_content
+                        num_backslashes = 0
+                        j = len(arith_content) - 1
+                        while j >= 0 and arith_content[j] == "\\":
+                            num_backslashes += 1
+                            j -= 1
+                        # If odd number of preceding backslashes, this backslash is escaped
+                        if num_backslashes % 2 == 1:
+                            arith_content.append("\\")
+                            arith_content.append("\n")
+                            i += 2
+                        else:
+                            # Skip backslash-newline (line continuation)
+                            i += 2
                         if depth == 1:
                             first_close_idx = None  # Content after first close
                     else:

--- a/tests/parable/character-fuzzer/fuzz-fadd68d7b83bfa4c2cd0be504428a55b.tests
+++ b/tests/parable/character-fuzzer/fuzz-fadd68d7b83bfa4c2cd0be504428a55b.tests
@@ -1,0 +1,6 @@
+=== backslash-newline in arithmetic expansion
+$((\\
+1))
+---
+(command (word "$((\\\\\n1))"))
+---


### PR DESCRIPTION
## Summary
- Fixed incorrect handling of escaped backslash before newline in arithmetic expressions
- When `\\<newline>` appears in `$((...))`, the first backslash escapes the second, so both backslashes and the newline should be preserved
- Previously, Parable was treating the second `\<newline>` as a line continuation and stripping it
- MRE: `$((\\<newline>1))`
  - Oracle: `(command (word "$((\\\\\n1))"))`
  - Parable (before fix): `(command (word "$((\\1))"))`
  - Parable (after fix): `(command (word "$((\\\\\n1))"))`