### PR TITLE
fuzzer fix: don't treat <( as process substitution with unclosed quote

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1576,6 +1576,15 @@ class Word extends Node {
 					// No AST node but valid procsub context - parse content on the fly
 					direction = value[i];
 					j = _findCmdsubEnd(value, i + 2);
+					// Check if we found a valid closing ) - if not, treat as literal characters
+					if (
+						j > value.length ||
+						(j > 0 && j <= value.length && value[j - 1] !== ")")
+					) {
+						result.push(value[i]);
+						i += 1;
+						continue;
+					}
 					inner = value.slice(i + 2, j - 1);
 					// Preserve leading whitespace (bash keeps it in procsub inside arithmetic)
 					leading_ws = "";

--- a/src/parable.py
+++ b/src/parable.py
@@ -1268,6 +1268,11 @@ class Word(Node):
                     # No AST node but valid procsub context - parse content on the fly
                     direction = value[i]
                     j = _find_cmdsub_end(value, i + 2)
+                    # Check if we found a valid closing ) - if not, treat as literal characters
+                    if j > len(value) or (j > 0 and j <= len(value) and value[j - 1] != ")"):
+                        result.append(value[i])
+                        i += 1
+                        continue
                     inner = _substring(value, i + 2, j - 1)
                     # Preserve leading whitespace (bash keeps it in procsub inside arithmetic)
                     leading_ws = ""

--- a/tests/parable/character-fuzzer/fuzz-ced5d0ba4488aa6ef57e9ae15d4cee5b.tests
+++ b/tests/parable/character-fuzzer/fuzz-ced5d0ba4488aa6ef57e9ae15d4cee5b.tests
@@ -1,0 +1,5 @@
+=== ansi-c quoted string with escaped quote followed by process substitution and carriage return
+$'\'<(\r'
+---
+(command (word "''\\''<('"))
+---


### PR DESCRIPTION
## Summary

Fixed a bug where `_format_command_substitutions` was incorrectly treating `<(` as a process substitution when it appeared in expanded ANSI-C strings with unclosed quotes.

MRE: `$'\\\\'<(\\r'`

When the ANSI-C expansion produces a string like `''\\\\''<(\r'` that ends with an unclosed single quote, `_find_cmdsub_end` doesn't find a matching `)` and returns a position past the end of the string. The fix checks if a valid closing `)` was found before treating `<(` as a process substitution.