### PR TITLE
fuzzer fix: preserve escaped newline in heredoc with backslash continuation in process substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8395,6 +8395,7 @@ class Parser {
 			depth,
 			esc,
 			esc_val,
+			had_continuation,
 			heredoc_end,
 			i,
 			line,
@@ -8722,10 +8723,19 @@ class Parser {
 				// Only match if delimiter is exact or followed by whitespace/punctuation
 				rest = check_line.slice(delimiter.length);
 				// In process sub, accept: exact match, whitespace only, or whitespace + )
+				// Also accept if there was backslash-newline continuation (line was joined)
+				// In that case, end heredoc after the original line with escaped newline preserved
+				had_continuation =
+					check_line !==
+					this.source.slice(
+						line_start,
+						Math.min(line_start + check_line.length, this.length),
+					);
 				if (
 					rest === "" ||
 					rest.trimStart() === "" ||
-					rest.trimStart().startsWith(")")
+					rest.trimStart().startsWith(")") ||
+					had_continuation
 				) {
 					// Adjust line_end to point just past the delimiter, not the whole line
 					// This allows remaining content after delimiter to be parsed

--- a/src/parable.py
+++ b/src/parable.py
@@ -7279,7 +7279,17 @@ class Parser:
                 # Only match if delimiter is exact or followed by whitespace/punctuation
                 rest = check_line[len(delimiter) :]
                 # In process sub, accept: exact match, whitespace only, or whitespace + )
-                if rest == "" or rest.lstrip() == "" or rest.lstrip().startswith(")"):
+                # Also accept if there was backslash-newline continuation (line was joined)
+                # In that case, end heredoc after the original line with escaped newline preserved
+                had_continuation = check_line != _substring(
+                    self.source, line_start, min(line_start + len(check_line), self.length)
+                )
+                if (
+                    rest == ""
+                    or rest.lstrip() == ""
+                    or rest.lstrip().startswith(")")
+                    or had_continuation
+                ):
                     # Adjust line_end to point just past the delimiter, not the whole line
                     # This allows remaining content after delimiter to be parsed
                     tabs_stripped = len(line) - len(check_line)

--- a/tests/parable/character-fuzzer/fuzz-186ac01a6d1191177ea96d0c13414f3f.tests
+++ b/tests/parable/character-fuzzer/fuzz-186ac01a6d1191177ea96d0c13414f3f.tests
@@ -1,0 +1,7 @@
+=== backslash-newline in heredoc within process substitution
+<(<<a
+a\
+[)
+---
+(command (word "<(<<a\na\n\n[)"))
+---


### PR DESCRIPTION
## Summary
- Fixed heredoc parsing to correctly preserve escaped newlines when backslash-newline continuation occurs in process substitutions at EOF
- When a heredoc line with backslash-newline is joined and starts with the delimiter in a process substitution at EOF, the heredoc now correctly ends with the escaped newline preserved as a literal newline
- Test: `<(<<a\na\\\n[)` now correctly produces `<(<<a\na\n\n[)` instead of `<(<<a\na[\na\n)`