### PR TITLE
fuzzer fix: preserve heredoc newlines in process substitutions inside conditionals

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1809,7 +1809,13 @@ class Word extends Node {
 	}
 
 	_normalizeExtglobWhitespace(value) {
-		let current_part, depth, i, pattern_parts, prefix_char, result;
+		let current_part,
+			depth,
+			i,
+			part_content,
+			pattern_parts,
+			prefix_char,
+			result;
 		result = [];
 		i = 0;
 		while (i < value.length) {
@@ -1839,14 +1845,26 @@ class Word extends Node {
 							depth -= 1;
 							if (depth === 0) {
 								// End of pattern
-								pattern_parts.push(current_part.join("").trim());
+								part_content = current_part.join("");
+								// Don't strip if this looks like a process substitution with heredoc
+								if (part_content.includes("<<")) {
+									pattern_parts.push(part_content);
+								} else {
+									pattern_parts.push(part_content.trim());
+								}
 								break;
 							}
 							current_part.push(value[i]);
 							i += 1;
 						} else if (value[i] === "|" && depth === 1) {
 							// Top-level pipe separator
-							pattern_parts.push(current_part.join("").trim());
+							part_content = current_part.join("");
+							// Don't strip if this looks like a process substitution with heredoc
+							if (part_content.includes("<<")) {
+								pattern_parts.push(part_content);
+							} else {
+								pattern_parts.push(part_content.trim());
+							}
 							current_part = [];
 							i += 1;
 						} else {

--- a/src/parable.py
+++ b/src/parable.py
@@ -1467,13 +1467,23 @@ class Word(Node):
                             depth -= 1
                             if depth == 0:
                                 # End of pattern
-                                pattern_parts.append("".join(current_part).strip())
+                                part_content = "".join(current_part)
+                                # Don't strip if this looks like a process substitution with heredoc
+                                if "<<" in part_content:
+                                    pattern_parts.append(part_content)
+                                else:
+                                    pattern_parts.append(part_content.strip())
                                 break
                             current_part.append(value[i])
                             i += 1
                         elif value[i] == "|" and depth == 1:
                             # Top-level pipe separator
-                            pattern_parts.append("".join(current_part).strip())
+                            part_content = "".join(current_part)
+                            # Don't strip if this looks like a process substitution with heredoc
+                            if "<<" in part_content:
+                                pattern_parts.append(part_content)
+                            else:
+                                pattern_parts.append(part_content.strip())
                             current_part = []
                             i += 1
                         else:

--- a/tests/parable/character-fuzzer/fuzz-98c6ab59e959925f1b1103448ce5c4e1.tests
+++ b/tests/parable/character-fuzzer/fuzz-98c6ab59e959925f1b1103448ce5c4e1.tests
@@ -1,0 +1,7 @@
+=== heredoc in process substitution inside conditional missing final newline
+[[ <(<<x) ]]
+---
+(cond (cond-unary "-n" (cond-term "<(<<x
+x
+)")))
+---


### PR DESCRIPTION
## Summary

Fixed a bug where heredocs inside process substitutions within conditional expressions were having their trailing newlines incorrectly stripped.

**Bug:** The `_normalize_extglob_whitespace()` function was calling `.strip()` on the content of all `<(...)` and `>(...)` patterns, including process substitutions with heredocs. This removed significant newlines that are part of the heredoc formatting.

**Fix:** Modified `_normalize_extglob_whitespace()` to detect content containing heredoc operators (`<<`) and preserve it without stripping whitespace.

**MRE:** `[[ <(<<x) ]]`

New test added to `tests/parable/character-fuzzer/fuzz-98c6ab59e959925f1b1103448ce5c4e1.tests`