### PR TITLE
fuzzer fix: validate coproc name as identifier

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-2b090db1d81b07d38e370ac7399afa8c.tests
+++ b/tests/parable/character-fuzzer/fuzz-2b090db1d81b07d38e370ac7399afa8c.tests
@@ -1,0 +1,5 @@
+=== coproc with invalid name followed by arithmetic expression
+coproc +(())
+---
+(coproc "COPROC" (command (word "+(())")))
+---


### PR DESCRIPTION
## Summary
- Fixed coproc parser to validate that the name is a valid bash identifier before extracting it
- Invalid identifiers (like `+` in `coproc +(())`) now correctly parse the entire string as a command
- MRE: `coproc +(())` now parses as `(coproc "COPROC" (command (word "+(())")))` instead of `(coproc "+" (arith (word "")))`