### PR TITLE
fuzzer fix: don't add spaces to operators in process substitution without semicolons

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1322,6 +1322,7 @@ class Word extends Node {
 			formatted,
 			formatted_inner,
 			has_brace_cmdsub,
+			has_semicolon,
 			has_untracked_cmdsub,
 			has_untracked_procsub,
 			i,
@@ -1645,7 +1646,26 @@ class Word extends Node {
 						// Starts with subshell and formatting would change it - preserve original
 						result.push(`${direction}(${raw_stripped})`);
 					} else {
-						result.push(`${direction}(${formatted})`);
+						// Check if list contains semicolon operators
+						has_semicolon = false;
+						if (node.command.kind === "list" && node.command.parts) {
+							for (p of node.command.parts) {
+								if (p.kind === "operator" && [";", "\n"].includes(p.op)) {
+									has_semicolon = true;
+									break;
+								}
+							}
+						}
+						// For lists without newlines or semicolons, preserve raw content
+						if (
+							node.command.kind === "list" &&
+							!raw_stripped.includes("\n") &&
+							!has_semicolon
+						) {
+							result.push(`${direction}(${raw_stripped})`);
+						} else {
+							result.push(`${direction}(${formatted})`);
+						}
 					}
 					procsub_idx += 1;
 					i = j;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1306,7 +1306,22 @@ class Word(Node):
                         # Starts with subshell and formatting would change it - preserve original
                         result.append(direction + "(" + raw_stripped + ")")
                     else:
-                        result.append(direction + "(" + formatted + ")")
+                        # Check if list contains semicolon operators
+                        has_semicolon = False
+                        if node.command.kind == "list" and node.command.parts:
+                            for p in node.command.parts:
+                                if p.kind == "operator" and p.op in (";", "\n"):
+                                    has_semicolon = True
+                                    break
+                        # For lists without newlines or semicolons, preserve raw content
+                        if (
+                            node.command.kind == "list"
+                            and "\n" not in raw_stripped
+                            and not has_semicolon
+                        ):
+                            result.append(direction + "(" + raw_stripped + ")")
+                        else:
+                            result.append(direction + "(" + formatted + ")")
                     procsub_idx += 1
                     i = j
                 elif is_procsub and len(self.parts):

--- a/tests/parable/character-fuzzer/fuzz-657827b12398297314ccfa382f9c37db.tests
+++ b/tests/parable/character-fuzzer/fuzz-657827b12398297314ccfa382f9c37db.tests
@@ -1,0 +1,5 @@
+=== don't add spaces to && inside process substitution with arithmetic
+$>((1)&&2)
+---
+(command (word "$>((1)&&2)"))
+---


### PR DESCRIPTION
Fixes process substitution formatting to preserve original spacing for operators (&&, ||, &) when there are no semicolons in the list.

MRE: $>((1)&&2)

Before: (command (word "$>((1) && 2)"))
After: (command (word "$>((1)&&2)"))

Test added: tests/parable/character-fuzzer/fuzz-657827b12398297314ccfa382f9c37db.tests