### PR TITLE
fuzzer fix: strip $'...' quotes in invalid param expansions in dquotes

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-838b7aee482acfa46ebbe561ce8b8583.tests
+++ b/tests/parable/character-fuzzer/fuzz-838b7aee482acfa46ebbe561ce8b8583.tests
@@ -1,0 +1,5 @@
+=== single-quoted string inside parameter expansion in double quotes
+"${%$'b'}"
+---
+(command (word "\"${%b}\""))
+---


### PR DESCRIPTION
## Summary
- Fixed handling of $'...' ANSI-C quotes inside parameter expansions within double quotes
- Pattern detection now properly distinguishes between valid pattern syntax (e.g., ${var%pattern}) and invalid syntax (e.g., ${%...})
- MRE: `"${%$'b'}"` now correctly outputs `"${%b}"` instead of `"${%'b'}"`

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-838b7aee482acfa46ebbe561ce8b8583.tests`
- [ ] `just check` passes