### PR TITLE
fuzzer fix: handle ANSI-C quotes in command substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -5674,6 +5674,28 @@ class Parser {
 		arith_depth = 0;
 		while (!this.atEnd() && depth > 0) {
 			c = this.peek();
+			// ANSI-C quoted string $'...' - handle escape sequences
+			if (
+				c === "$" &&
+				this.pos + 1 < this.length &&
+				this.source[this.pos + 1] === "'"
+			) {
+				this.advance();
+				this.advance();
+				while (!this.atEnd()) {
+					if (this.peek() === "'") {
+						this.advance();
+						break;
+					}
+					if (this.peek() === "\\" && this.pos + 1 < this.length) {
+						this.advance();
+						this.advance();
+					} else {
+						this.advance();
+					}
+				}
+				continue;
+			}
 			// Single-quoted string - no special chars inside
 			if (c === "'") {
 				this.advance();

--- a/src/parable.py
+++ b/src/parable.py
@@ -4743,6 +4743,21 @@ class Parser:
         while not self.at_end() and depth > 0:
             c = self.peek()
 
+            # ANSI-C quoted string $'...' - handle escape sequences
+            if c == "$" and self.pos + 1 < self.length and self.source[self.pos + 1] == "'":
+                self.advance()  # $
+                self.advance()  # '
+                while not self.at_end():
+                    if self.peek() == "'":
+                        self.advance()
+                        break
+                    if self.peek() == "\\" and self.pos + 1 < self.length:
+                        self.advance()  # backslash
+                        self.advance()  # escaped char
+                    else:
+                        self.advance()
+                continue
+
             # Single-quoted string - no special chars inside
             if c == "'":
                 self.advance()


### PR DESCRIPTION
## Summary
- Fixed handling of ANSI-C quoted strings ($'...') inside command substitutions
- When looking for the closing `)` of a `$(...)` command substitution, the parser now correctly handles ANSI-C quotes where `\'` is an escaped quote, not a closing quote
- This prevents the parser from incorrectly identifying quote boundaries inside command substitutions

## Test plan
- Fuzzer found no discrepancies after this fix (tested with 50,000 iterations)
- `just check` passes