### PR TITLE
fuzzer fix: add spaces around operators in process substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1322,7 +1322,7 @@ class Word extends Node {
 			formatted,
 			formatted_inner,
 			has_brace_cmdsub,
-			has_semicolon,
+			has_operator_needing_spaces,
 			has_untracked_cmdsub,
 			has_untracked_procsub,
 			i,
@@ -1646,21 +1646,24 @@ class Word extends Node {
 						// Starts with subshell and formatting would change it - preserve original
 						result.push(`${direction}(${raw_stripped})`);
 					} else {
-						// Check if list contains semicolon operators
-						has_semicolon = false;
+						// Check if list contains operators that need formatting
+						has_operator_needing_spaces = false;
 						if (node.command.kind === "list" && node.command.parts) {
 							for (p of node.command.parts) {
-								if (p.kind === "operator" && [";", "\n"].includes(p.op)) {
-									has_semicolon = true;
+								if (
+									p.kind === "operator" &&
+									[";", "\n", "&&", "||", "&"].includes(p.op)
+								) {
+									has_operator_needing_spaces = true;
 									break;
 								}
 							}
 						}
-						// For lists without newlines or semicolons, preserve raw content
+						// For lists without newlines or operators that need spaces, preserve raw content
 						if (
 							node.command.kind === "list" &&
 							!raw_stripped.includes("\n") &&
-							!has_semicolon
+							!has_operator_needing_spaces
 						) {
 							result.push(`${direction}(${raw_stripped})`);
 						} else {

--- a/src/parable.py
+++ b/src/parable.py
@@ -1306,18 +1306,18 @@ class Word(Node):
                         # Starts with subshell and formatting would change it - preserve original
                         result.append(direction + "(" + raw_stripped + ")")
                     else:
-                        # Check if list contains semicolon operators
-                        has_semicolon = False
+                        # Check if list contains operators that need formatting
+                        has_operator_needing_spaces = False
                         if node.command.kind == "list" and node.command.parts:
                             for p in node.command.parts:
-                                if p.kind == "operator" and p.op in (";", "\n"):
-                                    has_semicolon = True
+                                if p.kind == "operator" and p.op in (";", "\n", "&&", "||", "&"):
+                                    has_operator_needing_spaces = True
                                     break
-                        # For lists without newlines or semicolons, preserve raw content
+                        # For lists without newlines or operators that need spaces, preserve raw content
                         if (
                             node.command.kind == "list"
                             and "\n" not in raw_stripped
-                            and not has_semicolon
+                            and not has_operator_needing_spaces
                         ):
                             result.append(direction + "(" + raw_stripped + ")")
                         else:

--- a/tests/parable/character-fuzzer/fuzz-11adf46315c9402ecf834c6deb6046f3.tests
+++ b/tests/parable/character-fuzzer/fuzz-11adf46315c9402ecf834c6deb6046f3.tests
@@ -1,0 +1,5 @@
+=== process substitution with && operator
+<(a&&b)
+---
+(command (word "<(a && b)"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where operators like `&&`, `||`, and `&` inside process substitutions were not formatted with spaces
- MRE: `<(a&&b)` should format as `<(a && b)` but was being preserved as `<(a&&b)`
- The fix checks for operators that need spacing and uses formatted output instead of raw content

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-11adf46315c9402ecf834c6deb6046f3.tests`
- [ ] `just check` passes