### PR TITLE
fuzzer fix: add spaces in process substitution with operators

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1333,7 +1333,6 @@ class Word extends Node {
 			formatted,
 			formatted_inner,
 			has_brace_cmdsub,
-			has_operator_needing_spaces,
 			has_untracked_cmdsub,
 			has_untracked_procsub,
 			i,
@@ -1657,29 +1656,7 @@ class Word extends Node {
 						// Starts with subshell and formatting would change it - preserve original
 						result.push(`${direction}(${raw_stripped})`);
 					} else {
-						// Check if list contains operators that need formatting
-						has_operator_needing_spaces = false;
-						if (node.command.kind === "list" && node.command.parts) {
-							for (p of node.command.parts) {
-								if (
-									p.kind === "operator" &&
-									[";", "\n", "&&", "||", "&"].includes(p.op)
-								) {
-									has_operator_needing_spaces = true;
-									break;
-								}
-							}
-						}
-						// For lists without newlines or operators that need spaces, preserve raw content
-						if (
-							node.command.kind === "list" &&
-							!raw_stripped.includes("\n") &&
-							!has_operator_needing_spaces
-						) {
-							result.push(`${direction}(${raw_stripped})`);
-						} else {
-							result.push(`${direction}(${formatted})`);
-						}
+						result.push(`${direction}(${formatted})`);
 					}
 					procsub_idx += 1;
 					i = j;

--- a/src/parable.py
+++ b/src/parable.py
@@ -1315,22 +1315,7 @@ class Word(Node):
                         # Starts with subshell and formatting would change it - preserve original
                         result.append(direction + "(" + raw_stripped + ")")
                     else:
-                        # Check if list contains operators that need formatting
-                        has_operator_needing_spaces = False
-                        if node.command.kind == "list" and node.command.parts:
-                            for p in node.command.parts:
-                                if p.kind == "operator" and p.op in (";", "\n", "&&", "||", "&"):
-                                    has_operator_needing_spaces = True
-                                    break
-                        # For lists without newlines or operators that need spaces, preserve raw content
-                        if (
-                            node.command.kind == "list"
-                            and "\n" not in raw_stripped
-                            and not has_operator_needing_spaces
-                        ):
-                            result.append(direction + "(" + raw_stripped + ")")
-                        else:
-                            result.append(direction + "(" + formatted + ")")
+                        result.append(direction + "(" + formatted + ")")
                     procsub_idx += 1
                     i = j
                 elif is_procsub and len(self.parts):

--- a/tests/parable/character-fuzzer/fuzz-fda5c32dbdd5b0d71846e6645e7c2c3f.tests
+++ b/tests/parable/character-fuzzer/fuzz-fda5c32dbdd5b0d71846e6645e7c2c3f.tests
@@ -1,0 +1,5 @@
+=== process substitution with background and redirect missing spaces
+>(a& >b)
+---
+(command (word ">(a & > b)"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where Parable wasn't adding spaces around operators and redirects inside process substitutions
- MRE: `>(a& >b)` was formatted as `>(a& >b)` instead of `>(a & > b)`

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-fda5c32dbdd5b0d71846e6645e7c2c3f.tests`
- [ ] `just check` passes