### PR TITLE
fuzzer fix: handle process substitution operators in dquoted conditionals

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1856,17 +1856,27 @@ class Word extends Node {
 		let current_part,
 			depth,
 			i,
+			in_double_quote,
 			part_content,
 			pattern_parts,
 			prefix_char,
 			result;
 		result = [];
 		i = 0;
+		in_double_quote = false;
 		while (i < value.length) {
+			// Track double-quote state
+			if (value[i] === '"') {
+				in_double_quote = !in_double_quote;
+				result.push(value[i]);
+				i += 1;
+				continue;
+			}
 			// Check for >( or <( pattern (process substitution-like in regex)
+			// Only process these patterns when NOT inside double quotes
 			if (i + 1 < value.length && value[i + 1] === "(") {
 				prefix_char = value[i];
-				if ("><".includes(prefix_char)) {
+				if ("><".includes(prefix_char) && !in_double_quote) {
 					// Found pattern start
 					result.push(prefix_char);
 					result.push("(");

--- a/src/parable.py
+++ b/src/parable.py
@@ -1470,11 +1470,19 @@ class Word(Node):
         """Normalize whitespace around | in >() and <() patterns for regex contexts."""
         result = []
         i = 0
+        in_double_quote = False
         while i < len(value):
+            # Track double-quote state
+            if value[i] == '"':
+                in_double_quote = not in_double_quote
+                result.append(value[i])
+                i += 1
+                continue
             # Check for >( or <( pattern (process substitution-like in regex)
+            # Only process these patterns when NOT inside double quotes
             if i + 1 < len(value) and value[i + 1] == "(":
                 prefix_char = value[i]
-                if prefix_char in "><":
+                if prefix_char in "><" and not in_double_quote:
                     # Found pattern start
                     result.append(prefix_char)
                     result.append("(")

--- a/tests/parable/character-fuzzer/fuzz-b447402908244c125a7628de55d1f88f.tests
+++ b/tests/parable/character-fuzzer/fuzz-b447402908244c125a7628de55d1f88f.tests
@@ -1,0 +1,5 @@
+=== process substitution operator in double-quoted conditional
+[[ "<(x" ]]
+---
+(cond (cond-unary "-n" (cond-term ""<(x"")))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug where process substitution operators `<(` and `>(` inside double-quoted strings in conditional expressions were incorrectly processed by `_normalize_extglob_whitespace`, causing text after the `(` to be truncated
- MRE: `[[ "<(x" ]]` was producing `"<()"` instead of `"<(x"`
- The fix adds double-quote tracking to `_normalize_extglob_whitespace` to skip pattern normalization when inside quotes