### PR TITLE
fuzzer fix: handle escaped $ before 93475 in locale strings

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -678,7 +678,6 @@ class Word extends Node {
 			i,
 			in_double_quote,
 			in_single_quote,
-			j,
 			result;
 		result = [];
 		i = 0;
@@ -758,12 +757,7 @@ class Word extends Node {
 				!bracket_in_double_quote
 			) {
 				// Count consecutive $ chars ending at i to check for $$ (PID param)
-				dollar_count = 1;
-				j = i - 1;
-				while (j >= 0 && value[j] === "$") {
-					dollar_count += 1;
-					j -= 1;
-				}
+				dollar_count = 1 + _countConsecutiveDollarsBefore(value, i);
 				if (dollar_count % 2 === 1) {
 					// Odd count: locale string $"..." - strip the $ and enter double quote
 					result.push('"');

--- a/src/parable.py
+++ b/src/parable.py
@@ -659,11 +659,7 @@ class Word(Node):
                 and not bracket_in_double_quote
             ):
                 # Count consecutive $ chars ending at i to check for $$ (PID param)
-                dollar_count = 1
-                j = i - 1
-                while j >= 0 and value[j] == "$":
-                    dollar_count += 1
-                    j -= 1
+                dollar_count = 1 + _count_consecutive_dollars_before(value, i)
                 if dollar_count % 2 == 1:
                     # Odd count: locale string $"..." - strip the $ and enter double quote
                     result.append('"')

--- a/tests/parable/character-fuzzer/fuzz-65fda3dc859ea794c8526916636b2a67.tests
+++ b/tests/parable/character-fuzzer/fuzz-65fda3dc859ea794c8526916636b2a67.tests
@@ -1,0 +1,5 @@
+=== backslash followed by $$ before double quotes
+\$$""
+---
+(command (word "\\$\"\""))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where Parable incorrectly counted consecutive `$` characters when determining if `$"` is a locale string
- MRE: `\$$""`
- The bug occurred because the manual dollar counting didn't account for escaped dollars (preceded by backslash)
- Fixed by using the existing `_count_consecutive_dollars_before()` helper function which properly handles escaped dollars

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-65fda3dc859ea794c8526916636b2a67.tests`
- [x] `just check` passes