### PR TITLE
fuzzer fix: preserve newline before ) in heredoc with pipeline in command substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3698,6 +3698,21 @@ function _formatCmdsubNode(
 						break;
 					}
 				}
+			} else if (p.kind === "pipeline") {
+				// Check commands within the pipeline
+				for (cmd of p.commands) {
+					if (cmd.kind === "command" && cmd.redirects) {
+						for (r of cmd.redirects) {
+							if (r.kind === "heredoc") {
+								has_heredoc = true;
+								break;
+							}
+						}
+					}
+					if (has_heredoc) {
+						break;
+					}
+				}
 			}
 		}
 		// Join commands with operators

--- a/src/parable.py
+++ b/src/parable.py
@@ -3135,6 +3135,16 @@ def _format_cmdsub_node(
                     if r.kind == "heredoc":
                         has_heredoc = True
                         break
+            elif p.kind == "pipeline":
+                # Check commands within the pipeline
+                for cmd in p.commands:
+                    if cmd.kind == "command" and cmd.redirects:
+                        for r in cmd.redirects:
+                            if r.kind == "heredoc":
+                                has_heredoc = True
+                                break
+                    if has_heredoc:
+                        break
         # Join commands with operators
         result = []
         skipped_semi = False

--- a/tests/parable/character-fuzzer/fuzz-d281580e0e0544ff296a5070535b4249.tests
+++ b/tests/parable/character-fuzzer/fuzz-d281580e0e0544ff296a5070535b4249.tests
@@ -1,0 +1,6 @@
+=== unterminated heredoc in command substitution with text after closing paren
+export "$(ec
+ho ${key} | tr [:lower:] [:uppe<<r:])=${p_key#*=}"
+---
+(command (word "export") (word "\"$(ec\nho ${key} | tr [:lower:] [:uppe <<r:]\nr:]\n)=${p_key#*=}\""))
+---


### PR DESCRIPTION
## Summary
- Fixes formatting of heredocs in pipelines within command substitutions when the pipeline is preceded by a newline
- MRE: `"$(x\na|b<<c)d"` - bash-oracle produces `c\n)` but parable was producing `c)`
- Root cause: list formatting code only checked for heredocs in direct commands, not in pipelines, causing trailing newlines to be stripped
- Fix: extend heredoc check to also look inside pipeline commands when determining whether to preserve trailing newlines

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-d281580e0e0544ff296a5070535b4249.tests`
- [x] `just check` passes