### PR TITLE
fuzzer fix: handle <( inside double quotes in conditionals

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1833,15 +1833,25 @@ class Word extends Node {
 		let current_part,
 			depth,
 			i,
+			in_double_quote,
 			part_content,
 			pattern_parts,
 			prefix_char,
 			result;
 		result = [];
 		i = 0;
+		in_double_quote = false;
 		while (i < value.length) {
+			// Track double quotes
+			if (value[i] === '"') {
+				in_double_quote = !in_double_quote;
+				result.push(value[i]);
+				i += 1;
+				continue;
+			}
 			// Check for >( or <( pattern (process substitution-like in regex)
-			if (i + 1 < value.length && value[i + 1] === "(") {
+			// But not inside double quotes
+			if (i + 1 < value.length && value[i + 1] === "(" && !in_double_quote) {
 				prefix_char = value[i];
 				if ("><".includes(prefix_char)) {
 					// Found pattern start

--- a/src/parable.py
+++ b/src/parable.py
@@ -1455,9 +1455,17 @@ class Word(Node):
         """Normalize whitespace around | in >() and <() patterns for regex contexts."""
         result = []
         i = 0
+        in_double_quote = False
         while i < len(value):
+            # Track double quotes
+            if value[i] == '"':
+                in_double_quote = not in_double_quote
+                result.append(value[i])
+                i += 1
+                continue
             # Check for >( or <( pattern (process substitution-like in regex)
-            if i + 1 < len(value) and value[i + 1] == "(":
+            # But not inside double quotes
+            if i + 1 < len(value) and value[i + 1] == "(" and not in_double_quote:
                 prefix_char = value[i]
                 if prefix_char in "><":
                     # Found pattern start

--- a/tests/parable/character-fuzzer/fuzz-6082bfe35473ff12b5ffa6736f7bfcb2.tests
+++ b/tests/parable/character-fuzzer/fuzz-6082bfe35473ff12b5ffa6736f7bfcb2.tests
@@ -1,0 +1,5 @@
+=== process substitution in dquotes inside conditional
+[[ "<(" ]]
+---
+(cond (cond-unary "-n" (cond-term ""<("")))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `<(` inside double quotes in conditional expressions was incorrectly treated as a process substitution pattern
- The MRE is `[[ "<(" ]]` which should treat `<(` as literal text inside the double quotes

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-6082bfe35473ff12b5ffa6736f7bfcb2.tests`
- [x] `just check` passes