### PR TITLE
fuzzer fix: handle <&- in command substitution with pipe

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4029,7 +4029,7 @@ function _formatCmdsubNode(
 }
 
 function _formatRedirect(r, compact, heredoc_op_only) {
-	let after_amp, delim, is_literal_fd, op, target;
+	let after_amp, delim, is_literal_fd, op, target, was_input_close;
 	if (compact == null) {
 		compact = false;
 	}
@@ -4074,7 +4074,9 @@ function _formatRedirect(r, compact, heredoc_op_only) {
 	// For fd duplication (target starts with &), handle normalization
 	if (target.startsWith("&")) {
 		// Normalize N<&- to N>&- (close always uses >)
+		was_input_close = false;
 		if (target === "&-" && op.endsWith("<")) {
+			was_input_close = true;
 			op = `${op.slice(0, op.length - 1)}>`;
 		}
 		// Check if target is a literal fd (digit or -)
@@ -4085,7 +4087,8 @@ function _formatRedirect(r, compact, heredoc_op_only) {
 		if (is_literal_fd) {
 			// Add default fd for bare >&N or <&N
 			if (op === ">") {
-				op = "1>";
+				// If we normalized from <&-, use fd 0 (stdin), otherwise fd 1 (stdout)
+				op = was_input_close ? "0>" : "1>";
 			} else if (op === "<") {
 				op = "0<";
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -3445,7 +3445,9 @@ def _format_redirect(
     # For fd duplication (target starts with &), handle normalization
     if target.startswith("&"):
         # Normalize N<&- to N>&- (close always uses >)
+        was_input_close = False
         if target == "&-" and op.endswith("<"):
+            was_input_close = True
             op = _substring(op, 0, len(op) - 1) + ">"
         # Check if target is a literal fd (digit or -)
         after_amp = _substring(target, 1, len(target))
@@ -3453,7 +3455,8 @@ def _format_redirect(
         if is_literal_fd:
             # Add default fd for bare >&N or <&N
             if op == ">":
-                op = "1>"
+                # If we normalized from <&-, use fd 0 (stdin), otherwise fd 1 (stdout)
+                op = "0>" if was_input_close else "1>"
             elif op == "<":
                 op = "0<"
         else:

--- a/tests/parable/character-fuzzer/fuzz-7231c71d2ae0c0597b8c0a7e6d1230a8.tests
+++ b/tests/parable/character-fuzzer/fuzz-7231c71d2ae0c0597b8c0a7e6d1230a8.tests
@@ -1,0 +1,5 @@
+=== redirect <&- in command substitution with pipe should close fd 0 not fd 1
+a=$(a | ((a) <&- | a))
+---
+(command (word "a=$(a | ( ( a ) 0>&- | a ))"))
+---

--- a/tools/fuzzer/discrepancy-input.txt
+++ b/tools/fuzzer/discrepancy-input.txt
@@ -1,0 +1,961 @@
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+if (( $UID == 0 )); then
+	echo "new-exp.tests: the test suite should not be run as root" >&2
+fi
+
+# must do this because posix mode causes process substitution to be disabled
+# and flagged as a syntax error, which causes the shell to exit
+set +o posix
+
+expect()
+{
+        echo expect "$@"
+}
+
+HOME=/usr/homes/chet	# to make the check against new-exp.right work
+expect '<foo bar>'
+recho "${undef-"foo bar"}"	# should be foo bar
+expect '<foo>'
+recho "${und="foo"}"		# should be foo
+
+expect "<$HOME>"
+recho ${HOME-"}"}
+expect "<$HOME>"
+recho "${HOME-'}'}"
+expect "<$HOME>"
+recho "${HOME-"}"}"
+
+expect $0: 'HOME: }: syntax error: operand expected (error token is "}")'
+recho "${HOME:`echo `}"	# should be a math error -- bad substring substitution
+
+expect unset
+_ENV=oops
+x=${_ENV[(_$-=0)+(_=1)-_${-%%*i*}]}
+echo ${x:-unset}
+
+expect "<$HOME>"
+recho ${HOME}
+expect "<$HOME>"
+recho ${HOME:-`echo `}
+expect "<$HOME>"
+recho ${HOME:-`echo "}"`}
+expect "<$HOME>"
+recho "${HOME:-`echo "}"`}"
+expect "<$HOME>"
+recho "$(echo "${HOME}")"
+expect "<$HOME>"
+recho "$(echo "$(echo ${HOME})")"
+expect "<$HOME>"
+recho "$(echo "$(echo "${HOME}")")"
+
+P=*@*
+expect '<*@>'
+recho "${P%"*"}"	#
+expect '<*@>'
+recho "${P%'*'}"	#
+expect '<@*>'
+recho "${P#\*}"		# should be @*
+
+expect '<)>'
+recho "$(echo ")")"	# should be )
+expect '<")">'"
+recho "$(echo "\")\"")"	# should be ")"
+
+foo='abcd   '
+expect '<-abcd> <->'
+recho -${foo}-		# should be -abcd -
+expect '<-abcd> <->'
+recho -${foo% *}-	# should be -abcd -
+expect '<-abcd->'
+recho -${foo%% *}-	# should be -abcd-
+
+foo=bar
+expect '<bar foo>'
+echo -n $foo' ' ; echo foo
+
+expect '<bar foo>'
+echo -n $foo" " ; echo foo
+
+expect '<bar foo>'
+echo -n "$foo " ; echo foo
+
+unset foo
+
+expect '<>">'
+recho ">${foo}`echo hi`"
+
+expect "<$(echo /bin/sh)>"
+recho "<$(echo /bin/sh)>"
+
+# tests of quoting and CTLESC in new patterns
+${THIS_SH} ./new-exp1.sub
+
+${THIS_SH} ./new-exp2.sub
+
+# old-style command substitution parsing compatibility tests -- post Bush 2001 bash-2.05a-beta1 change
+recho `echo \`echo hi\``
+
+recho `echo  "\`echo hi\`"`
+
+# More tests of old-style command substitution parsing in different
+# contexts
+expect '<-foobar->'
+foo=bar
+recho -`echo \\\"${foo}\\\"`-
+recho -`echo \"\${foo}\"`-
+
+${THIS_SH} ./new-exp3a.sub
+
+unset var
+var=$'\x21\x21'	# =!!
+expect '<!!>'
+echo "<$var>"
+
+expect '<\x21\x21>'
+echo "<$(echo $var)>"
+
+expect '<\x21\x21>'
+echo "<`echo $var`>"
+
+set --
+
+expect '<>'
+recho "$@"
+
+expect '<>'
+echo $(echo $@)
+
+expect '<>">'
+echo "$(echo $@)"
+
+expect '<>">'
+set ''
+recho "${@:-foo}"
+
+expect nothing
+x=
+echo ${x#[}	# an unsatisfied bracket expression
+
+# test backslash escaping with P modifier
+expect '<hello%world>'
+v=hello%world
+recho "${v@P}"
+
+v='hello%world%again'
+expect '<hello%world%again>'
+recho "${v@P}"
+
+# more tests of backslash escaping with P modifier
+expect '<%>'
+recho "${v/hello*again/%}${v/hello*again/%}"
+
+# this had better be the same, since backslashes don't quote %
+expect '<%>'
+recho "${v/hello*again/\%}${v/hello*again/\%}"
+
+# backslashes quote % in printf formats, and \% is removed by quote removal
+printf '<%s%s>\n' "${v/hello*again/\%}" "${v/hello*again/\%}"
+
+# more tests of command and process substitution
+expect '<-->'
+recho -$(echo '')-
+
+expect '<-->'
+recho -$(echo "")-
+
+expect '<-->'
+recho `echo ''`
+
+expect '<-->'
+recho `echo ""`
+
+# COMMAND SUBSTITION AND PROCESS SUBSTITUTION
+
+s=($(echo one; echo two))
+expect '<one> <two>'
+recho ${s[@]}
+
+s=(`echo one; echo two`)
+expect '<one> <two>'
+recho ${s[@]}
+
+expect '< one two three >'
+a=($(echo one; echo two; echo three))
+printf '< %s >\n' "${a[*]}"
+
+s=$(echo '')
+expect '<>'
+recho $s
+
+s=$(echo "")
+expect '<>'
+recho $s
+
+s=`echo ''`
+expect '<>'
+recho $s
+
+s=`echo ""`
+expect '<>'
+recho $s
+
+unset v
+
+expect '<foo bar>'
+recho ${undef-$(echo "foo bar")}
+
+expect '<foo bar>'
+recho ${undef-`echo "foo bar"`}
+
+expect '<foo bar>'
+recho "${undef-$(echo "foo bar")}"
+
+expect '<foo bar>'
+recho "${undef-`echo "foo bar"`}"
+
+expect unset
+recho ${v:-$(echo ${x-unset})}
+
+# MORE PROCESS SUBSTITUTION TESTS
+
+# These tests check for proper return values and exit status codes for
+# process substitution
+# Test ksh's <(...) and >(...) process substitution -- this is processed
+# at the same stage as $(...) command substitution, so these tests go here
+
+if ${THIS_SH} -c '(( 1 ))' 2>/dev/null ; then
+	expect '<A>'
+	recho <(echo A)
+fi
+
+if ${THIS_SH} -c '(( 1 ))' 2>/dev/null ; then
+	expect '<A>'
+	cat <(echo A)
+fi
+
+if ${THIS_SH} -c '(( 1 ))' 2>/dev/null ; then
+	true | cat <(echo B)
+fi
+
+# make sure process substitution works in an environment without fifos
+if ${THIS_SH} -c '(( 1 ))' 2>/dev/null ; then
+	${THIS_SH} +H ./new-exp3b.sub
+fi
+
+# test behavior of assignment statements in different compound command
+# contexts
+${THIS_SH} ./new-exp4a.sub
+
+# tests of `word expansions' with null arguments
+unset var
+
+expect '<>'
+recho ${var[@]:3}
+
+expect '<>'
+recho ${var:3}
+
+expect '<>'
+recho ${var[@]/#/--}
+
+expect '<>'
+recho ${var/#/--}
+
+expect '<>'
+recho ${var[@]##?}
+
+expect '<>'
+recho ${var##?}
+
+unset var
+var=
+
+expect '<>'
+recho ${var[@]:3}
+
+expect '<>'
+recho ${var:3}
+
+expect '<-->'
+recho ${var[@]/#/--}
+
+expect '<-->'
+recho ${var/#/--}
+
+expect '<>'
+recho ${var[@]##?}
+
+expect '<>'
+recho ${var##?}
+
+# tests of various expansions that use globbing
+# make sure that these don't cause globbing
+
+expect 1
+x=?
+echo ${x#\?}
+
+# This should be an syntax error
+expect 2 errors
+${THIS_SH} -c 'echo ${x${y}}'
+
+# POSIX.2 says these are syntax errors
+expect 2 more errors
+${THIS_SH} -c 'echo ${#${x}}'
+${THIS_SH} -c 'echo ${#${x/foo/bar}}'
+
+# make sure that expansion happens in pattern-removal operations
+a=aab
+expect '<b>'
+echo ${a%${a#?}}
+
+expect '<b>'
+echo ${a%%${a#?}}
+
+set -- a aab
+expect '<b>'
+echo ${2%${2#?}}
+
+expect '<b>'
+echo ${2%%${2#?}}
+
+# tests of anchoring pattern match expansion against substrings
+
+a=ABCABC
+expect XXBC XXBC
+recho ${a//#A/XX} ${a//#A/XX}
+
+a=ABCABC
+expect XXBC XXBC
+recho ${a//A/XX} ${a//A/XX}
+
+# tests of substring extraction
+# more substring extraction tests, including the '-' in substring expansions
+# test null positional parameters -- this might fail badly on Ultrix
+set --
+expect 2
+echo ${2-2}
+
+var=(1 2 3)
+expect '<>'
+recho ${var[@]:3}
+
+var=a
+expect a
+recho ${var:0}
+
+expect a
+recho ${var: -1}
+
+expect nothing
+recho ${var:1}
+
+expect nothing
+recho ${var:99}
+
+expect error
+${THIS_SH} -c 'var=abcd ; recho ${var:0:-0}'
+${THIS_SH} -c 'unset var; recho ${var:0}'
+${THIS_SH} -c 'unset var; recho ${var:3}'
+
+var=abcd
+expect a
+recho ${var:0:1}
+
+expect ab
+recho ${var:0:2}
+
+expect c
+recho ${var:2:1}
+
+expect cd
+recho ${var:2:2}
+
+expect 'nothing<><>'
+recho nothing${var:4:1}${var:3:0}${var:0:0}
+
+expect nothing
+recho ${var:4:0}
+
+expect nothing
+recho ${var: -2:0}
+
+expect cd
+recho ${var: -2}
+
+expect d
+recho ${var: -1}
+
+expect nothing
+recho ${var: -99}
+
+# unset var
+
+var=(0 1 2 3)
+expect 0 1 2 3
+recho "${var[@]}"
+
+expect 1 2 3
+recho ${var[@]:1}
+
+expect 1
+recho ${var[1]}
+
+expect 2
+recho ${var[@]:2:1}
+
+expect error
+${THIS_SH} -c 'var=(0 1 2 3); echo ${var[@]:2:-0}'
+${THIS_SH} -c 'var=(0 1 2 3); echo ${var[@]:2:-1}'
+
+# More tests of the ${array[@]/x/y} expansion
+
+a=(xyz.c)
+expect '<xyz.o>'
+recho ${a[@]/.c/.o}
+
+b=(123)
+expect '<xxx>'
+recho ${b[@]//?/x}
+
+c=(abc1 abc2 abc3)
+expect '<Abc1> <Abc2> <Abc3>'
+recho "${c[@]/a/A}"
+
+expect '<Abc1> <Abc2> <Abc3>'
+recho "${c[@]/#a/A}"
+
+expect '<abcx> <abcx> <abcx>'
+recho "${c[@]/1/x}"
+
+expect '<abcx> <abc2> <abc3>'
+recho "${c[@]/#1/x}"
+
+expect '<Xbc1> <Xbc2> <Xbc3>'
+recho "${c[@]/#abc/X}"
+
+expect '<abc> <abc> <abc>'
+recho "${c[@]/%[0-9]/}"
+
+expect '<1> <2> <3>'
+recho "${c[@]/#abc/}"
+
+expect '<> <> <>'
+recho "${c[@]/#abc?/}"
+
+expect '<abcx>'
+recho "${c[@]/%1/x}"
+
+expect '<abcx> <abc2> <abc3>'
+recho "${c[@]/%1/x}"
+
+expect '<abc> <abc2> <abc3>'
+recho "${c[@]//%1/}"
+
+expect '<abc1> <abc> <abc3>'
+recho "${c[@]//%2/}"
+
+expect '<abc1> <abc2> <abc>'
+recho "${c[@]/%3/}"
+
+expect '<Abc1> <Abc2> <Abc3>'
+recho "${c[@]/a/A}"
+
+expect '<AxyzX> <AxyzX> <AxyzX>'
+recho "${c[@]//abc?/AxyzX}"
+
+expect '<1Axyz> <2Axyz> <3Axyz>'
+recho "${c[@]//#abc?/?Axyz}"
+
+expect '<Axyz1> <Axyz2> <Axyz3>'
+recho "${c[@]//%abc?/Axyz?}"
+
+# problem with backslash escaping caused infinite loop in bash-2.03
+c=
+expect nothing
+echo "${c//%[^\/]}"
+
+unset c
+
+# this caused an infinite loop in bash-4.0-alpha
+unset y
+expect '<>'
+recho "${y////}"
+
+# this is a parsing problem; it got fixed in bash-2.04
+
+expect 31
+echo ${var:=#x?//{/}
+echo ${#var}
+
+expect $0: 'ksh93: readonly variable'
+readonly ksh93
+${THIS_SH} -c 'ksh93=gnu' $0
+
+expect '<ksh93> <gnu>'
+${THIS_SH} -c 'ksh93=(ksh93 gnu); recho ${ksh93[@]}'
+
+# several of these caused core dumps in bash-2.0 -- see bash CWRU/changelog
+expect $0: 'HOME: readonly variable'
+readonly HOME
+${THIS_SH} -c 'HOME=/' $0
+
+# this caused a core dump in bash-2.01 (fixed by bash-2.01.1)
+${THIS_SH} -c 'unset XPATH+; declare XPATH' $0
+
+export var
+expect XPATH
+var=XPATH ${THIS_SH} -c 'echo $var' $0
+
+x=14
+expect '<10#14> <0x0e>'
+printf '<%d> <%#x>\n' x x
+
+# problems with positional parameter substring expansion and removal
+# fixed after bash-2.01.1
+
+${THIS_SH} ./new-exp5a.sub
+
+# bug with indirect variable reference when dealing with array variables
+# reported and fixed in bash-2.05 (bug #17)
+# this is how it's reported to work in ksh93, and the code is now fixed
+
+${THIS_SH} ./new-exp5b.sub
+
+# test recent additions -- bash-2.05b
+
+# case-changing expansions
+${THIS_SH} ./new-exp6.sub
+
+# substring extraction with positive and negative offsets
+${THIS_SH} ./new-exp7.sub
+
+# arithmetic in substring extraction
+${THIS_SH} ./new-exp8.sub
+
+# make sure that additional subscript operators are tested
+${THIS_SH} ./new-exp9.sub
+
+# bash-3.0
+${THIS_SH} ./new-exp10.sub
+
+# bash-3.1
+${THIS_SH} ./new-exp11.sub
+
+# bash-3.2
+${THIS_SH} ./new-exp12.sub
+
+# bash-4.0
+${THIS_SH} ./new-exp13.sub
+
+# bash-4.2
+${THIS_SH} ./new-exp14.sub
+
+${THIS_SH} ./new-exp15.sub
+
+${THIS_SH} ./new-exp16.sub
+
+# after bash-4.2
+a=121
+expect '<21>'
+recho ${a#${a%?}}
+
+expect '<21>'
+recho "${a#${a%?}}"
+
+# problems with double-quoted values and separate words with IFS whitespace
+
+IFS=$' \t\n'
+x=one
+recho ${foo=$x}
+
+unset foo x
+IFS=$' \t\n'
+x='one two'
+recho ${foo=$x}
+
+unset foo x
+IFS=$' \t\n'
+x='one two'
+recho "${foo=$x}"
+
+# problems with $*/$@ and IFS
+
+IFS=:
+set a b c d e
+recho "$*"
+
+set a b c d e
+recho ${foo="$*"}
+
+set a b c d e
+recho "${foo=$*}"
+
+set a b c d e
+recho "${foo="$*"}"
+
+# Problems with unbalanced and nested ${...} in indirect expansion
+${THIS_SH} ./new-exp17.sub
+
+# bug in ${1+"$@"}; didn't handle $@ being null
+# fixed in bash-5.0
+unset v
+v=
+recho "${1+"$@"}"
+
+# bug with ${x//} expansion reported by Marty Leisner,
+#   fixed in bash-5.0
+unset x
+expect nothing
+recho ${x//}
+
+expect nothing
+echo ${x//}
+
+# bug with empty arguments to :? expansion reported by Don Kimber
+# fixed in bash-5.0
+x=/tmp/foo
+expect nothing
+: ${x:?}
+
+# problem with stripping all % or # when they're in double quotes
+# when parenremoval happens before CTLESC removal
+# reported by Robert Holland
+# fixed in bash-5.0
+unset foo
+expect '<>>'
+recho "${foo/%/%}"
+
+expect '<#>'
+recho "${foo/#/#}"
+
+# command substitution delimits strings, so expansion should try to remove
+# the quote if it's not escaped. this would have had them left on in
+# versions before bash-5.0
+v=100
+expect '<100>'
+recho "$(echo "$v")%"
+
+expect '<100>'
+echo "$(echo "$v")%"
+
+# more tests of empty pattern-substitution expansions
+x=one/two/three
+expect '</one/two/three>'
+recho ${x/#/\/}
+
+expect '<one/two/three/>'
+recho ${x/%/\/}
+
+expect '<one/two/three>'
+recho ${x//}
+
+unset x
+expect '<>'
+recho "${x//[!a]}"
+
+unset x v
+
+# tests of word expansions using tildes and colons, and tilde_expansion
+# and word_split with IFS=
+IFS=
+expect $HOME
+echo ~/
+
+IFS=$'\n\t '
+expect $HOME
+echo ~/
+
+IFS=
+expect $HOME
+v="~/"
+echo $v
+
+# tests of substring replacement
+y=abcdabcd
+expect '<one/two>'
+recho "${y/abcd/one/two}"
+
+# simple offset tests
+a=abcdefghijklmnopqrstuvwxyz
+expect '<cdefg>'
+recho "${a:2:5}"
+
+set -- 1 2 3 4 5 6 7 8 9 10
+expect '<3> <4> <5>'
+recho "${@:3:3}"
+
+expect '<4> <5> <6> <7> <8> <9> <10>'
+recho "${@:4}"
+
+expect '<4> <5> <6>'
+recho "${*:4:3}"
+
+expect error
+${THIS_SH} -c 'echo ${@:0}'
+
+expect error
+${THIS_SH} -c 'echo ${@:0:1}'
+
+# substring replacement with simple forms
+xx=one/two/three
+expect '<one-two/three>'
+recho ${xx//\//two}
+
+expect '<onetwo/three>'
+recho ${xx/\/}
+
+yy=oneonetwo
+recho ${yy//one}
+recho ${yy/\/one}
+
+xx=oneonetwo
+
+recho ${xx/one}
+recho ${xx//one}
+recho ${xx/\/one}
+
+# out-of-range substrings
+var=abc
+c=${var:3}
+expect nothing
+recho $c
+c=${var:4}
+expect nothing
+recho $c
+# as of bash-4.2, negative LENGTH means offset from the end
+c=${var:0:-2}
+expect '<a>'
+recho $c
+
+var=abcdefghi
+c=${var:3:12}
+recho $c
+c=${var:4:20}
+recho $c
+
+# make sure null patterns work
+xxx=endocrine
+yyy=n
+unset zzz
+
+recho ${xxx/$yyy/*}
+recho ${xxx//$yyy/*}
+
+recho ${xxx/$zzz/*}
+recho ${xxx//$zzz/*}
+
+recho ${xxx//%${zzz}/}
+recho ${xxx//%${zzz}}
+recho ${xxx//#${zzz}/}
+recho ${xxx//#${zzz}}
+
+# make sure null strings are replaced appropriately
+unset var
+var=
+echo "${var/#/x}"
+echo "${var/*/x}"
+echo "${var//*/x}"
+
+var=abc
+echo "${var/#/x}"
+echo "${var/*/x}"
+echo "${var//*/x}"
+unset var
+
+# another case that caused a core dump in bash-2.0
+XPATH=/usr/bin:/bin:/usr/local/bin:/usr/gnu/bin::/usr/bin/X11:/sbin:/usr/sbin
+
+recho ${XPATH//:/ }
+
+xx=(ar as at au av aw ax ay az)
+
+recho ${xx[@]/a/}
+recho ${xx[@]//a/}
+
+recho ${xx[*]/a/}
+recho ${xx[*]//a/}
+
+recho ${xx[@]%?}
+recho ${xx[*]%?}
+
+recho ${xx[@]#?}
+recho ${xx[*]#?}
+
+set -- ar as at au av aw ax ay az
+
+recho ${@/a/}
+recho ${@//a/}
+
+recho ${*/a/}
+recho ${*//a/}
+
+recho ${@%?}
+recho ${*%?}
+
+recho ${@#?}
+recho ${*#?}
+
+shift ${#}
+set -u
+( recho $9 ; echo after 1)
+( recho ${9} ; echo after 2)
+( recho $UNSET ; echo after 3)
+( recho ${UNSET} ; echo after 4)
+( recho "$UNSET" ; echo after 5)
+( recho "${UNSET}" ; echo after 6)
+( recho "${#UNSET}" ; echo after 7)
+set +u
+
+RECEIVED="12345"
+recho "${RECEIVED:$((${#RECEIVED}-1)):1}"
+RECEIVED="12345#"
+recho "${RECEIVED:$((${#RECEIVED}-1)):1}"
+RECEIVED="#"
+recho "${RECEIVED:$((${#RECEIVED}-1)):1}"
+RECEIVED=""
+recho "${RECEIVED:$((${#RECEIVED}-1)):1}"
+
+# tests of new prefix expansion ${!prefix*}
+${THIS_SH} ./new-exp3.sub
+
+# bug with indirect expansion through bash-2.05b
+${THIS_SH} ./new-exp4.sub
+
+# these caused errors and core dumps in versions before bash-2.04
+c=""
+echo ${c//${$(($#-1))}/x/}
+
+set a b c d e f g
+recho "$@"
+
+set -- ${@:1:$(($# - 2))}
+recho "$@"
+
+set a b
+recho ${@:1:$(($# - 2))}
+
+recho ${@:1:0}
+recho ${@:1:1}
+recho ${@:1:2}
+
+recho "${*:1:0}"
+
+# this is an error -- negative expression
+set a
+recho ${@:1:$(($# - 2))}
+set a b c d e
+recho ${@: -3:-2}
+
+XPATH=/bin:/usr/bin:/usr/ucb:/usr/local/bin:.:/sbin:/usr/sbin
+set $( IFS=: ; echo $XPATH )
+
+recho ${@##*/}
+recho ${@%%[!/]*}
+
+recho ${@#/*}
+recho ${@%*/}
+
+set /full/path/to/x16 /another/full/path
+
+recho ${1%/*}
+recho ${1%%[!/]*}
+recho ${1#*/}
+recho ${1##*/}
+
+${THIS_SH} ./new-exp5.sub
+
+unset var
+var=blah
+
+# these had better agree
+echo ${var[@]:3}
+echo ${var:3}
+echo ${var[@]/#/--}
+echo ${var/#/--}
+echo ${var##?}
+echo ${var##?}
+
+unset var
+var=(abcde abcfg abchi)
+
+# problems with anchoring pattern replacements
+echo ${var[*]//#abc/foo}
+echo ${var[*]/#abc/foo}
+unset var
+
+${THIS_SH} ./new-exp6.sub
+
+${THIS_SH} ./new-exp7.sub
+
+${THIS_SH} ./new-exp8.sub
+
+# tests to check whether things like indirect expansion of a variable whose
+# value is 'anothervar[@]' stop working
+${THIS_SH} ./new-exp9.sub
+
+# new parameter transformation `@' expansion operator
+${THIS_SH} ./new-exp10.sub
+
+# parameter substring replacement and removal operators with multibyte chars
+${THIS_SH} ./new-exp11.sub
+
+# indirect expansion with arrays and local variables
+${THIS_SH} ./new-exp12.sub
+
+# more indirecte xpansion and parameter transformation issues
+${THIS_SH} ./new-exp13.sub
+
+# new K parameter transformation operator
+${THIS_SH} ./new-exp14.sub
+
+# ongoing work with a/A parameter transformations and `nounset'
+${THIS_SH} ./new-exp15.sub
+
+# pattern substitution with `&' (quoted and unquoted) in the replacement string
+${THIS_SH} ./new-exp16.sub
+
+
+# problems with stray CTLNUL in bash-4.0-alpha
+unset a
+a=/a
+recho "/${a%/*}"
+recho "/${a///a/}"
+
+patfunc()
+{
+	echo ${1##*"${1##*}"}
+}
+patfunc foo
+
+# caused core dumps because of bad bracket expression parsing in bash-5.0
+eval : $'${x/#[0\xef\xbf\xbd\\Z[:]]}'
+
+a=1/%2/%3
+echo "${a/\%/##}"
+echo "${a//\%/##}"
+echo "${a/\/%/##}"
+
+b=1/#2/#3
+echo "${b/\#/%%}"
+echo "${b//\#/%%}"
+echo "${b/\/#/%%}"
+
+unset a b
+
+expect $0: 'ABXD: parameter unset'
+${THIS_SH} -c 'recho ${ABXD:?"parameter unset"}' $0
+
+--------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixed bug where `<&-` (close stdin) was incorrectly formatted as `1>&-` (close stdout) instead of `0>&-` (close stdin) when inside a command substitution with pipes
- MRE: `a=$(a | ((a) <&- | a))`

## Test plan
- New test added to `tests/parable/character-fuzzer/fuzz-7231c71d2ae0c0597b8c0a7e6d1230a8.tests`
- `just check` passes
