### PR TITLE
fuzzer fix: handle None node in _format_cmdsub_node

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3615,6 +3615,9 @@ function _formatCmdsubNode(
 	if (procsub_first == null) {
 		procsub_first = false;
 	}
+	if (node == null) {
+		return "";
+	}
 	sp = " ".repeat(indent);
 	inner_sp = " ".repeat(indent + 4);
 	if (node.kind === "empty") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3067,6 +3067,8 @@ def _format_cmdsub_node(
     procsub_first: bool = False,
 ) -> str:
     """Format an AST node for command substitution output (bash-oracle pretty-print format)."""
+    if node is None:
+        return ""
     sp = _repeat_str(" ", indent)
     inner_sp = _repeat_str(" ", indent + 4)
     if node.kind == "empty":
@@ -5000,7 +5002,11 @@ class Parser:
                     while not self.at_end():
                         line_start = self.pos
                         line_end = self.pos
-                        while line_end < self.length and self.source[line_end] != "\n" and self.source[line_end] != ")":
+                        while (
+                            line_end < self.length
+                            and self.source[line_end] != "\n"
+                            and self.source[line_end] != ")"
+                        ):
                             line_end += 1
                         # If we hit ) before newline, heredoc is incomplete - position at ) and break
                         if line_end < self.length and self.source[line_end] == ")":

--- a/tests/parable/character-fuzzer/fuzz-8679fc6f262b4b7df6898fa01fab5542.tests
+++ b/tests/parable/character-fuzzer/fuzz-8679fc6f262b4b7df6898fa01fab5542.tests
@@ -1,0 +1,5 @@
+=== empty cmdsub in arith expansion with param expansion
+$(($())#)
+---
+(command (word "$(($())#)"))
+---


### PR DESCRIPTION
## Summary
- Fixed AttributeError when `_format_cmdsub_node` receives a None node
- MRE: `$(($())#)` - empty command substitution in arithmetic expansion with parameter expansion

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-8679fc6f262b4b7df6898fa01fab5542.tests`
- [x] `just check` passes