### PR TITLE
fuzzer fix: handle <<& in arith-for test expression (#223)

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4124,7 +4124,7 @@ function _formatHeredocBody(r) {
 }
 
 function _normalizeFdRedirects(s) {
-	let i, prev_is_digit, result;
+	let i, prev_is_digit, prev_is_same_op, result;
 	// Match >&N or <&N not preceded by a digit, add default fd
 	result = [];
 	i = 0;
@@ -4132,12 +4132,13 @@ function _normalizeFdRedirects(s) {
 		// Check for >&N or <&N
 		if (i + 2 < s.length && s[i + 1] === "&" && /^[0-9]+$/.test(s[i + 2])) {
 			prev_is_digit = i > 0 && /^[0-9]+$/.test(s[i - 1]);
-			if (s[i] === ">" && !prev_is_digit) {
+			prev_is_same_op = i > 0 && s[i - 1] === s[i];
+			if (s[i] === ">" && !prev_is_digit && !prev_is_same_op) {
 				result.push("1>&");
 				result.push(s[i + 2]);
 				i += 3;
 				continue;
-			} else if (s[i] === "<" && !prev_is_digit) {
+			} else if (s[i] === "<" && !prev_is_digit && !prev_is_same_op) {
 				result.push("0<&");
 				result.push(s[i + 2]);
 				i += 3;

--- a/src/parable.py
+++ b/src/parable.py
@@ -3494,12 +3494,13 @@ def _normalize_fd_redirects(s: str) -> str:
         # Check for >&N or <&N
         if i + 2 < len(s) and s[i + 1] == "&" and s[i + 2].isdigit():
             prev_is_digit = i > 0 and s[i - 1].isdigit()
-            if s[i] == ">" and not prev_is_digit:
+            prev_is_same_op = i > 0 and s[i - 1] == s[i]
+            if s[i] == ">" and not prev_is_digit and not prev_is_same_op:
                 result.append("1>&")
                 result.append(s[i + 2])
                 i += 3
                 continue
-            elif s[i] == "<" and not prev_is_digit:
+            elif s[i] == "<" and not prev_is_digit and not prev_is_same_op:
                 result.append("0<&")
                 result.append(s[i + 2])
                 i += 3
@@ -5003,7 +5004,11 @@ class Parser:
                     while not self.at_end():
                         line_start = self.pos
                         line_end = self.pos
-                        while line_end < self.length and self.source[line_end] != "\n" and self.source[line_end] != ")":
+                        while (
+                            line_end < self.length
+                            and self.source[line_end] != "\n"
+                            and self.source[line_end] != ")"
+                        ):
                             line_end += 1
                         # If we hit ) before newline, heredoc is incomplete - position at ) and break
                         if line_end < self.length and self.source[line_end] == ")":

--- a/tests/parable/character-fuzzer/fuzz-5fe70ede1cc2b99678d79661b963018c.tests
+++ b/tests/parable/character-fuzzer/fuzz-5fe70ede1cc2b99678d79661b963018c.tests
@@ -1,0 +1,5 @@
+=== handle <<& in arith-for test expression
+for ((;i<<&0;)); do :; done
+---
+(arith-for (init (word "1")) (test (word "i<<&0")) (step (word "1")) (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- Fixed parser incorrectly converting `<<&` to `<0<&` in arith-for test expressions
- MRE: `for ((;i<<&0;)); do :; done`
- The issue was in `_normalize_fd_redirects()` which was treating `<<&` as a file descriptor redirect that needed normalization, when it should be preserved as a left-shift operator `<<` followed by `&`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-5fe70ede1cc2b99678d79661b963018c.tests`
- [x] `just check` passes