### PR TITLE
fuzzer fix: handle space after & in close redirect before digit

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8568,29 +8568,63 @@ class Parser {
 		// NOTE: No whitespace allowed between operator and & (e.g., <&- is valid, < &- is not)
 		if (!this.atEnd() && this.peek() === "&") {
 			this.advance();
-			// Parse the fd number or - for close, including move syntax like &10-
-			if (
-				!this.atEnd() &&
-				(/^[0-9]+$/.test(this.peek()) || this.peek() === "-")
-			) {
-				word_start = this.pos;
-				fd_chars = [];
-				while (!this.atEnd() && /^[0-9]+$/.test(this.peek())) {
-					fd_chars.push(this.advance());
-				}
-				if (fd_chars) {
-					fd_target = fd_chars.join("");
+			// Skip whitespace after & to check what follows
+			this.skipWhitespace();
+			// Check for "& -" followed by non-metachar (e.g., "3>& -5" -> 3>&- + word "5")
+			if (!this.atEnd() && this.peek() === "-") {
+				if (
+					this.pos + 1 < this.length &&
+					!_isMetachar(this.source[this.pos + 1])
+				) {
+					// Consume just the - as close target, leave rest for next word
+					this.advance();
+					target = new Word("&-");
 				} else {
-					fd_target = "";
+					// Set target to None to fall through to normal parsing
+					target = null;
 				}
-				// Handle just - for close, or N- for move syntax
-				if (!this.atEnd() && this.peek() === "-") {
-					fd_target += this.advance();
-				}
-				// If more word characters follow, treat the whole target as a word (e.g., <&0=)
-				// BUT: bare "-" (close syntax) is always complete - trailing chars are separate words
-				if (fd_target !== "-" && !this.atEnd() && !_isMetachar(this.peek())) {
-					this.pos = word_start;
+			} else {
+				target = null;
+			}
+			// If we didn't handle close syntax above, continue with normal parsing
+			if (target == null) {
+				if (
+					!this.atEnd() &&
+					(/^[0-9]+$/.test(this.peek()) || this.peek() === "-")
+				) {
+					word_start = this.pos;
+					fd_chars = [];
+					while (!this.atEnd() && /^[0-9]+$/.test(this.peek())) {
+						fd_chars.push(this.advance());
+					}
+					if (fd_chars) {
+						fd_target = fd_chars.join("");
+					} else {
+						fd_target = "";
+					}
+					// Handle just - for close, or N- for move syntax
+					if (!this.atEnd() && this.peek() === "-") {
+						fd_target += this.advance();
+					}
+					// If more word characters follow, treat the whole target as a word (e.g., <&0=)
+					// BUT: bare "-" (close syntax) is always complete - trailing chars are separate words
+					if (fd_target !== "-" && !this.atEnd() && !_isMetachar(this.peek())) {
+						this.pos = word_start;
+						inner_word = this.parseWord();
+						if (inner_word != null) {
+							target = new Word(`&${inner_word.value}`);
+							target.parts = inner_word.parts;
+						} else {
+							throw new ParseError(
+								`Expected target for redirect ${op}`,
+								this.pos,
+							);
+						}
+					} else {
+						target = new Word(`&${fd_target}`);
+					}
+				} else {
+					// Could be &$var or &word - parse word and prepend &
 					inner_word = this.parseWord();
 					if (inner_word != null) {
 						target = new Word(`&${inner_word.value}`);
@@ -8601,17 +8635,6 @@ class Parser {
 							this.pos,
 						);
 					}
-				} else {
-					target = new Word(`&${fd_target}`);
-				}
-			} else {
-				// Could be &$var or &word - parse word and prepend &
-				inner_word = this.parseWord();
-				if (inner_word != null) {
-					target = new Word(`&${inner_word.value}`);
-					target.parts = inner_word.parts;
-				} else {
-					throw new ParseError(`Expected target for redirect ${op}`, this.pos);
 				}
 			}
 		} else {

--- a/src/parable.py
+++ b/src/parable.py
@@ -4990,7 +4990,11 @@ class Parser:
                     while not self.at_end():
                         line_start = self.pos
                         line_end = self.pos
-                        while line_end < self.length and self.source[line_end] != "\n" and self.source[line_end] != ")":
+                        while (
+                            line_end < self.length
+                            and self.source[line_end] != "\n"
+                            and self.source[line_end] != ")"
+                        ):
                             line_end += 1
                         # If we hit ) before newline, heredoc is incomplete - position at ) and break
                         if line_end < self.length and self.source[line_end] == ")":
@@ -7150,39 +7154,53 @@ class Parser:
         # NOTE: No whitespace allowed between operator and & (e.g., <&- is valid, < &- is not)
         if not self.at_end() and self.peek() == "&":
             self.advance()  # consume &
-            # Parse the fd number or - for close, including move syntax like &10-
-            if not self.at_end() and (self.peek().isdigit() or self.peek() == "-"):
-                word_start = self.pos
-                fd_chars = []
-                while not self.at_end() and self.peek().isdigit():
-                    fd_chars.append(self.advance())
-                if fd_chars:
-                    fd_target = "".join(fd_chars)
+            # Skip whitespace after & to check what follows
+            self.skip_whitespace()
+            # Check for "& -" followed by non-metachar (e.g., "3>& -5" -> 3>&- + word "5")
+            if not self.at_end() and self.peek() == "-":
+                if self.pos + 1 < self.length and not _is_metachar(self.source[self.pos + 1]):
+                    # Consume just the - as close target, leave rest for next word
+                    self.advance()
+                    target = Word("&-")
                 else:
-                    fd_target = ""
-                # Handle just - for close, or N- for move syntax
-                if not self.at_end() and self.peek() == "-":
-                    fd_target += self.advance()  # consume the trailing -
-                # If more word characters follow, treat the whole target as a word (e.g., <&0=)
-                # BUT: bare "-" (close syntax) is always complete - trailing chars are separate words
-                if fd_target != "-" and not self.at_end() and not _is_metachar(self.peek()):
-                    self.pos = word_start
+                    # Set target to None to fall through to normal parsing
+                    target = None
+            else:
+                target = None
+            # If we didn't handle close syntax above, continue with normal parsing
+            if target is None:
+                if not self.at_end() and (self.peek().isdigit() or self.peek() == "-"):
+                    word_start = self.pos
+                    fd_chars = []
+                    while not self.at_end() and self.peek().isdigit():
+                        fd_chars.append(self.advance())
+                    if fd_chars:
+                        fd_target = "".join(fd_chars)
+                    else:
+                        fd_target = ""
+                    # Handle just - for close, or N- for move syntax
+                    if not self.at_end() and self.peek() == "-":
+                        fd_target += self.advance()  # consume the trailing -
+                    # If more word characters follow, treat the whole target as a word (e.g., <&0=)
+                    # BUT: bare "-" (close syntax) is always complete - trailing chars are separate words
+                    if fd_target != "-" and not self.at_end() and not _is_metachar(self.peek()):
+                        self.pos = word_start
+                        inner_word = self.parse_word()
+                        if inner_word is not None:
+                            target = Word("&" + inner_word.value)
+                            target.parts = inner_word.parts
+                        else:
+                            raise ParseError("Expected target for redirect " + op, pos=self.pos)
+                    else:
+                        target = Word("&" + fd_target)
+                else:
+                    # Could be &$var or &word - parse word and prepend &
                     inner_word = self.parse_word()
                     if inner_word is not None:
                         target = Word("&" + inner_word.value)
                         target.parts = inner_word.parts
                     else:
                         raise ParseError("Expected target for redirect " + op, pos=self.pos)
-                else:
-                    target = Word("&" + fd_target)
-            else:
-                # Could be &$var or &word - parse word and prepend &
-                inner_word = self.parse_word()
-                if inner_word is not None:
-                    target = Word("&" + inner_word.value)
-                    target.parts = inner_word.parts
-                else:
-                    raise ParseError("Expected target for redirect " + op, pos=self.pos)
         else:
             self.skip_whitespace()
             # Handle >& - or <& - where space precedes the close syntax

--- a/tests/parable/character-fuzzer/fuzz-e8c3a639d98cc6a49cbed2603f9470ce.tests
+++ b/tests/parable/character-fuzzer/fuzz-e8c3a639d98cc6a49cbed2603f9470ce.tests
@@ -1,0 +1,5 @@
+=== handle space after & in close redirect before digit
+(: 3>& -5)
+---
+(subshell (command (word ":") (word "5") (redirect ">&-" 0)))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `3>& -5` where space after `&` before `-` followed by digit
- MRE: `(: 3>& -5)` should parse as close redirect `3>&-` plus word `5`
- Bug: Parable was parsing it as redirect to file `-5`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-e8c3a639d98cc6a49cbed2603f9470ce.tests`
- [x] `just check` passes (4443 passed, 1 pre-existing failure)