### PR TITLE
fuzzer fix: handle trailing \ after heredoc with newline in delimiter

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8731,7 +8731,11 @@ class Parser {
 					quoted = true;
 					this.advance();
 					while (!this.atEnd() && this.peek() !== "'") {
-						delimiter_chars.push(this.advance());
+						c = this.advance();
+						if (c === "\n") {
+							this._saw_newline_in_single_quote = true;
+						}
+						delimiter_chars.push(c);
 					}
 					if (!this.atEnd()) {
 						this.advance();
@@ -8960,10 +8964,17 @@ class Parser {
 						line_end += 1;
 					}
 				}
-			} else if (ch === "\\" && line_end + 1 < this.length) {
-				// Backslash escape - skip both chars
-				line_end += 2;
-				continue;
+			} else if (ch === "\\") {
+				if (line_end + 1 < this.length) {
+					// Backslash escape - skip both chars
+					line_end += 2;
+					continue;
+				} else {
+					// Backslash at EOF - treat as attempted line continuation
+					// Bash consumes this without an error
+					line_end += 1;
+					break;
+				}
 			}
 			line_end += 1;
 		}

--- a/tests/parable/character-fuzzer/fuzz-bab2496d76558ac3a62254abef13bd24.tests
+++ b/tests/parable/character-fuzzer/fuzz-bab2496d76558ac3a62254abef13bd24.tests
@@ -1,0 +1,6 @@
+=== heredoc with newline delimiter and trailing backslash
+<<'
+' y\
+---
+(command (word "y") (redirect "<<" ""))
+---


### PR DESCRIPTION
## Summary
When parsing `<<'\n' y\` (heredoc with quoted newline delimiter followed by word with trailing backslash), Parable incorrectly output `y\\` instead of `y`. The issue was that `_saw_newline_in_single_quote` wasn't set during heredoc delimiter parsing, preventing the trailing backslash from being stripped at EOF.

MRE: `<<'\n' y\`

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-bab2496d76558ac3a62254abef13bd24.tests`
- [ ] `just check` passes