### PR TITLE
fuzzer fix: preserve trailing backslash in word on own line after squoted newline

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -11805,16 +11805,26 @@ class Parser {
 			return [new Empty()];
 		}
 		// bash-oracle strips trailing backslash at EOF when there was a newline
-		// inside single quotes earlier in the input
+		// inside single quotes and the last word is on the same line as other content
+		// (not on its own line after a newline)
 		if (
 			this._saw_newline_in_single_quote &&
 			this.source &&
-			this.source[this.source.length - 1] === "\\" &&
-			(this.source.length < 2 || this.source[this.source.length - 2] !== "\n")
+			this.source[this.source.length - 1] === "\\"
 		) {
-			this._stripTrailingBackslashFromLastWord(results);
+			// Check if the last word started on its own line (after a newline)
+			// If so, keep the backslash. Otherwise, strip it as line continuation.
+			if (!this._lastWordOnOwnLine(results)) {
+				this._stripTrailingBackslashFromLastWord(results);
+			}
 		}
 		return results;
+	}
+
+	_lastWordOnOwnLine(nodes) {
+		// If we have multiple top-level nodes, they were separated by newlines,
+		// so the last node is on its own line
+		return nodes.length >= 2;
 	}
 
 	_stripTrailingBackslashFromLastWord(nodes) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -5003,7 +5003,11 @@ class Parser:
                     while not self.at_end():
                         line_start = self.pos
                         line_end = self.pos
-                        while line_end < self.length and self.source[line_end] != "\n" and self.source[line_end] != ")":
+                        while (
+                            line_end < self.length
+                            and self.source[line_end] != "\n"
+                            and self.source[line_end] != ")"
+                        ):
                             line_end += 1
                         # If we hit ) before newline, heredoc is incomplete - position at ) and break
                         if line_end < self.length and self.source[line_end] == ")":
@@ -9836,16 +9840,25 @@ class Parser:
             return [Empty()]
 
         # bash-oracle strips trailing backslash at EOF when there was a newline
-        # inside single quotes earlier in the input
+        # inside single quotes and the last word is on the same line as other content
+        # (not on its own line after a newline)
         if (
             self._saw_newline_in_single_quote
             and self.source
             and self.source[len(self.source) - 1] == "\\"
-            and (len(self.source) < 2 or self.source[len(self.source) - 2] != "\n")
         ):
-            self._strip_trailing_backslash_from_last_word(results)
+            # Check if the last word started on its own line (after a newline)
+            # If so, keep the backslash. Otherwise, strip it as line continuation.
+            if not self._last_word_on_own_line(results):
+                self._strip_trailing_backslash_from_last_word(results)
 
         return results
+
+    def _last_word_on_own_line(self, nodes: list[Node]) -> bool:
+        """Check if the last word is on its own line (after a newline with no other content)."""
+        # If we have multiple top-level nodes, they were separated by newlines,
+        # so the last node is on its own line
+        return len(nodes) >= 2
 
     def _strip_trailing_backslash_from_last_word(self, nodes: list[Node]) -> None:
         """Strip trailing backslash from the last word in the AST."""

--- a/tests/parable/character-fuzzer/fuzz-b8aa2533f3e88a5ec5a063f0a6af3389.tests
+++ b/tests/parable/character-fuzzer/fuzz-b8aa2533f3e88a5ec5a063f0a6af3389.tests
@@ -1,0 +1,8 @@
+=== trailing backslash after squoted string with newline
+'x
+y'
+ra\
+---
+(command (word "'x\ny'"))
+(command (word "ra\\\\"))
+---


### PR DESCRIPTION
## Summary
- Parable was incorrectly stripping trailing backslashes from words on their own line after a newline, when there was a newline inside a single-quoted string earlier in the input
- The bug was in the logic that determines when to strip trailing backslashes as line continuations
- Fixed by checking if the last word is on its own line (multiple top-level nodes = separated by newlines)
- MRE: `'x\ny'\nra\` where the trailing backslash should be preserved

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-b8aa2533f3e88a5ec5a063f0a6af3389.tests`
- [ ] `just check` passes