### PR TITLE
fuzzer fix: handle escaped brackets in deprecated arithmetic expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -7442,13 +7442,15 @@ class Parser {
 		depth = 1;
 		while (!this.atEnd() && depth > 0) {
 			c = this.peek();
-			if (c === "[") {
+			if (c === "[" && !_isBackslashEscaped(this.source, this.pos)) {
 				depth += 1;
 				this.advance();
 			} else if (c === "]") {
-				depth -= 1;
-				if (depth === 0) {
-					break;
+				if (!_isBackslashEscaped(this.source, this.pos)) {
+					depth -= 1;
+					if (depth === 0) {
+						break;
+					}
 				}
 				this.advance();
 			} else {

--- a/src/parable.py
+++ b/src/parable.py
@@ -6228,13 +6228,14 @@ class Parser:
         while not self.at_end() and depth > 0:
             c = self.peek()
 
-            if c == "[":
+            if c == "[" and not _is_backslash_escaped(self.source, self.pos):
                 depth += 1
                 self.advance()
             elif c == "]":
-                depth -= 1
-                if depth == 0:
-                    break
+                if not _is_backslash_escaped(self.source, self.pos):
+                    depth -= 1
+                    if depth == 0:
+                        break
                 self.advance()
             else:
                 self.advance()

--- a/tests/parable/character-fuzzer/fuzz-0f2d6ced4e6651a06bcbdda5fddc3197.tests
+++ b/tests/parable/character-fuzzer/fuzz-0f2d6ced4e6651a06bcbdda5fddc3197.tests
@@ -1,0 +1,5 @@
+=== arithmetic expansion with escaped brackets should split words
+$[\[] [\]]
+---
+(command (word "$[\\[]") (word "[\\]]"))
+---


### PR DESCRIPTION
## Summary
Fixed bug where deprecated arithmetic expansion `$[...]` was not correctly handling escaped brackets. The parser was treating `\[` and `\]` as nested brackets instead of escaped literal characters, causing incorrect word splitting.

MRE: `$[\[] [\]]`
- Before: parsed as single word `(word "$[\\[] [\\]]")`
- After: correctly parsed as two words `(word "$[\\[]") (word "[\\]]")`