### PR TITLE
fuzzer fix: handle semicolon in arith expansion with command sub

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-81801d3c8b82f618ee664200be7f4498.tests
+++ b/tests/parable/character-fuzzer/fuzz-81801d3c8b82f618ee664200be7f4498.tests
@@ -1,0 +1,5 @@
+=== semicolon in arith expansion with command substitution
+$(($() +;3))
+---
+(command (word "$(($() +;3))"))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `$(($() +;3))` - semicolon inside arith expansion with command sub
- Modified validation check in `_find_cmdsub_end` to skip over `$()` command subs when scanning
- Added `;` to arithmetic parser's end-of-expression character list