### PR TITLE
fuzzer fix: don't normalize FD redirects in arith-for test clause

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2611,7 +2611,7 @@ class ForArith extends Node {
 			suffix = ` ${redirect_parts.join(" ")}`;
 		}
 		init_val = this.init ? this.init : "1";
-		cond_val = this.cond ? _normalizeFdRedirects(this.cond) : "1";
+		cond_val = this.cond ? this.cond : "1";
 		incr_val = this.incr ? this.incr : "1";
 		init_str = formatArithVal(init_val);
 		cond_str = formatArithVal(cond_val);

--- a/src/parable.py
+++ b/src/parable.py
@@ -2139,7 +2139,7 @@ class ForArith(Node):
                 redirect_parts.append(r.to_sexp())
             suffix = " " + " ".join(redirect_parts)
         init_val = self.init if self.init else "1"
-        cond_val = _normalize_fd_redirects(self.cond) if self.cond else "1"
+        cond_val = self.cond if self.cond else "1"
         incr_val = self.incr if self.incr else "1"
         init_str = format_arith_val(init_val)
         cond_str = format_arith_val(cond_val)

--- a/tests/parable/character-fuzzer/fuzz-51bc14cf0baae734b79fb958dbbbca69.tests
+++ b/tests/parable/character-fuzzer/fuzz-51bc14cf0baae734b79fb958dbbbca69.tests
@@ -1,0 +1,5 @@
+=== arith-for with <& in test expression
+for ((;i<&10;)); do :; done
+---
+(arith-for (init (word "1")) (test (word "i<&10")) (step (word "1")) (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `_normalize_fd_redirects()` was incorrectly being called on the test clause of arithmetic for loops, causing `<&` operators to be treated as file descriptor redirects instead of arithmetic operators
- MRE: `for ((;i<&10;)); do :; done` was producing `(word "i0<&10")` instead of `(word "i<&10")`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-51bc14cf0baae734b79fb958dbbbca69.tests`
- [x] `just check` passes