### PR TITLE
fuzzer fix: don't normalize fd redirects in arith-for condition

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2611,7 +2611,7 @@ class ForArith extends Node {
 			suffix = ` ${redirect_parts.join(" ")}`;
 		}
 		init_val = this.init ? this.init : "1";
-		cond_val = this.cond ? _normalizeFdRedirects(this.cond) : "1";
+		cond_val = this.cond ? this.cond : "1";
 		incr_val = this.incr ? this.incr : "1";
 		init_str = formatArithVal(init_val);
 		cond_str = formatArithVal(cond_val);

--- a/src/parable.py
+++ b/src/parable.py
@@ -2139,7 +2139,7 @@ class ForArith(Node):
                 redirect_parts.append(r.to_sexp())
             suffix = " " + " ".join(redirect_parts)
         init_val = self.init if self.init else "1"
-        cond_val = _normalize_fd_redirects(self.cond) if self.cond else "1"
+        cond_val = self.cond if self.cond else "1"
         incr_val = self.incr if self.incr else "1"
         init_str = format_arith_val(init_val)
         cond_str = format_arith_val(cond_val)

--- a/tests/parable/character-fuzzer/fuzz-19d62b1a27524db0158ac1e1a41298ec.tests
+++ b/tests/parable/character-fuzzer/fuzz-19d62b1a27524db0158ac1e1a41298ec.tests
@@ -1,0 +1,5 @@
+=== arith-for with redirect in test expression
+for((;i<&0;));do :;done
+---
+(arith-for (init (word "1")) (test (word "i<&0")) (step (word "1")) (command (word ":")))
+---


### PR DESCRIPTION
## Summary
- Fixed incorrect normalization of file descriptor redirects in arithmetic for-loop conditions
- In `for((;i<&0;));do :;done`, the condition `i<&0` was incorrectly being normalized to `i0<&0`
- The `_normalize_fd_redirects` function should not be applied to arithmetic expressions where `<&` are operators, not redirects

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-19d62b1a27524db0158ac1e1a41298ec.tests`
- [ ] `just check` passes