### PR TITLE
fuzzer fix: handle backslash after quoted newline and line continuation

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -11857,10 +11857,16 @@ class Parser {
 		// bash-oracle strips trailing backslash at EOF when there was a newline
 		// inside single quotes and the last word is on the same line as other content
 		// (not on its own line after a newline)
+		// Exception: keep backslash if it's on a continuation line (preceded by \<newline>)
 		if (
 			this._saw_newline_in_single_quote &&
 			this.source &&
-			this.source[this.source.length - 1] === "\\"
+			this.source[this.source.length - 1] === "\\" &&
+			!(
+				this.source.length >= 3 &&
+				this.source.slice(this.source.length - 3, this.source.length - 1) ===
+					"\\\n"
+			)
 		) {
 			// Check if the last word started on its own line (after a newline)
 			// If so, keep the backslash. Otherwise, strip it as line continuation.

--- a/src/parable.py
+++ b/src/parable.py
@@ -9874,10 +9874,15 @@ class Parser:
         # bash-oracle strips trailing backslash at EOF when there was a newline
         # inside single quotes and the last word is on the same line as other content
         # (not on its own line after a newline)
+        # Exception: keep backslash if it's on a continuation line (preceded by \<newline>)
         if (
             self._saw_newline_in_single_quote
             and self.source
             and self.source[len(self.source) - 1] == "\\"
+            and not (
+                len(self.source) >= 3
+                and self.source[len(self.source) - 3 : len(self.source) - 1] == "\\\n"
+            )
         ):
             # Check if the last word started on its own line (after a newline)
             # If so, keep the backslash. Otherwise, strip it as line continuation.

--- a/tests/parable/character-fuzzer/fuzz-4993a116014fd1768d15e54683ae3b87.tests
+++ b/tests/parable/character-fuzzer/fuzz-4993a116014fd1768d15e54683ae3b87.tests
@@ -1,0 +1,7 @@
+=== backslash after quoted newline and line continuation
+'
+'\
+\
+---
+(command (word "'\n'\\\\"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where a trailing backslash on a continuation line was incorrectly stripped when preceded by a single-quoted string containing a newline
- MRE: `'\n'\\\n\\` should output `(command (word "'\n'\\\\"))` not `(command (word "'\n'"))`
- The issue was that the code treated all trailing backslashes as line continuations to strip, but backslashes on continuation lines (preceded by `\<newline>`) should be preserved

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-4993a116014fd1768d15e54683ae3b87.tests`
- [ ] `just check` passes