### PR TITLE
fuzzer fix: preserve space in process substitution within arithmetic expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1711,6 +1711,7 @@ class Word extends Node {
 				} else if (is_procsub) {
 					// Process substitution but no parts (failed to parse or in arithmetic context)
 					// Strip leading whitespace after >( or <( to match bash behavior
+					// But preserve if content is only whitespace
 					direction = value[i];
 					j = _findCmdsubEnd(value, i + 2);
 					if (
@@ -1723,9 +1724,14 @@ class Word extends Node {
 						continue;
 					}
 					inner = value.slice(i + 2, j - 1);
-					// Strip leading whitespace
-					stripped = inner.replace(/^[ \t]+/, "");
-					result.push(`${direction}(${stripped})`);
+					// Only strip leading whitespace if there's non-whitespace content
+					if (inner.trim()) {
+						stripped = inner.replace(/^[ \t]+/, "");
+						result.push(`${direction}(${stripped})`);
+					} else {
+						// Content is only whitespace - preserve as-is
+						result.push(`${direction}(${inner})`);
+					}
 					i = j;
 				} else {
 					// Not a process substitution (e.g., arithmetic comparison)

--- a/src/parable.py
+++ b/src/parable.py
@@ -1360,6 +1360,7 @@ class Word(Node):
                 elif is_procsub:
                     # Process substitution but no parts (failed to parse or in arithmetic context)
                     # Strip leading whitespace after >( or <( to match bash behavior
+                    # But preserve if content is only whitespace
                     direction = value[i]
                     j = _find_cmdsub_end(value, i + 2)
                     if j > len(value) or (j > 0 and j <= len(value) and value[j - 1] != ")"):
@@ -1368,9 +1369,13 @@ class Word(Node):
                         i += 1
                         continue
                     inner = _substring(value, i + 2, j - 1)
-                    # Strip leading whitespace
-                    stripped = inner.lstrip(" \t")
-                    result.append(direction + "(" + stripped + ")")
+                    # Only strip leading whitespace if there's non-whitespace content
+                    if inner.strip():
+                        stripped = inner.lstrip(" \t")
+                        result.append(direction + "(" + stripped + ")")
+                    else:
+                        # Content is only whitespace - preserve as-is
+                        result.append(direction + "(" + inner + ")")
                     i = j
                 else:
                     # Not a process substitution (e.g., arithmetic comparison)

--- a/tests/parable/character-fuzzer/fuzz-164c5e939c29323c5a4312ddd037f88e.tests
+++ b/tests/parable/character-fuzzer/fuzz-164c5e939c29323c5a4312ddd037f88e.tests
@@ -1,0 +1,5 @@
+=== preserve space in process substitution within arithmetic expansion
+((<( )))
+---
+(arith (word "<( )"))
+---


### PR DESCRIPTION
## Summary
Fixed a bug where spaces inside process substitutions were being stripped when they appeared within arithmetic expansions. The MRE is `((<( )))` where the space inside `<( )` was being removed.

The fix ensures that when content is only whitespace, it's preserved as-is, while still stripping leading whitespace when there's actual non-whitespace content (to maintain bash compatibility).

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-164c5e939c29323c5a4312ddd037f88e.tests`
- [x] `just check` passes