### PR TITLE
fuzzer fix: handle backslash-quoted heredoc delimiters in _skip_heredoc

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4474,7 +4474,10 @@ function _skipHeredoc(value, start) {
 		// Backslash-quoted delimiter like <<\EOF
 		i += 1;
 		delim_start = i;
-		while (i < value.length && !_isWhitespace(value[i])) {
+		if (i < value.length) {
+			i += 1;
+		}
+		while (i < value.length && !_isMetachar(value[i])) {
 			i += 1;
 		}
 		delimiter = value.slice(delim_start, i);

--- a/src/parable.py
+++ b/src/parable.py
@@ -3742,7 +3742,9 @@ def _skip_heredoc(value: str, start: int) -> int:
         # Backslash-quoted delimiter like <<\EOF
         i += 1
         delim_start = i
-        while i < len(value) and not _is_whitespace(value[i]):
+        if i < len(value):
+            i += 1
+        while i < len(value) and not _is_metachar(value[i]):
             i += 1
         delimiter = _substring(value, delim_start, i)
     else:

--- a/tests/parable/character-fuzzer/fuzz-b8c2071dd6c487f16ad04a268b2534b7.tests
+++ b/tests/parable/character-fuzzer/fuzz-b8c2071dd6c487f16ad04a268b2534b7.tests
@@ -1,0 +1,5 @@
+=== heredoc in command substitution with backslash missing closing quote
+"$(<<\\)"
+---
+(command (word "\"$(<<'\\'\n\\\n)\""))
+---


### PR DESCRIPTION
## Summary
Fixed a bug where `_skip_heredoc` incorrectly parsed backslash-quoted heredoc delimiters by reading until whitespace instead of properly handling metacharacters. This caused it to consume the closing double quote from parent double-quoted strings.

MRE: `"$(<<\\)"`

The function now reads exactly one character after the backslash (even if it's a metachar), then continues reading additional non-metachar characters, matching the behavior in `_parse_command_substitution`.