### PR TITLE
fuzzer fix: handle backslash-newline after escaped backslash and newline in arithmetic expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1159,6 +1159,7 @@ class Word extends Node {
 
 	_stripArithLineContinuations(value) {
 		let arith_content,
+			closing,
 			content,
 			depth,
 			first_close_idx,
@@ -1203,6 +1204,10 @@ class Word extends Node {
 						// Count preceding backslashes in arith_content
 						num_backslashes = 0;
 						j = arith_content.length - 1;
+						// Skip trailing newlines before counting backslashes
+						while (j >= 0 && arith_content[j] === "\n") {
+							j -= 1;
+						}
 						while (j >= 0 && arith_content[j] === "\\") {
 							num_backslashes += 1;
 							j -= 1;
@@ -1227,12 +1232,15 @@ class Word extends Node {
 						}
 					}
 				}
-				if (depth === 0) {
+				if (depth === 0 || (depth === 1 && first_close_idx != null)) {
 					content = arith_content.join("");
 					if (first_close_idx != null) {
 						// Standard close: trim content, add ))
 						content = content.slice(0, first_close_idx);
-						result.push(`$((${content}))`);
+						// If depth==1, we only found one closing paren, add )
+						// If depth==0, we found both closing parens, add ))
+						closing = depth === 0 ? "))" : ")";
+						result.push(`$((${content}${closing}`);
 					} else {
 						// Content after first close: content has intermediate ), add single )
 						result.push(`$((${content})`);

--- a/src/parable.py
+++ b/src/parable.py
@@ -981,6 +981,9 @@ class Word(Node):
                         # Count preceding backslashes in arith_content
                         num_backslashes = 0
                         j = len(arith_content) - 1
+                        # Skip trailing newlines before counting backslashes
+                        while j >= 0 and arith_content[j] == "\n":
+                            j -= 1
                         while j >= 0 and arith_content[j] == "\\":
                             num_backslashes += 1
                             j -= 1
@@ -999,12 +1002,15 @@ class Word(Node):
                         i += 1
                         if depth == 1:
                             first_close_idx = None  # Content after first close
-                if depth == 0:
+                if depth == 0 or (depth == 1 and first_close_idx is not None):
                     content = "".join(arith_content)
                     if first_close_idx is not None:
                         # Standard close: trim content, add ))
                         content = content[:first_close_idx]
-                        result.append("$((" + content + "))")
+                        # If depth==1, we only found one closing paren, add )
+                        # If depth==0, we found both closing parens, add ))
+                        closing = "))" if depth == 0 else ")"
+                        result.append("$((" + content + closing)
                     else:
                         # Content after first close: content has intermediate ), add single )
                         result.append("$((" + content + ")")

--- a/tests/parable/character-fuzzer/fuzz-98348ea69f843fb13fa4228bcd9c4c96.tests
+++ b/tests/parable/character-fuzzer/fuzz-98348ea69f843fb13fa4228bcd9c4c96.tests
@@ -1,0 +1,7 @@
+=== backslash-newline after escaped backslash in arithmetic expansion
+echo $((\(
+\
+2))
+---
+(command (word "echo") (word "$((\\(\n2))"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where backslash-newline sequences in arithmetic expansions were not removed when preceded by a newline after an escaped backslash
- MRE: `echo $((\\(\n\\\n2))` - oracle removes the backslash-newline before `2`, parable was preserving it
- Root cause: `_strip_arith_line_continuations` was not skipping newlines when counting preceding backslashes, and wasn't handling the case where the loop exits with depth==1

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-98348ea69f843fb13fa4228bcd9c4c96.tests`
- [ ] `just check` passes