### PR TITLE
fuzzer fix: handle incomplete case statements in command substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4211,12 +4211,17 @@ function _findCmdsubEnd(value, start) {
 		c,
 		case_depth,
 		depth,
+		found_esac,
 		i,
 		in_case_patterns,
 		in_double,
 		in_single,
 		is_valid_arith,
 		j,
+		lookahead_c,
+		lookahead_case_depth,
+		lookahead_i,
+		quote,
 		scan_c,
 		scan_i,
 		scan_paren;
@@ -4417,8 +4422,116 @@ function _findCmdsubEnd(value, start) {
 			}
 		} else if (c === ")") {
 			// In case patterns, ) after pattern name is not a grouping paren
-			if (in_case_patterns && case_depth > 0) {
-				// This ) is a case pattern terminator, skip it
+			if (in_case_patterns && case_depth > 0 && depth > 1) {
+				// This might be a case pattern terminator, but check if there's an esac
+				// If we're at depth 1 (outermost level), this ) might close the cmdsub
+				// Do lookahead to find if there's an esac for this case
+				lookahead_i = i + 1;
+				lookahead_case_depth = case_depth;
+				found_esac = false;
+				while (lookahead_i < value.length) {
+					lookahead_c = value[lookahead_i];
+					if (lookahead_c === "'" || lookahead_c === '"') {
+						// Skip quoted strings in lookahead
+						quote = lookahead_c;
+						lookahead_i += 1;
+						while (lookahead_i < value.length && value[lookahead_i] !== quote) {
+							if (lookahead_c === '"' && value[lookahead_i] === "\\") {
+								lookahead_i += 1;
+							}
+							lookahead_i += 1;
+						}
+						if (lookahead_i < value.length) {
+							lookahead_i += 1;
+						}
+					} else if (
+						_startsWithAt(value, lookahead_i, "case") &&
+						_isWordBoundary(value, lookahead_i, 4)
+					) {
+						lookahead_case_depth += 1;
+						lookahead_i += 4;
+					} else if (
+						_startsWithAt(value, lookahead_i, "esac") &&
+						_isWordBoundary(value, lookahead_i, 4)
+					) {
+						lookahead_case_depth -= 1;
+						if (lookahead_case_depth === 0) {
+							found_esac = true;
+							break;
+						}
+						lookahead_i += 4;
+					} else if (lookahead_c === "(") {
+						lookahead_i += 1;
+					} else if (lookahead_c === ")") {
+						// Hit another ) before finding esac - stop lookahead
+						if (lookahead_case_depth > 0) {
+							lookahead_i += 1;
+						} else {
+							break;
+						}
+					} else {
+						lookahead_i += 1;
+					}
+				}
+				if (found_esac) {
+					// This ) is a case pattern terminator, skip it
+				} else {
+					// No esac found, this ) closes the command substitution
+					depth -= 1;
+				}
+			} else if (in_case_patterns && case_depth > 0) {
+				// At depth 1, check for esac (same lookahead logic)
+				// If no esac, this ) closes the cmdsub
+				lookahead_i = i + 1;
+				lookahead_case_depth = case_depth;
+				found_esac = false;
+				while (lookahead_i < value.length) {
+					lookahead_c = value[lookahead_i];
+					if (lookahead_c === "'" || lookahead_c === '"') {
+						quote = lookahead_c;
+						lookahead_i += 1;
+						while (lookahead_i < value.length && value[lookahead_i] !== quote) {
+							if (lookahead_c === '"' && value[lookahead_i] === "\\") {
+								lookahead_i += 1;
+							}
+							lookahead_i += 1;
+						}
+						if (lookahead_i < value.length) {
+							lookahead_i += 1;
+						}
+					} else if (
+						_startsWithAt(value, lookahead_i, "case") &&
+						_isWordBoundary(value, lookahead_i, 4)
+					) {
+						lookahead_case_depth += 1;
+						lookahead_i += 4;
+					} else if (
+						_startsWithAt(value, lookahead_i, "esac") &&
+						_isWordBoundary(value, lookahead_i, 4)
+					) {
+						lookahead_case_depth -= 1;
+						if (lookahead_case_depth === 0) {
+							found_esac = true;
+							break;
+						}
+						lookahead_i += 4;
+					} else if (lookahead_c === ")") {
+						// Hit another ) before finding esac - stop lookahead
+						if (lookahead_case_depth > 0) {
+							lookahead_i += 1;
+						} else {
+							break;
+						}
+					} else {
+						lookahead_i += 1;
+					}
+				}
+				if (found_esac) {
+					// This ) is a case pattern terminator, skip it
+				} else {
+					// No esac found, this ) closes the command substitution
+					depth -= 1;
+				}
 			} else if (arith_depth > 0) {
 				if (arith_paren_depth > 0) {
 					arith_paren_depth -= 1;
@@ -4880,7 +4993,8 @@ function _isWordStartContext(c) {
 		c === "|" ||
 		c === "&" ||
 		c === "<" ||
-		c === "("
+		c === "(" ||
+		c === "{"
 	);
 }
 

--- a/src/parable.py
+++ b/src/parable.py
@@ -3704,9 +3704,98 @@ def _find_cmdsub_end(value: str, start: int) -> int:
                     depth += 1
         elif c == ")":
             # In case patterns, ) after pattern name is not a grouping paren
-            if in_case_patterns and case_depth > 0:
-                # This ) is a case pattern terminator, skip it
-                pass
+            if in_case_patterns and case_depth > 0 and depth > 1:
+                # This might be a case pattern terminator, but check if there's an esac
+                # If we're at depth 1 (outermost level), this ) might close the cmdsub
+                # Do lookahead to find if there's an esac for this case
+                lookahead_i = i + 1
+                lookahead_case_depth = case_depth
+                found_esac = False
+                while lookahead_i < len(value):
+                    lookahead_c = value[lookahead_i]
+                    if lookahead_c == "'" or lookahead_c == '"':
+                        # Skip quoted strings in lookahead
+                        quote = lookahead_c
+                        lookahead_i += 1
+                        while lookahead_i < len(value) and value[lookahead_i] != quote:
+                            if lookahead_c == '"' and value[lookahead_i] == "\\":
+                                lookahead_i += 1
+                            lookahead_i += 1
+                        if lookahead_i < len(value):
+                            lookahead_i += 1
+                    elif _starts_with_at(value, lookahead_i, "case") and _is_word_boundary(
+                        value, lookahead_i, 4
+                    ):
+                        lookahead_case_depth += 1
+                        lookahead_i += 4
+                    elif _starts_with_at(value, lookahead_i, "esac") and _is_word_boundary(
+                        value, lookahead_i, 4
+                    ):
+                        lookahead_case_depth -= 1
+                        if lookahead_case_depth == 0:
+                            found_esac = True
+                            break
+                        lookahead_i += 4
+                    elif lookahead_c == "(":
+                        lookahead_i += 1
+                    elif lookahead_c == ")":
+                        # Hit another ) before finding esac - stop lookahead
+                        if lookahead_case_depth > 0:
+                            lookahead_i += 1
+                        else:
+                            break
+                    else:
+                        lookahead_i += 1
+                if found_esac:
+                    # This ) is a case pattern terminator, skip it
+                    pass
+                else:
+                    # No esac found, this ) closes the command substitution
+                    depth -= 1
+            elif in_case_patterns and case_depth > 0:
+                # At depth 1, check for esac (same lookahead logic)
+                # If no esac, this ) closes the cmdsub
+                lookahead_i = i + 1
+                lookahead_case_depth = case_depth
+                found_esac = False
+                while lookahead_i < len(value):
+                    lookahead_c = value[lookahead_i]
+                    if lookahead_c == "'" or lookahead_c == '"':
+                        quote = lookahead_c
+                        lookahead_i += 1
+                        while lookahead_i < len(value) and value[lookahead_i] != quote:
+                            if lookahead_c == '"' and value[lookahead_i] == "\\":
+                                lookahead_i += 1
+                            lookahead_i += 1
+                        if lookahead_i < len(value):
+                            lookahead_i += 1
+                    elif _starts_with_at(value, lookahead_i, "case") and _is_word_boundary(
+                        value, lookahead_i, 4
+                    ):
+                        lookahead_case_depth += 1
+                        lookahead_i += 4
+                    elif _starts_with_at(value, lookahead_i, "esac") and _is_word_boundary(
+                        value, lookahead_i, 4
+                    ):
+                        lookahead_case_depth -= 1
+                        if lookahead_case_depth == 0:
+                            found_esac = True
+                            break
+                        lookahead_i += 4
+                    elif lookahead_c == ")":
+                        # Hit another ) before finding esac - stop lookahead
+                        if lookahead_case_depth > 0:
+                            lookahead_i += 1
+                        else:
+                            break
+                    else:
+                        lookahead_i += 1
+                if found_esac:
+                    # This ) is a case pattern terminator, skip it
+                    pass
+                else:
+                    # No esac found, this ) closes the command substitution
+                    depth -= 1
             elif arith_depth > 0:
                 if arith_paren_depth > 0:
                     arith_paren_depth -= 1
@@ -4081,6 +4170,7 @@ def _is_word_start_context(c: str) -> bool:
         or c == "&"
         or c == "<"
         or c == "("
+        or c == "{"
     )
 
 

--- a/tests/parable/character-fuzzer/fuzz-45ddfe7b1cce210d96c6cf780ffa05e6.tests
+++ b/tests/parable/character-fuzzer/fuzz-45ddfe7b1cce210d96c6cf780ffa05e6.tests
@@ -1,0 +1,5 @@
+=== case statement with incomplete pattern inside brace group command substitution
+"$({case x in)"
+---
+(command (word "\"$({case x in)\""))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where incomplete case statements in command substitutions caused closing ) to be skipped
- MRE: `"$({case x in)"`
- Bug: `)` after `in` was treated as case pattern terminator instead of closing the command substitution
- Fix: Added lookahead in `_find_cmdsub_end` to check for `esac` before treating `)` as pattern terminator
- Also added `{` to `_is_word_start_context` to properly detect keywords after braces