### PR TITLE
fuzzer fix: handle heredoc in command substitution with immediate closing paren

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -5159,7 +5159,39 @@ class Parser:
         content = _substring(self.source, content_start, self.pos)
         self.advance()  # consume final )
 
-        text = _substring(self.source, start, self.pos)
+        # Save position after ) for text (before skipping heredoc content)
+        text_end = self.pos
+
+        # Check for heredocs in content whose bodies follow the )
+        # This handles cases like $(cmd <<X) where ) immediately follows <<X
+        # Only process if there's a newline after ) - otherwise no heredoc content exists
+        if not self.at_end() and self.peek() == "\n":
+            # Filter to only heredocs that weren't already consumed during parsing
+            all_heredoc_delimiters = _extract_heredoc_delimiters(content)
+            heredoc_delimiters = []
+            for delim, strip_tabs in all_heredoc_delimiters:
+                # Check if this delimiter was already consumed (appears on its own line in content)
+                found_in_content = False
+                for line in content.split("\n"):
+                    check_line = line.lstrip("\t") if strip_tabs else line
+                    if check_line == delim:
+                        found_in_content = True
+                        break
+                if not found_in_content:
+                    heredoc_delimiters.append((delim, strip_tabs))
+
+            if heredoc_delimiters:
+                heredoc_start, heredoc_end = _find_heredoc_content_end(
+                    self.source, self.pos, heredoc_delimiters
+                )
+                if heredoc_end > heredoc_start:
+                    content = content + _substring(self.source, heredoc_start, heredoc_end)
+                    if self._pending_heredoc_end is None:
+                        self._pending_heredoc_end = heredoc_end
+                    else:
+                        self._pending_heredoc_end = max(self._pending_heredoc_end, heredoc_end)
+
+        text = _substring(self.source, start, text_end)
 
         # Parse the content as a command list
         sub_parser = Parser(content, in_process_sub=True)

--- a/tests/parable/character-fuzzer/fuzz-67774ca5993881342bcc2b4bbc83d181.tests
+++ b/tests/parable/character-fuzzer/fuzz-67774ca5993881342bcc2b4bbc83d181.tests
@@ -1,0 +1,6 @@
+=== heredoc in command substitution with immediate closing paren
+a=$(b <<X)
+c
+---
+(command (word "a=$(b <<X\nc\nX\n)"))
+---


### PR DESCRIPTION
## Summary
- Fixed parser bug where heredoc content after a command substitution with immediate closing paren was not included

MRE: `a=$(b <<X)\nc` - the `c` should be part of the heredoc content but was treated as a separate command

The fix adds post-processing to `_parse_command_substitution` to extract heredoc content that follows the `)`, but only when there's a newline after `)` (indicating heredoc content can exist). This avoids interfering with cases like `"$(<<a)"` where no heredoc content follows.