### PR TITLE
fuzzer fix: handle 5685{ in heredoc delimiters

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9000,18 +9000,31 @@ class Parser {
 					this.pos + 1 < this.length &&
 					this.source[this.pos + 1] === "{"
 				) {
-					// Parameter expansion embedded in delimiter
-					delimiter_chars.push(this.advance());
-					delimiter_chars.push(this.advance());
-					depth = 1;
-					while (!this.atEnd() && depth > 0) {
-						c = this.peek();
-						if (c === "{") {
-							depth += 1;
-						} else if (c === "}") {
-							depth -= 1;
-						}
+					// Check if this is $${ where $$ is PID and { ends delimiter
+					dollar_count = 0;
+					j = this.pos - 1;
+					while (j >= 0 && this.source[j] === "$") {
+						dollar_count += 1;
+						j -= 1;
+					}
+					if (dollar_count % 2 === 1) {
+						// Odd number of $ before: this $ pairs with previous to form $$
+						// Don't consume the {, let it end the delimiter
 						delimiter_chars.push(this.advance());
+					} else {
+						// Parameter expansion embedded in delimiter
+						delimiter_chars.push(this.advance());
+						delimiter_chars.push(this.advance());
+						depth = 1;
+						while (!this.atEnd() && depth > 0) {
+							c = this.peek();
+							if (c === "{") {
+								depth += 1;
+							} else if (c === "}") {
+								depth -= 1;
+							}
+							delimiter_chars.push(this.advance());
+						}
 					}
 				} else if (
 					ch === "$" &&

--- a/src/parable.py
+++ b/src/parable.py
@@ -7453,17 +7453,28 @@ class Parser:
                             depth -= 1
                         delimiter_chars.append(self.advance())
                 elif ch == "$" and self.pos + 1 < self.length and self.source[self.pos + 1] == "{":
-                    # Parameter expansion embedded in delimiter
-                    delimiter_chars.append(self.advance())  # $
-                    delimiter_chars.append(self.advance())  # {
-                    depth = 1
-                    while not self.at_end() and depth > 0:
-                        c = self.peek()
-                        if c == "{":
-                            depth += 1
-                        elif c == "}":
-                            depth -= 1
-                        delimiter_chars.append(self.advance())
+                    # Check if this is $${ where $$ is PID and { ends delimiter
+                    dollar_count = 0
+                    j = self.pos - 1
+                    while j >= 0 and self.source[j] == "$":
+                        dollar_count += 1
+                        j -= 1
+                    if dollar_count % 2 == 1:
+                        # Odd number of $ before: this $ pairs with previous to form $$
+                        # Don't consume the {, let it end the delimiter
+                        delimiter_chars.append(self.advance())  # $
+                    else:
+                        # Parameter expansion embedded in delimiter
+                        delimiter_chars.append(self.advance())  # $
+                        delimiter_chars.append(self.advance())  # {
+                        depth = 1
+                        while not self.at_end() and depth > 0:
+                            c = self.peek()
+                            if c == "{":
+                                depth += 1
+                            elif c == "}":
+                                depth -= 1
+                            delimiter_chars.append(self.advance())
                 elif ch == "$" and self.pos + 1 < self.length and self.source[self.pos + 1] == "[":
                     # Check if this is $$[ where $$ is PID and [ ends delimiter
                     dollar_count = 0

--- a/tests/parable/character-fuzzer/fuzz-7ae9cad8896c8f0860fa4ad75be38704.tests
+++ b/tests/parable/character-fuzzer/fuzz-7ae9cad8896c8f0860fa4ad75be38704.tests
@@ -1,0 +1,5 @@
+=== heredoc with ${ in delimiter followed by redirect
+<<$${>&}
+---
+(command (redirect "<<" "") (redirect ">&" "}"))
+---


### PR DESCRIPTION
## Summary
- Fixed parser bug where `$${` in heredoc delimiters was incorrectly treated as a parameter expansion
- The `$$` is the PID variable, so the `{` should end the delimiter, not start a `${...}` expansion
- Added logic similar to existing `$$[` handling to check for odd number of `$` before `${`
- MRE: `<<$${>&}` now correctly parses as heredoc with delimiter `$${` plus redirect `>&` with target `}`

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-7ae9cad8896c8f0860fa4ad75be38704.tests`
- [ ] `just check` passes