### PR TITLE
fuzzer fix: handle 6463 before quoted string in parameter expansion

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-3b9c8f46fcf4a0066380b2d54abcc9c1.tests
+++ b/tests/parable/character-fuzzer/fuzz-3b9c8f46fcf4a0066380b2d54abcc9c1.tests
@@ -1,0 +1,4 @@
+=== $$ before quoted string in parameter expansion
+${$$""}
+---
+(command (word "${$$\"\"}"))


### PR DESCRIPTION
## Summary
Fixed a bug where `$$` (process ID variable) was incorrectly dropped when it appeared before a quoted string inside a parameter expansion.

MRE: `${$$""}`

The parser was treating `$"` as a locale string and stripping the `$`, even when it was part of `$$`. Now it counts consecutive `$` characters and only strips the `$` when the count is odd (indicating a locale/ANSI-C string), not when even (indicating `$$` followed by a quoted string).