### PR TITLE
fuzzer fix: handle bracket as literal when followed by whitespace

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9794,6 +9794,7 @@ class Parser {
 			locale_result,
 			locale_text,
 			next_c,
+			next_ch,
 			param_node,
 			param_result,
 			param_text,
@@ -9898,6 +9899,19 @@ class Parser {
 			// Glob bracket expression [...] - consume until closing ]
 			// Handles [[:alpha:]], [^0-9], []a-z] (] as first char), etc.
 			if (ch === "[") {
+				// Check if [ is immediately followed by whitespace or terminator
+				// If so, treat [ as literal, not as bracket expression start
+				if (this.pos + 1 >= this.length) {
+					// [ at EOF is literal
+					chars.push(this.advance());
+					continue;
+				}
+				next_ch = this.source[this.pos + 1];
+				if (_isWhitespaceNoNewline(next_ch)) {
+					// [ followed by whitespace is literal
+					chars.push(this.advance());
+					continue;
+				}
 				chars.push(this.advance());
 				// Handle negation [^
 				if (!this.atEnd() && this.peek() === "^") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -8180,6 +8180,17 @@ class Parser:
             # Glob bracket expression [...] - consume until closing ]
             # Handles [[:alpha:]], [^0-9], []a-z] (] as first char), etc.
             if ch == "[":
+                # Check if [ is immediately followed by whitespace or terminator
+                # If so, treat [ as literal, not as bracket expression start
+                if self.pos + 1 >= self.length:
+                    # [ at EOF is literal
+                    chars.append(self.advance())
+                    continue
+                next_ch = self.source[self.pos + 1]
+                if _is_whitespace_no_newline(next_ch):
+                    # [ followed by whitespace is literal
+                    chars.append(self.advance())
+                    continue
                 chars.append(self.advance())  # consume [
                 # Handle negation [^
                 if not self.at_end() and self.peek() == "^":

--- a/tests/parable/character-fuzzer/fuzz-03debf9b1973f99038921b3125f6f3a5.tests
+++ b/tests/parable/character-fuzzer/fuzz-03debf9b1973f99038921b3125f6f3a5.tests
@@ -1,0 +1,5 @@
+=== single bracket with character class pattern
+[[ [ = [[::]] ]]
+---
+(cond (cond-binary "=" (cond-term "[") (cond-term "[[::]]")))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of standalone `[` in conditional expressions. When `[` is followed by whitespace, it should be treated as a literal character, not as the start of a glob bracket expression.
- MRE: `[[ [ = [[::]] ]]`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-03debf9b1973f99038921b3125f6f3a5.tests`
- [x] `just check` passes