### PR TITLE
fuzzer fix: handle newlines before background in process substitution

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1682,25 +1682,9 @@ class Word extends Node {
 					// Extract raw content for further checks
 					raw_content = value.slice(i + 2, j - 1);
 					raw_stripped = raw_content.replaceAll("\\\n", "");
-					// Check if this is a list with & operator and newlines before &
-					// In that case, preserve raw content to avoid losing newlines
-					if (
-						node.command.kind === "list" &&
-						node.command.parts &&
-						node.command.parts[node.command.parts.length - 1].kind ===
-							"operator" &&
-						node.command.parts[node.command.parts.length - 1].op === "&" &&
-						raw_content.endsWith("&") &&
-						raw_content.slice(0, raw_content.lastIndexOf("&")).includes("\n")
-					) {
-						// Preserve raw content for lists with & and newlines before &
-						result.push(`${direction}(${raw_stripped})`);
-					} else if (
-						_startsWithSubshell(node.command) &&
-						formatted !== raw_stripped
-					) {
-						// Check for pattern: subshell followed by operator with no space (e.g., "(0)&+")
-						// In this case, preserve original to match bash-oracle behavior
+					// Check for pattern: subshell followed by operator with no space (e.g., "(0)&+")
+					// In this case, preserve original to match bash-oracle behavior
+					if (_startsWithSubshell(node.command) && formatted !== raw_stripped) {
 						// Starts with subshell and formatting would change it - preserve original
 						result.push(`${direction}(${raw_stripped})`);
 					} else {

--- a/src/parable.py
+++ b/src/parable.py
@@ -1329,21 +1329,9 @@ class Word(Node):
                     # Extract raw content for further checks
                     raw_content = _substring(value, i + 2, j - 1)
                     raw_stripped = raw_content.replace("\\\n", "")
-                    # Check if this is a list with & operator and newlines before &
-                    # In that case, preserve raw content to avoid losing newlines
-                    if (
-                        node.command.kind == "list"
-                        and node.command.parts
-                        and node.command.parts[len(node.command.parts) - 1].kind == "operator"
-                        and node.command.parts[len(node.command.parts) - 1].op == "&"
-                        and raw_content.endswith("&")
-                        and "\n" in raw_content[: raw_content.rfind("&")]
-                    ):
-                        # Preserve raw content for lists with & and newlines before &
-                        result.append(direction + "(" + raw_stripped + ")")
                     # Check for pattern: subshell followed by operator with no space (e.g., "(0)&+")
                     # In this case, preserve original to match bash-oracle behavior
-                    elif _starts_with_subshell(node.command) and formatted != raw_stripped:
+                    if _starts_with_subshell(node.command) and formatted != raw_stripped:
                         # Starts with subshell and formatting would change it - preserve original
                         result.append(direction + "(" + raw_stripped + ")")
                     else:

--- a/tests/parable/character-fuzzer/fuzz-5bb9c9340be220283a1cf11a1232faa2.tests
+++ b/tests/parable/character-fuzzer/fuzz-5bb9c9340be220283a1cf11a1232faa2.tests
@@ -1,0 +1,6 @@
+=== newline before background in process substitution
+<(
+b&)
+---
+(command (word "<(b &)"))
+---


### PR DESCRIPTION
## Summary
Fixed bug where newlines before background operators in process substitutions were preserved as literal `\n` in the word representation instead of being processed as whitespace.

**MRE:** `<(\nb&)` 

Expected: `(command (word "<(b &)"))`
Was producing: `(command (word "<(\nb&)"))`

The fix removes a special case that was preserving raw content for lists with `&` operators and newlines. Now these are properly formatted using the AST, matching bash-oracle behavior.