### PR TITLE
fuzzer fix: handle here-strings in command substitutions correctly

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -3962,6 +3962,17 @@ def _extract_heredoc_delimiters(content: str) -> list[tuple[str, bool]]:
             continue
         if content[i] == "<" and i + 1 < len(content) and content[i + 1] == "<":
             i += 2
+            # Check for <<< (here-string) - skip it, not a heredoc
+            if i < len(content) and content[i] == "<":
+                i += 1
+                # Skip whitespace and word
+                while i < len(content) and _is_whitespace_no_newline(content[i]):
+                    i += 1
+                while (
+                    i < len(content) and not _is_whitespace(content[i]) and content[i] not in "()"
+                ):
+                    i += 1
+                continue
             strip_tabs = False
             if i < len(content) and content[i] == "-":
                 strip_tabs = True
@@ -5081,6 +5092,33 @@ class Parser:
             ):
                 self.advance()  # first <
                 self.advance()  # second <
+                # Check for <<< (here-string) - just skip the word and continue
+                if not self.at_end() and self.peek() == "<":
+                    self.advance()  # third <
+                    # Skip whitespace before word
+                    while not self.at_end() and _is_whitespace_no_newline(self.peek()):
+                        self.advance()
+                    # Skip the here-string word
+                    while (
+                        not self.at_end()
+                        and not _is_whitespace(self.peek())
+                        and self.peek() not in "()"
+                    ):
+                        if self.peek() == "\\" and self.pos + 1 < self.length:
+                            self.advance()
+                            self.advance()
+                        elif self.peek() in "\"'":
+                            quote = self.peek()
+                            self.advance()
+                            while not self.at_end() and self.peek() != quote:
+                                if quote == '"' and self.peek() == "\\":
+                                    self.advance()
+                                self.advance()
+                            if not self.at_end():
+                                self.advance()
+                        else:
+                            self.advance()
+                    continue
                 # Check for <<- (strip tabs)
                 if not self.at_end() and self.peek() == "-":
                     self.advance()

--- a/tests/parable/character-fuzzer/fuzz-cdd23c329946cf5f0362a6a571d65bfc.tests
+++ b/tests/parable/character-fuzzer/fuzz-cdd23c329946cf5f0362a6a571d65bfc.tests
@@ -1,0 +1,8 @@
+=== here-string in command substitution with whitespace before closing paren
+$(<<< a
+ )
+b
+---
+(command (word "$(<<< a)"))
+(command (word "b"))
+---


### PR DESCRIPTION
## Summary
Fixed a bug where here-strings (`<<<`) inside command substitutions were incorrectly treated as heredocs, causing the parser to consume content beyond the command substitution boundary.

**MRE:**
```bash
$(<<< a
 )
b
```

**Expected:** Two separate commands - the command substitution `$(<<< a)` and command `b`
**Before fix:** Single command with `b` incorrectly included in the command substitution
**After fix:** Correctly parses as two separate commands

The fix adds proper here-string detection in two places:
1. In `_parse_command_substitution`: Skip here-string word when parsing command substitution content
2. In `_extract_heredoc_delimiters`: Don't treat `<<<` as a heredoc when extracting heredoc delimiters

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-cdd23c329946cf5f0362a6a571d65bfc.tests`
- [x] `just check` passes