### PR TITLE
fuzzer fix: preserve whitespace in process substitution content

### DIFF
--- a/src/parable.py
+++ b/src/parable.py
@@ -1516,6 +1516,7 @@ class Word(Node):
                     depth = 1
                     pattern_parts = []
                     current_part = []
+                    has_pipe = False
                     while i < len(value) and depth > 0:
                         if value[i] == "\\" and i + 1 < len(value):
                             # Escaped character, keep as-is
@@ -1531,16 +1532,19 @@ class Word(Node):
                             if depth == 0:
                                 # End of pattern
                                 part_content = "".join(current_part)
-                                # Don't strip if this looks like a process substitution with heredoc
+                                # Only strip if this is an alternation pattern (has |) or contains heredoc
                                 if "<<" in part_content:
                                     pattern_parts.append(part_content)
-                                else:
+                                elif has_pipe:
                                     pattern_parts.append(part_content.strip())
+                                else:
+                                    pattern_parts.append(part_content)
                                 break
                             current_part.append(value[i])
                             i += 1
                         elif value[i] == "|" and depth == 1:
                             # Top-level pipe separator
+                            has_pipe = True
                             part_content = "".join(current_part)
                             # Don't strip if this looks like a process substitution with heredoc
                             if "<<" in part_content:

--- a/tests/parable/character-fuzzer/fuzz-468680da544044ec491fcbe3c35e724b.tests
+++ b/tests/parable/character-fuzzer/fuzz-468680da544044ec491fcbe3c35e724b.tests
@@ -1,0 +1,5 @@
+=== process substitution with arithmetic expansion and trailing space
+[[ <(( 1 ) ) ]]
+---
+(cond (cond-unary "-n" (cond-term "<(( 1 ) )")))
+---


### PR DESCRIPTION
## Summary
Fixed bug where trailing whitespace before the closing `)` in process substitution content was being stripped. For example, `[[ <(( 1 ) ) ]]` was incorrectly parsed as `<(( 1 ))` instead of `<(( 1 ) )`.

The issue was in `_normalize_extglob_whitespace` which was stripping all whitespace from `<()` and `>()` patterns, even when they were actual process substitutions rather than regex alternation patterns. The fix adds a check to only strip whitespace when there's an actual `|` alternation operator in the pattern.

MRE: `[[ <(( 1 ) ) ]]`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-468680da544044ec491fcbe3c35e724b.tests`
- [x] `just check` passes