### PR TITLE
fuzzer fix: normalize whitespace in heredoc delimiters with expansions

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-c74d8c48d3000300790c7cf88e998949.tests
+++ b/tests/parable/character-fuzzer/fuzz-c74d8c48d3000300790c7cf88e998949.tests
@@ -1,0 +1,6 @@
+=== heredoc delimiter with tab before closing paren
+cat <<$(a	)
+$(a)
+---
+(command (word "cat") (redirect "<<" ""))
+---


### PR DESCRIPTION
## Summary
Fixed bug where tabs/spaces inside expansion constructs (command substitutions, parameter expansions, process substitutions) in heredoc delimiters were not normalized during matching.

**MRE:** `cat <<$(a\t)\n$(a)` (where `\t` is a literal tab)

Expected: heredoc content is empty (delimiter `$(a\t)` matches line `$(a)`)
Was producing: heredoc content includes `$(a)\n` (delimiter didn't match)

The fix adds whitespace normalization for heredoc delimiter matching:
- Tabs/spaces inside `$(...)`, `${...}`, `<(...)`, `>(...)` are collapsed to single spaces
- Leading/trailing whitespace inside these constructs is stripped
- Whitespace outside these constructs is preserved as-is

This matches bash behavior where delimiters like `<<$(a\t)` expect a line `$(a)` to match.