### PR TITLE
fuzzer fix: handle semicolons after heredoc delimiters in command substitutions

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-c6637ca7e27d5c7795f0cf52500230fc.tests
+++ b/tests/parable/character-fuzzer/fuzz-c6637ca7e27d5c7795f0cf52500230fc.tests
@@ -1,0 +1,7 @@
+=== semicolon after heredoc in command substitution
+$(:<<E
+E
+a;b)
+---
+(command (word "$(: <<E\nE\n\na b)"))
+---


### PR DESCRIPTION
## Summary
- In bash, after a heredoc delimiter in a command substitution, semicolons on the following line are treated as whitespace (word separators) instead of command separators
- The MRE `$(:<<E\nE\na;b)` should parse as `a b` (two words), not `a; b` (two commands)
- Fix: When finding a heredoc delimiter in a command substitution, convert semicolons on the next line to spaces, preserving semicolons before closing braces/parens

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-c6637ca7e27d5c7795f0cf52500230fc.tests`
- [x] `just check` passes