### PR TITLE
fuzzer fix: handle [ followed by && or || as literal in conditionals

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9977,8 +9977,12 @@ class Parser {
 					continue;
 				}
 				next_ch = this.source[this.pos + 1];
-				if (_isWhitespaceNoNewline(next_ch)) {
-					// [ followed by whitespace is literal
+				if (
+					_isWhitespaceNoNewline(next_ch) ||
+					next_ch === "&" ||
+					next_ch === "|"
+				) {
+					// [ followed by whitespace or operator is literal
 					chars.push(this.advance());
 					continue;
 				}

--- a/src/parable.py
+++ b/src/parable.py
@@ -8241,8 +8241,8 @@ class Parser:
                     chars.append(self.advance())
                     continue
                 next_ch = self.source[self.pos + 1]
-                if _is_whitespace_no_newline(next_ch):
-                    # [ followed by whitespace is literal
+                if _is_whitespace_no_newline(next_ch) or next_ch == "&" or next_ch == "|":
+                    # [ followed by whitespace or operator is literal
                     chars.append(self.advance())
                     continue
                 chars.append(self.advance())  # consume [

--- a/tests/parable/character-fuzzer/fuzz-5215c1b4eb2a1575fc3115df286634b0.tests
+++ b/tests/parable/character-fuzzer/fuzz-5215c1b4eb2a1575fc3115df286634b0.tests
@@ -1,0 +1,5 @@
+=== && should be parsed as operator not literal in conditional
+[[ [&&] ]]
+---
+(cond (cond-and (cond-unary "-n" (cond-term "[")) (cond-unary "-n" (cond-term "]"))))
+---


### PR DESCRIPTION
## Summary
- Fixed parsing of `[` in conditional expressions when followed by `&&` or `||` operators
- MRE: `[[ [&&] ]]`
- Previously, `[&&]` was incorrectly parsed as a bracket expression instead of treating `[` as a literal, `&&` as AND operator, and `]` as another literal
- Now checks if `[` is followed by `&` or `|` and treats it as literal to allow proper operator parsing

## Test plan
- [ ] New test added to `tests/parable/character-fuzzer/fuzz-5215c1b4eb2a1575fc3115df286634b0.tests`
- [ ] `just check` passes