### PR TITLE
fuzzer fix: handle incomplete heredocs in command/process substitutions

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-674baea60f92ec6f977a5acfb25cf2bb.tests
+++ b/tests/parable/character-fuzzer/fuzz-674baea60f92ec6f977a5acfb25cf2bb.tests
@@ -1,0 +1,7 @@
+=== backslash-newline in heredoc inside process substitution with special chars
+<(<<a
+a?&\
+)
+---
+(command (word "<(<<a\na\n\n? &)"))
+---


### PR DESCRIPTION
## Summary
- When a heredoc inside a command or process substitution has backslash-newline continuations and doesn't find its closing delimiter at EOF, bash includes the delimiter line itself as content
- Added proper handling for backslash-newline continuations in delimiter matching
- Added delimiter prefix matching (stops at delimiter even if line continues)
- Include delimiter as content when heredoc is incomplete (in substitutions only)
- Exclude heredoc cases from raw content preservation in _format_command_substitutions