### PR TITLE
fuzzer fix: handle semicolons after heredoc-newline patterns in command substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3828,6 +3828,15 @@ function _formatCmdsubNode(
 						skipped_semi = true;
 						continue;
 					}
+					// Skip semicolon after pattern: heredoc, newline, command
+					if (
+						result.length >= 3 &&
+						result[result.length - 2] === "\n" &&
+						result[result.length - 3].endsWith("\n")
+					) {
+						skipped_semi = true;
+						continue;
+					}
 					result.push(";");
 					skipped_semi = false;
 				} else if (p.op === "\n") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3225,6 +3225,14 @@ def _format_cmdsub_node(
                     if result and result[len(result) - 1].endswith("\n"):
                         skipped_semi = True
                         continue
+                    # Skip semicolon after pattern: heredoc, newline, command
+                    if (
+                        len(result) >= 3
+                        and result[len(result) - 2] == "\n"
+                        and result[len(result) - 3].endswith("\n")
+                    ):
+                        skipped_semi = True
+                        continue
                     result.append(";")
                     skipped_semi = False
                 elif p.op == "\n":

--- a/tests/parable/character-fuzzer/fuzz-217f3cadbe1226c7f41d98694f13f745.tests
+++ b/tests/parable/character-fuzzer/fuzz-217f3cadbe1226c7f41d98694f13f745.tests
@@ -1,0 +1,7 @@
+=== semicolon after heredoc in command substitution treated as command separator
+$(a <<E
+E
+b;c)
+---
+(command (word "$(a <<E\nE\n\nb c)"))
+---


### PR DESCRIPTION
## Summary
- Fixed parser bug where semicolons after a heredoc followed by a newline in command substitutions were treated as command separators instead of being skipped
- MRE: `$(a <<E\nE\nb;c)` should parse as `b c` (no semicolon), not `b; c`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-217f3cadbe1226c7f41d98694f13f745.tests`
- [x] `just check` passes  