### PR TITLE
fuzzer fix: capture heredoc body when cmdsub has trailing content after )

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -6052,6 +6052,7 @@ class Parser {
 			found_in_content,
 			heredoc_delimiters,
 			heredoc_end,
+			heredoc_scan_pos,
 			heredoc_start,
 			line,
 			line_end,
@@ -6491,9 +6492,16 @@ class Parser {
 		// Save position after ) for text (before skipping heredoc content)
 		text_end = this.pos;
 		// Check for heredocs in content whose bodies follow the )
-		// This handles cases like $(cmd <<X) where ) immediately follows <<X
-		// Only process if there's a newline after ) - otherwise no heredoc content exists
-		if (!this.atEnd() && this.peek() === "\n") {
+		// This handles cases like $(cmd <<X) or $(cmd <<X)c where ) is followed by content then newline
+		// Look ahead for a newline - heredoc content starts after the first newline
+		heredoc_scan_pos = this.pos;
+		while (
+			heredoc_scan_pos < this.length &&
+			this.source[heredoc_scan_pos] !== "\n"
+		) {
+			heredoc_scan_pos += 1;
+		}
+		if (heredoc_scan_pos < this.length) {
 			// Filter to only heredocs that weren't already consumed during parsing
 			all_heredoc_delimiters = _extractHeredocDelimiters(content);
 			heredoc_delimiters = [];

--- a/src/parable.py
+++ b/src/parable.py
@@ -5391,9 +5391,12 @@ class Parser:
         text_end = self.pos
 
         # Check for heredocs in content whose bodies follow the )
-        # This handles cases like $(cmd <<X) where ) immediately follows <<X
-        # Only process if there's a newline after ) - otherwise no heredoc content exists
-        if not self.at_end() and self.peek() == "\n":
+        # This handles cases like $(cmd <<X) or $(cmd <<X)c where ) is followed by content then newline
+        # Look ahead for a newline - heredoc content starts after the first newline
+        heredoc_scan_pos = self.pos
+        while heredoc_scan_pos < self.length and self.source[heredoc_scan_pos] != "\n":
+            heredoc_scan_pos += 1
+        if heredoc_scan_pos < self.length:
             # Filter to only heredocs that weren't already consumed during parsing
             all_heredoc_delimiters = _extract_heredoc_delimiters(content)
             heredoc_delimiters = []

--- a/tests/parable/character-fuzzer/fuzz-ea8331ecf6918c15b50af14d894ba602.tests
+++ b/tests/parable/character-fuzzer/fuzz-ea8331ecf6918c15b50af14d894ba602.tests
@@ -1,0 +1,7 @@
+=== heredoc body after cmdsub with trailing content not captured
+$(a <<E)c
+b
+E
+---
+(command (word "$(a <<E\nb\nE\n)c"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where heredoc body was not captured when command substitution has trailing content after the closing paren
- MRE: `$(a <<E)c\nb\nE` should parse as single command with heredoc body `b`, not as separate commands

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-ea8331ecf6918c15b50af14d894ba602.tests`
- [x] `just check` passes