### PR TITLE
fuzzer fix: handle nested ${...} after param name without consuming $ as operator

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8365,6 +8365,14 @@ class Parser {
 				}
 				this.advance();
 				op = "`";
+			} else if (
+				!this.atEnd() &&
+				this.peek() === "$" &&
+				this.pos + 1 < this.length &&
+				this.source[this.pos + 1] === "{"
+			) {
+				// Nested ${...} - don't consume $ as operator, let argument loop handle it
+				op = "";
 			} else {
 				// Unknown operator - bash still parses these (fails at runtime)
 				// Treat the current char as the operator

--- a/src/parable.py
+++ b/src/parable.py
@@ -6967,6 +6967,14 @@ class Parser:
                     raise ParseError("Unterminated backtick", pos=backtick_pos)
                 self.advance()  # closing `
                 op = "`"  # treat as operator for now, bash will error at runtime
+            elif (
+                not self.at_end()
+                and self.peek() == "$"
+                and self.pos + 1 < self.length
+                and self.source[self.pos + 1] == "{"
+            ):
+                # Nested ${...} - don't consume $ as operator, let argument loop handle it
+                op = ""
             else:
                 # Unknown operator - bash still parses these (fails at runtime)
                 # Treat the current char as the operator

--- a/tests/parable/character-fuzzer/fuzz-cee5f7afcc6b52a1f6f07436a6a0056a.tests
+++ b/tests/parable/character-fuzzer/fuzz-cee5f7afcc6b52a1f6f07436a6a0056a.tests
@@ -1,0 +1,6 @@
+=== nested brace expansion with newline inside outer expansion
+${a${b}
+x}
+---
+(command (word "${a${b}\nx}"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `${a${b}\nx}` was incorrectly parsed as two commands
- When a `${` follows a param name (like `${a${b}`), the `$` was consumed as an unknown operator instead of letting the argument loop handle it as a nested expansion
- MRE: `${a${b}\nx}` should be one command with a single word, not two commands