### PR TITLE
fuzzer fix: place 2>&1 before heredoc body in |& pipes

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3738,9 +3738,6 @@ function _formatCmdsubNode(
 				false,
 				procsub_first && idx === 0,
 			);
-			if (needs_redirect) {
-				formatted = `${formatted} 2>&1`;
-			}
 			is_last = idx === cmds.length - 1;
 			// Check if command has actual heredoc redirects
 			has_heredoc = false;
@@ -3750,6 +3747,19 @@ function _formatCmdsubNode(
 						has_heredoc = true;
 						break;
 					}
+				}
+			}
+			// Add 2>&1 for |& pipes - before heredoc body if present
+			if (needs_redirect) {
+				if (has_heredoc) {
+					first_nl = formatted.indexOf("\n");
+					if (first_nl !== -1) {
+						formatted = `${formatted.slice(0, first_nl)} 2>&1${formatted.slice(first_nl)}`;
+					} else {
+						formatted = `${formatted} 2>&1`;
+					}
+				} else {
+					formatted = `${formatted} 2>&1`;
 				}
 			}
 			if (!is_last && has_heredoc) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3156,8 +3156,6 @@ def _format_cmdsub_node(
             formatted = _format_cmdsub_node(
                 cmd, indent, in_procsub, False, procsub_first and idx == 0
             )
-            if needs_redirect:
-                formatted = formatted + " 2>&1"
             is_last = idx == len(cmds) - 1
             # Check if command has actual heredoc redirects
             has_heredoc = False
@@ -3166,6 +3164,16 @@ def _format_cmdsub_node(
                     if r.kind == "heredoc":
                         has_heredoc = True
                         break
+            # Add 2>&1 for |& pipes - before heredoc body if present
+            if needs_redirect:
+                if has_heredoc:
+                    first_nl = formatted.find("\n")
+                    if first_nl != -1:
+                        formatted = formatted[:first_nl] + " 2>&1" + formatted[first_nl:]
+                    else:
+                        formatted = formatted + " 2>&1"
+                else:
+                    formatted = formatted + " 2>&1"
             if not is_last and has_heredoc:
                 # Heredoc present - insert pipe after heredoc delimiter, before content
                 # Pattern: "... <<DELIM\ncontent\nDELIM\n" -> "... <<DELIM |\ncontent\nDELIM\n"

--- a/tests/parable/character-fuzzer/fuzz-ed6dea47ffd7289817496ab36681fa5c.tests
+++ b/tests/parable/character-fuzzer/fuzz-ed6dea47ffd7289817496ab36681fa5c.tests
@@ -1,0 +1,5 @@
+=== heredoc with |& in command substitution
+"$(a<<d|&b)"
+---
+(command (word "\"$(a <<d 2>&1 |\nd\n  b)\""))
+---


### PR DESCRIPTION
## Summary
- When `|&` is used with a heredoc in a command substitution, the `2>&1` redirect was incorrectly placed after the heredoc body instead of before it
- MRE: `"$(a<<d|&b)"`