### PR TITLE
fuzzer fix: normalize array whitespace in command substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3686,6 +3686,8 @@ function _formatCmdsubNode(
 			val = w._expandAllAnsiCQuotes(w.value);
 			// Strip $ from locale strings $"..." (quote-aware)
 			val = w._stripLocaleStringDollars(val);
+			// Normalize whitespace in array assignments
+			val = w._normalizeArrayWhitespace(val);
 			val = w._formatCommandSubstitutions(val);
 			parts.push(val);
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -3117,6 +3117,8 @@ def _format_cmdsub_node(
             val = w._expand_all_ansi_c_quotes(w.value)
             # Strip $ from locale strings $"..." (quote-aware)
             val = w._strip_locale_string_dollars(val)
+            # Normalize whitespace in array assignments
+            val = w._normalize_array_whitespace(val)
             val = w._format_command_substitutions(val)
             parts.append(val)
         # Check for heredocs - their bodies need to come at the end

--- a/tests/parable/character-fuzzer/fuzz-83c8191e3d95d38e1b03caf0858b601a.tests
+++ b/tests/parable/character-fuzzer/fuzz-83c8191e3d95d38e1b03caf0858b601a.tests
@@ -1,0 +1,5 @@
+=== whitespace stripped in array assignment inside command substitution
+$(x=( ))
+---
+(command (word "$(x=())"))
+---


### PR DESCRIPTION
## Summary
- Array assignments like `x=( )` inside command substitutions weren't having their whitespace normalized
- MRE: `$(x=( ))` produced `$(x=( ))` instead of `$(x=())`
- Added call to `_normalize_array_whitespace` in `_format_cmdsub_node` when formatting word values