### PR TITLE
fuzzer fix: track single quotes inside brace expansions for locale strings

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-ad88fc84d25f8c904c201779df7384e7.tests
+++ b/tests/parable/character-fuzzer/fuzz-ad88fc84d25f8c904c201779df7384e7.tests
@@ -1,0 +1,5 @@
+=== preserve $" inside single quotes in parameter expansion
+${a:-'$"'}
+---
+(command (word "${a:-'$\"'}"))
+---


### PR DESCRIPTION
## Summary
- `$"` inside single quotes within parameter expansions was incorrectly being treated as a locale string and having the `$` stripped
- MRE: `${a:-'$"'}`
- Fix: Track single quotes inside brace expansions (`brace_in_single_quote`) similar to how double quotes are tracked