### PR TITLE
fuzzer fix: preserve ANSI-C quotes after @% and similar operators in param expansions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -667,8 +667,23 @@ class Word extends Node {
 							// Check if operator immediately after variable name is a pattern operator
 							if (var_name_len > 0 && var_name_len < after_brace.length) {
 								op_start = after_brace.slice(var_name_len);
+								// Skip @ prefix if present (handles @%, @#, @/ etc.)
+								if (op_start.startsWith("@") && op_start.length > 1) {
+									op_start = op_start.slice(1);
+								}
 								// Check if it starts with a pattern operator
-								for (op of ["//", "%%", "##", "/", "%", "#"]) {
+								for (op of [
+									"//",
+									"%%",
+									"##",
+									"/",
+									"%",
+									"#",
+									"^",
+									"^^",
+									",",
+									",,",
+								]) {
 									if (op_start.startsWith(op)) {
 										in_pattern = true;
 										break;

--- a/src/parable.py
+++ b/src/parable.py
@@ -582,8 +582,11 @@ class Word(Node):
                             # Check if operator immediately after variable name is a pattern operator
                             if var_name_len > 0 and var_name_len < len(after_brace):
                                 op_start = after_brace[var_name_len:]
+                                # Skip @ prefix if present (handles @%, @#, @/ etc.)
+                                if op_start.startswith("@") and len(op_start) > 1:
+                                    op_start = op_start[1:]
                                 # Check if it starts with a pattern operator
-                                for op in ["//", "%%", "##", "/", "%", "#"]:
+                                for op in ["//", "%%", "##", "/", "%", "#", "^", "^^", ",", ",,"]:
                                     if op_start.startswith(op):
                                         in_pattern = True
                                         break

--- a/tests/parable/character-fuzzer/fuzz-a42b1f014d8cb7531d0c37b3aa5f835f.tests
+++ b/tests/parable/character-fuzzer/fuzz-a42b1f014d8cb7531d0c37b3aa5f835f.tests
@@ -1,0 +1,5 @@
+=== ANSI-C quote after @% in double-quoted param expansion loses quotes
+"${x@%$'a'}"
+---
+(command (word "\"${x@%'a'}\""))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where ANSI-C quoted strings (`$'...'`) after `@%`, `@#`, `@/`, `@^`, `@,` operators inside double-quoted parameter expansions were incorrectly having their quotes stripped
- MRE: `"${x@%$'a'}"` should preserve as `"${x@%'a'}"`, not `"${x@%a}"`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-a42b1f014d8cb7531d0c37b3aa5f835f.tests`
- [x] `just check` passes