### PR TITLE
Add pricing lookup and improve fuzzer-agent CLI

### DIFF
--- a/tools/fuzzer-agent/README.md
+++ b/tools/fuzzer-agent/README.md
@@ -2,11 +2,15 @@
 
 Strands SDK agent that autonomously finds and fixes fuzzer bugs.
 
-```bash
-uv run fuzzer-agent --model haiku-35
-uv run fuzzer-agent --model sonnet-45
 ```
+usage: fuzzer-agent [-h] [--model MODEL] [--prices]
 
-Exit codes: 0 (fixed + PR created), 1 (no bugs found), 2 (agent failed).
+Autonomous fuzzer bug fixing agent
 
-Requires AWS credentials for Bedrock.
+options:
+  -h, --help     show this help message and exit
+  --model MODEL  Model to use (default: sonnet-45)
+  --prices       Fetch live pricing from AWS and exit
+
+exit codes: 0 (fixed + PR), 1 (no bugs), 2 (failed)
+```

--- a/tools/fuzzer-agent/pyproject.toml
+++ b/tools/fuzzer-agent/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Autonomous fuzzer bug fixing agent for Parable"
 requires-python = ">=3.14"
 dependencies = [
+    "boto3>=1.35.0",
     "strands-agents>=1.22.0",
     "strands-agents-tools>=0.2.19",
     "structlog>=25.5.0",

--- a/tools/fuzzer-agent/src/fuzzer_agent/agent.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/agent.py
@@ -1,6 +1,8 @@
 """Fuzzer bug fixing agent using Strands."""
 
 import io
+import os
+import subprocess
 import time
 from contextlib import redirect_stderr
 from pathlib import Path
@@ -10,6 +12,25 @@ from strands import Agent
 from strands.models import BedrockModel
 
 from .tools import shell
+
+# Pricing per 1M tokens (input, output)
+MODEL_PRICING = {
+    "haiku-3": (0.25, 1.25),
+    "haiku-35": (0.80, 4.00),
+    "haiku-45": (1.00, 5.00),
+    "sonnet-35": (3.00, 15.00),
+    "sonnet-37": (3.00, 15.00),
+    "sonnet-4": (3.00, 15.00),
+    "sonnet-45": (3.00, 15.00),
+    "opus-4": (15.00, 75.00),
+    "opus-41": (15.00, 75.00),
+    "opus-45": (15.00, 75.00),
+    "llama-33-70b": (0.99, 0.99),
+    "llama-32-90b": (0.99, 0.99),
+    "llama-31-70b": (0.99, 0.99),
+    "nova-pro": (0.80, 3.20),
+    "nova-premier": (2.50, 10.00),
+}
 
 MODELS = {
     "haiku-3": "anthropic.claude-3-haiku-20240307-v1:0",
@@ -45,7 +66,39 @@ class FuzzerFixer:
     def _load_system_prompt(self) -> str:
         base = (PROMPTS_DIR / "fuzzer-fix-base.md").read_text()
         local = (PROMPTS_DIR / "fuzzer-fix-local.md").read_text()
-        return f"{base}\n\n{local}"
+        mre_instruction = "\n\n**Important:** After finding an MRE, write it to `/tmp/mre.txt` (just the bash code, no explanation).\n"
+        return f"{base}\n\n{local}{mre_instruction}"
+
+    def _write_summary(self, content: str) -> None:
+        """Append to GitHub Actions job summary if running in CI."""
+        summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_file:
+            try:
+                with open(summary_file, "a") as f:
+                    f.write(content)
+            except Exception as e:
+                self.log.warning("summary_write_failed", error=str(e))
+
+    def _get_git_sha(self) -> str:
+        """Get current git SHA."""
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=REPO_ROOT,
+                timeout=5,
+            )
+            return result.stdout.strip()[:7] if result.returncode == 0 else "unknown"
+        except Exception:
+            return "unknown"
+
+    def _calculate_cost(self, input_tokens: int, output_tokens: int) -> float:
+        """Calculate cost in dollars based on model pricing."""
+        pricing = MODEL_PRICING.get(self.model_name, (0, 0))
+        input_cost = (input_tokens / 1_000_000) * pricing[0]
+        output_cost = (output_tokens / 1_000_000) * pricing[1]
+        return input_cost + output_cost
 
     def run(self) -> int:
         """Run the fuzzer fixing agent.
@@ -55,6 +108,11 @@ class FuzzerFixer:
             1: No bugs found (fuzzer found no discrepancies)
             2: Agent failed
         """
+        base_sha = self._get_git_sha()
+        self._write_summary(
+            f"## Fuzzer Agent\n\n| | |\n|---|---|\n| **Model** | `{self.model_name}` |\n| **Base SHA** | `{base_sha}` |\n"
+        )
+        self.log.info("agent_start", model=self.model_name, base_sha=base_sha)
         model = BedrockModel(model_id=self.model_id, region_name="us-east-2")
         agent = Agent(
             model=model,
@@ -71,8 +129,41 @@ class FuzzerFixer:
             for line in stderr_capture.getvalue().splitlines():
                 if line.strip():
                     self.log.warning("agent_stderr", message=line)
-            output = str(response).lower()
-            self.log.info("agent_complete", duration=round(duration, 2))
+            output = str(response).lower() if response else ""
+            # Extract metrics safely
+            input_tokens = 0
+            output_tokens = 0
+            try:
+                if response and response.metrics and response.metrics.accumulated_usage:
+                    input_tokens = response.metrics.accumulated_usage.get("inputTokens", 0)
+                    output_tokens = response.metrics.accumulated_usage.get("outputTokens", 0)
+            except Exception:
+                pass
+            cost = self._calculate_cost(input_tokens, output_tokens)
+            final_sha = self._get_git_sha()
+            # Read MRE if written
+            mre = ""
+            mre_path = Path("/tmp/mre.txt")
+            try:
+                if mre_path.exists():
+                    mre = mre_path.read_text().strip()
+            except Exception:
+                pass
+            # Write final summary
+            summary = f"| **Final SHA** | `{final_sha}` |\n"
+            summary += f"| **Tokens** | {input_tokens:,} in / {output_tokens:,} out |\n"
+            summary += f"| **Cost** | ${cost:.4f} |\n"
+            summary += f"| **Duration** | {duration:.1f}s |\n"
+            if mre:
+                summary += f"\n### MRE\n```bash\n{mre}\n```\n"
+            self._write_summary(summary)
+            self.log.info(
+                "agent_complete",
+                duration=round(duration, 2),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost=round(cost, 4),
+            )
             # Determine exit code based on agent output
             if "no discrepancies" in output or "no bugs found" in output:
                 return 1
@@ -81,4 +172,6 @@ class FuzzerFixer:
             return 2
         except Exception as e:
             self.log.error("agent_failed", error=str(e))
+            error_msg = str(e).replace("`", "'")  # Escape backticks for markdown
+            self._write_summary(f"\n### Error\n```\n{error_msg}\n```\n")
             return 2

--- a/tools/fuzzer-agent/src/fuzzer_agent/pricing.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/pricing.py
@@ -1,0 +1,136 @@
+"""Fetch model pricing from AWS Pricing API.
+
+Claude models use hardcoded values because AWS Pricing API is incomplete
+(missing output token prices and newer models).
+
+Sources:
+- AWS Pricing API: Nova, Llama models
+- AWS Bedrock pricing page: Claude models (manually verified)
+"""
+
+import json
+import sys
+from collections import defaultdict
+
+import boto3
+
+REGION = "US East (Ohio)"
+
+# Claude pricing hardcoded - AWS Pricing API is incomplete (missing output prices)
+# Source: https://aws.amazon.com/bedrock/pricing/
+# Bug: https://github.com/aws/aws-cli/issues/9567
+CLAUDE_PRICING: dict[str, tuple[float, float]] = {
+    "haiku-3": (0.25, 1.25),
+    "haiku-35": (0.80, 4.00),
+    "haiku-45": (1.00, 5.00),
+    "sonnet-3": (3.00, 15.00),
+    "sonnet-35": (3.00, 15.00),
+    "sonnet-4": (3.00, 15.00),
+    "sonnet-45": (3.00, 15.00),
+    "opus-4": (15.00, 75.00),
+    "opus-45": (5.00, 25.00),
+}
+
+# Non-Claude pricing (fetched 2026-01-16, can be refreshed with --prices)
+OTHER_PRICING: dict[str, tuple[float, float]] = {
+    "llama-31-70b": (0.72, 0.72),
+    "llama-32-90b": (0.72, 0.72),
+    "llama-33-70b": (0.72, 0.72),
+    "nova-lite": (0.06, 0.24),
+    "nova-micro": (0.03, 0.14),
+    "nova-pro": (0.80, 3.20),
+}
+
+# Models to fetch from AWS Pricing API (API name -> our name)
+API_MODELS = {
+    "Nova Micro": "nova-micro",
+    "Nova Lite": "nova-lite",
+    "Nova Pro": "nova-pro",
+    "Llama 3.3 70B": "llama-33-70b",
+    "Llama 3.2 90B": "llama-32-90b",
+    "Llama 3.1 70B": "llama-31-70b",
+}
+
+
+def fetch_bedrock_pricing() -> dict[str, tuple[float, float]]:
+    """Fetch pricing from AWS Pricing API. Returns {model: (input, output)} per 1M tokens."""
+    client = boto3.client("pricing", region_name="us-east-1")
+    prices: dict[str, dict[str, float]] = defaultdict(dict)
+    next_token = None
+    while True:
+        kwargs: dict = {
+            "ServiceCode": "AmazonBedrock",
+            "Filters": [{"Type": "TERM_MATCH", "Field": "location", "Value": REGION}],
+            "MaxResults": 100,
+        }
+        if next_token:
+            kwargs["NextToken"] = next_token
+        response = client.get_products(**kwargs)
+        for price_item in response["PriceList"]:
+            item = json.loads(price_item)
+            attrs = item.get("product", {}).get("attributes", {})
+            model = attrs.get("model")
+            inference_type = attrs.get("inferenceType")
+            feature = attrs.get("feature")
+            if not model or model not in API_MODELS:
+                continue
+            if feature != "On-demand Inference":
+                continue
+            if inference_type not in ("Input tokens", "Output tokens"):
+                continue
+            terms = item.get("terms", {}).get("OnDemand", {})
+            for term in terms.values():
+                for dim in term.get("priceDimensions", {}).values():
+                    price_per_1k = float(dim["pricePerUnit"]["USD"])
+                    price_per_1m = price_per_1k * 1000
+                    key = "input" if inference_type == "Input tokens" else "output"
+                    prices[model][key] = price_per_1m
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+    # Convert to our format
+    result: dict[str, tuple[float, float]] = {}
+    for api_name, our_name in API_MODELS.items():
+        if api_name in prices:
+            p = prices[api_name]
+            if "input" in p and "output" in p:
+                result[our_name] = (p["input"], p["output"])
+    return result
+
+
+def get_all_pricing() -> dict[str, tuple[float, float]]:
+    """Get pricing for all models, combining API and hardcoded values."""
+    prices = dict(CLAUDE_PRICING)
+    try:
+        api_prices = fetch_bedrock_pricing()
+        prices.update(api_prices)
+    except Exception as e:
+        print(f"Warning: Could not fetch API pricing: {e}", file=sys.stderr)
+    return prices
+
+
+def main() -> None:
+    """Fetch and print pricing for all models."""
+    print("Fetching pricing from AWS...", file=sys.stderr)
+    prices = get_all_pricing()
+    print(f"\n{'Model':<15} {'Input/1M':<12} {'Output/1M':<12}")
+    print("-" * 40)
+    all_models = sorted(set(CLAUDE_PRICING.keys()) | set(API_MODELS.values()))
+    for model in all_models:
+        if model in prices:
+            input_price, output_price = prices[model]
+            print(f"{model:<15} ${input_price:<11.2f} ${output_price:<11.2f}")
+        else:
+            print(f"{model:<15} {'(not found)':<12} {'(not found)':<12}")
+    # Output as Python dict for easy copy
+    print("\n# Python dict format:")
+    print("MODEL_PRICING = {")
+    for model in all_models:
+        if model in prices:
+            input_price, output_price = prices[model]
+            print(f'    "{model}": ({input_price:.2f}, {output_price:.2f}),')
+    print("}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fuzzer-agent/uv.lock
+++ b/tools/fuzzer-agent/uv.lock
@@ -365,6 +365,7 @@ name = "fuzzer-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "strands-agents" },
     { name = "strands-agents-tools" },
     { name = "structlog" },
@@ -372,6 +373,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "strands-agents", specifier = ">=1.22.0" },
     { name = "strands-agents-tools", specifier = ">=0.2.19" },
     { name = "structlog", specifier = ">=25.5.0" },


### PR DESCRIPTION
- Add `--prices` flag to fetch live model pricing from AWS Pricing API
- Display model pricing table in `--help` output
- Add boto3 dependency for AWS API access
- Make GitHub summary writes robust against failures
- Update README with full help text