### PR TITLE
fuzzer fix: handle unclosed parameter expansion in extglob patterns

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1913,9 +1913,20 @@ class Word extends Node {
 					j += 1;
 				}
 				// Recursively format any cmdsubs inside the param expansion
-				inner = value.slice(i + 2, j - 1);
+				// When depth > 0 (unclosed ${), include all remaining chars
+				if (depth > 0) {
+					inner = value.slice(i + 2, j);
+				} else {
+					inner = value.slice(i + 2, j - 1);
+				}
 				formatted_inner = this._formatCommandSubstitutions(inner);
-				result.push(`\${${formatted_inner}}`);
+				// Only append closing } if we found one in the input
+				if (depth === 0) {
+					result.push(`\${${formatted_inner}}`);
+				} else {
+					// Unclosed ${...} - output without closing brace
+					result.push(`\${${formatted_inner}`);
+				}
 				i = j;
 			} else if (value[i] === '"') {
 				// Track double-quote state (single quotes inside double quotes are literal)

--- a/src/parable.py
+++ b/src/parable.py
@@ -1493,9 +1493,18 @@ class Word(Node):
                             depth -= 1
                     j += 1
                 # Recursively format any cmdsubs inside the param expansion
-                inner = _substring(value, i + 2, j - 1)
+                # When depth > 0 (unclosed ${), include all remaining chars
+                if depth > 0:
+                    inner = _substring(value, i + 2, j)
+                else:
+                    inner = _substring(value, i + 2, j - 1)
                 formatted_inner = self._format_command_substitutions(inner)
-                result.append("${" + formatted_inner + "}")
+                # Only append closing } if we found one in the input
+                if depth == 0:
+                    result.append("${" + formatted_inner + "}")
+                else:
+                    # Unclosed ${...} - output without closing brace
+                    result.append("${" + formatted_inner)
                 i = j
             # Track double-quote state (single quotes inside double quotes are literal)
             elif value[i] == '"':

--- a/tests/parable/character-fuzzer/fuzz-ba6b7c38aa719757aedb0b3668e4697a.tests
+++ b/tests/parable/character-fuzzer/fuzz-ba6b7c38aa719757aedb0b3668e4697a.tests
@@ -1,0 +1,5 @@
+=== parameter expansion with nested command substitution in @() - no closing brace
+@(${$(a))
+---
+(command (word "@(${$(a))"))
+---


### PR DESCRIPTION
## Summary
- Fixed issue where parameter expansions without closing braces (e.g., `${$(a)`) were incorrectly having a closing brace added when formatting
- The bug occurred in `_format_command_substitutions` when processing `${...}` patterns that don't have a matching `}`
- MRE: `@(${$(a))` - the parameter expansion `${$(a)` is left unclosed when the extglob pattern closes