### PR TITLE
fuzzer-agent: disable should_truncate_results

### DIFF
--- a/tools/fuzzer-agent/src/fuzzer_agent/agent.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/agent.py
@@ -126,7 +126,7 @@ class FuzzerFixer:
             tools=self.tools,
             conversation_manager=SlidingWindowConversationManager(
                 window_size=40,
-                should_truncate_results=True,
+                should_truncate_results=False,
                 per_turn=True,
             ),
         )


### PR DESCRIPTION
## Summary
- Disable `should_truncate_results` in SlidingWindowConversationManager

The aggressive truncation was replacing tool results with "The tool result was too large!" causing the agent to lose context of earlier findings and get confused (e.g., thinking its shell was "broken" when it was working fine).