### PR TITLE
fuzzer fix: handle failed process substitution in conditional words

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -10555,7 +10555,11 @@ class Parser {
 				if (procsub_node) {
 					parts.push(procsub_node);
 					chars.push(procsub_text);
+				} else if (procsub_text) {
+					// Not a valid process substitution, treat full <(...) as literal
+					chars.push(procsub_text);
 				} else {
+					// Couldn't parse at all, treat <( as literal chars
 					chars.push(this.advance());
 				}
 			} else if (ch === "`") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -8670,8 +8670,12 @@ class Parser:
                 if procsub_node:
                     parts.append(procsub_node)
                     chars.append(procsub_text)
+                elif procsub_text:
+                    # Not a valid process substitution, treat full <(...) as literal
+                    chars.append(procsub_text)
                 else:
-                    chars.append(self.advance())
+                    # Couldn't parse at all, treat <( as literal chars
+                    chars.append(self.advance())  # <
 
             # Backtick command substitution
             elif ch == "`":

--- a/tests/parable/character-fuzzer/fuzz-50d448fd772b1f2907304b1780d10533.tests
+++ b/tests/parable/character-fuzzer/fuzz-50d448fd772b1f2907304b1780d10533.tests
@@ -1,0 +1,5 @@
+=== failed process substitution in conditional should be treated as literal
+[[ <((1){) ]]
+---
+(cond (cond-unary "-n" (cond-term "<((1){)")))
+---

--- a/tests/parable/character-fuzzer/fuzz-d6af72c7a9034dfb78865714db5b7ec0.tests
+++ b/tests/parable/character-fuzzer/fuzz-d6af72c7a9034dfb78865714db5b7ec0.tests
@@ -1,0 +1,5 @@
+=== arithmetic expansion with brace group in process substitution
+[[ <((1){) ]]
+---
+(cond (cond-unary "-n" (cond-term "<((1){)")))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where failed process substitutions in conditional words were being treated as a single space instead of literal text
- MRE: `[[ <((1){) ]]` should parse as literal `<((1){)` not as a space
- The issue was that when `_parse_process_substitution()` returned a non-null `procsub_text` but null `procsub_node`, we were only advancing one character instead of using the full failed text