### PR TITLE
fuzzer-agent: use PAT to enable CI triggering on PRs

### DIFF
--- a/.github/workflows/fuzzer-agent.yml
+++ b/.github/workflows/fuzzer-agent.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run fuzzer agent
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           cd tools/fuzzer-agent
           uv run fuzzer-agent --model ${{ inputs.model }}


### PR DESCRIPTION
When the fuzzer-agent creates PRs using the default `GITHUB_TOKEN`, the `pull_request` event doesn't trigger other workflows (like CI). This is a GitHub security measure to prevent recursive workflow triggering.

Using a PAT instead allows PRs created by the agent to trigger CI normally.