### PR TITLE
fuzzer fix: handle pattern operators after invalid variable names

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-f3820e3386363558772d52f8616a94ff.tests
+++ b/tests/parable/character-fuzzer/fuzz-f3820e3386363558772d52f8616a94ff.tests
@@ -1,0 +1,5 @@
+=== dollar-single-quote in parameter expansion pattern should be literal
+"${>%$'b'}"
+---
+(command (word "\"${>%'b'}\""))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug where Parable was incorrectly stripping ANSI-C quotes ($'...') in pattern operators when the variable name was invalid
- MRE: `"${>%$'b'}"`
- Bash-oracle output: `(command (word "\"${>%'b'}\""))` (preserves the quotes around 'b')
- Parable was outputting: `(command (word "\"${>%b}\""))` (incorrectly stripped quotes)

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-f3820e3386363558772d52f8616a94ff.tests`
- [x] `just check` passes