### PR TITLE
fuzzer-agent: disable streaming for DeepSeek R1

### DIFF
--- a/tools/fuzzer-agent/src/fuzzer_agent/agent.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/agent.py
@@ -152,11 +152,14 @@ class FuzzerFixer:
                     },
                 )
             else:
+                # DeepSeek R1 doesn't support tool use in streaming mode
+                streaming = self.model_name != "deepseek-r1"
                 model = BedrockModel(
                     model_id=self.model_id,
                     region_name="us-east-2",
                     temperature=0.2,
                     max_tokens=4096,
+                    streaming=streaming,
                 )
             agent = Agent(
                 model=model,


### PR DESCRIPTION
DeepSeek R1 on Bedrock doesn't support tool use in streaming mode. This disables streaming for that model.