### PR TITLE
fuzzer fix: don't treat ${ as brace expansion when preceded by $

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -769,8 +769,10 @@ class Word extends Node {
 			} else if (
 				_startsWithAt(value, i, "${") &&
 				!in_single_quote &&
-				!brace_in_single_quote
+				!brace_in_single_quote &&
+				(i === 0 || value[i - 1] !== "$")
 			) {
+				// Don't treat ${ as brace expansion if preceded by $ (it's $$ + literal {)
 				brace_depth += 1;
 				brace_in_double_quote = false;
 				brace_in_single_quote = false;

--- a/src/parable.py
+++ b/src/parable.py
@@ -648,6 +648,8 @@ class Word(Node):
                 _starts_with_at(value, i, "${")
                 and not in_single_quote
                 and not brace_in_single_quote
+                # Don't treat ${ as brace expansion if preceded by $ (it's $$ + literal {)
+                and (i == 0 or value[i - 1] != "$")
             ):
                 brace_depth += 1
                 brace_in_double_quote = False

--- a/tests/parable/character-fuzzer/fuzz-6bf847d892c7ac8f2efd22f7c76aad7c.tests
+++ b/tests/parable/character-fuzzer/fuzz-6bf847d892c7ac8f2efd22f7c76aad7c.tests
@@ -1,0 +1,5 @@
+=== dollar sign before closing quote in brace expansion
+"$${$"
+---
+(command (word "\"$${$\""))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `$${` was incorrectly treated as `$` followed by `${...}` brace expansion
- When `$$` (PID expansion) is followed by `{`, the `{` is a literal brace, not part of a parameter expansion
- This caused `_strip_locale_string_dollars` to strip `$` from `$"` patterns inside what it thought was a brace expansion

**MRE:** `"$${$"` was output as `"$${"` instead of `"$${$"`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-6bf847d892c7ac8f2efd22f7c76aad7c.tests`
- [x] `just check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)