### PR TITLE
fuzzer fix: treat fd numbers > INT_MAX as strings in redirects

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -2495,12 +2495,16 @@ class Redirect extends Node {
 				op = "<&";
 			}
 			raw = target_val.slice(1, target_val.length);
-			// Pure digits: dup fd N
-			if (/^[0-9]+$/.test(raw)) {
+			// Pure digits: dup fd N (must be <= INT_MAX to be a valid fd)
+			if (/^[0-9]+$/.test(raw) && parseInt(raw, 10) <= 2147483647) {
 				return `(redirect "${op}" ${parseInt(raw, 10)})`;
 			}
-			// Exact move syntax: N- (digits + exactly one dash)
-			if (raw.endsWith("-") && /^[0-9]+$/.test(raw.slice(0, -1))) {
+			// Exact move syntax: N- (digits + exactly one dash, N <= INT_MAX)
+			if (
+				raw.endsWith("-") &&
+				/^[0-9]+$/.test(raw.slice(0, -1)) &&
+				parseInt(raw.slice(0, -1), 10) <= 2147483647
+			) {
 				return `(redirect "${op}" ${parseInt(raw.slice(0, -1), 10)})`;
 			}
 			if (target_val === "&-") {
@@ -2512,17 +2516,22 @@ class Redirect extends Node {
 		}
 		// Handle case where op is already >& or <&
 		if (op === ">&" || op === "<&") {
-			if (/^[0-9]+$/.test(target_val)) {
+			// Valid fd number must be digits and <= INT_MAX (2147483647)
+			if (
+				/^[0-9]+$/.test(target_val) &&
+				parseInt(target_val, 10) <= 2147483647
+			) {
 				return `(redirect "${op}" ${parseInt(target_val, 10)})`;
 			}
 			// Handle close: <& - or >& - (with space before -)
 			if (target_val === "-") {
 				return '(redirect ">&-" 0)';
 			}
-			// Exact move syntax: N- (digits + exactly one dash)
+			// Exact move syntax: N- (digits + exactly one dash, N <= INT_MAX)
 			if (
 				target_val.endsWith("-") &&
-				/^[0-9]+$/.test(target_val.slice(0, -1))
+				/^[0-9]+$/.test(target_val.slice(0, -1)) &&
+				parseInt(target_val.slice(0, -1), 10) <= 2147483647
 			) {
 				return `(redirect "${op}" ${parseInt(target_val.slice(0, -1), 10)})`;
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -1971,11 +1971,11 @@ class Redirect(Node):
             elif op == "<":
                 op = "<&"
             raw = _substring(target_val, 1, len(target_val))  # "&0--" -> "0--"
-            # Pure digits: dup fd N
-            if raw.isdigit():
+            # Pure digits: dup fd N (must be <= INT_MAX to be a valid fd)
+            if raw.isdigit() and int(raw) <= 2147483647:
                 return '(redirect "' + op + '" ' + str(int(raw)) + ")"
-            # Exact move syntax: N- (digits + exactly one dash)
-            if raw.endswith("-") and raw[:-1].isdigit():
+            # Exact move syntax: N- (digits + exactly one dash, N <= INT_MAX)
+            if raw.endswith("-") and raw[:-1].isdigit() and int(raw[:-1]) <= 2147483647:
                 return '(redirect "' + op + '" ' + str(int(raw[:-1])) + ")"
             if target_val == "&-":
                 return '(redirect ">&-" 0)'
@@ -1984,13 +1984,18 @@ class Redirect(Node):
             return '(redirect "' + op + '" "' + fd_target + '")'
         # Handle case where op is already >& or <&
         if op == ">&" or op == "<&":
-            if target_val.isdigit():
+            # Valid fd number must be digits and <= INT_MAX (2147483647)
+            if target_val.isdigit() and int(target_val) <= 2147483647:
                 return '(redirect "' + op + '" ' + str(int(target_val)) + ")"
             # Handle close: <& - or >& - (with space before -)
             if target_val == "-":
                 return '(redirect ">&-" 0)'
-            # Exact move syntax: N- (digits + exactly one dash)
-            if target_val.endswith("-") and target_val[:-1].isdigit():
+            # Exact move syntax: N- (digits + exactly one dash, N <= INT_MAX)
+            if (
+                target_val.endswith("-")
+                and target_val[:-1].isdigit()
+                and int(target_val[:-1]) <= 2147483647
+            ):
                 return '(redirect "' + op + '" ' + str(int(target_val[:-1])) + ")"
             # Variable/word target: strip exactly one trailing dash if present
             out_val = target_val[:-1] if target_val.endswith("-") else target_val

--- a/tests/parable/character-fuzzer/fuzz-3c3837cbf6f3e2e8d781e205daa06e0b.tests
+++ b/tests/parable/character-fuzzer/fuzz-3c3837cbf6f3e2e8d781e205daa06e0b.tests
@@ -1,0 +1,5 @@
+=== redirect target exceeding INT_MAX should be treated as string
+x>&2147483648
+---
+(command (word "x") (redirect ">&" "2147483648"))
+---


### PR DESCRIPTION
## Summary
- Bash file descriptors are limited to INT_MAX (2^31-1 = 2147483647)
- When the redirect target exceeds this limit, bash treats it as a string rather than a file descriptor number
- MRE: `x>&2147483648`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-3c3837cbf6f3e2e8d781e205daa06e0b.tests`
- [x] `just check` passes