### PR TITLE
fuzzer fix: background operator after pipeline with heredoc

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -3991,15 +3991,21 @@ function _formatCmdsubNode(
 					skipped_semi = false;
 				} else if (p.op === "&") {
 					// If previous command has heredoc, insert & before heredoc content
+					// But if it's a pipeline (contains |), append at end instead
 					if (
 						result.length > 0 &&
 						result[result.length - 1].includes("<<") &&
 						result[result.length - 1].includes("\n")
 					) {
 						last = result[result.length - 1];
-						first_nl = last.indexOf("\n");
-						result[result.length - 1] =
-							`${last.slice(0, first_nl)} &${last.slice(first_nl)}`;
+						// If this is a pipeline (has |), append & at the end
+						if (last.includes(" |") || last.startsWith("|")) {
+							result[result.length - 1] = `${last} &`;
+						} else {
+							first_nl = last.indexOf("\n");
+							result[result.length - 1] =
+								`${last.slice(0, first_nl)} &${last.slice(first_nl)}`;
+						}
 					} else {
 						result.push(" &");
 					}

--- a/src/parable.py
+++ b/src/parable.py
@@ -3342,14 +3342,19 @@ def _format_cmdsub_node(
                     skipped_semi = False
                 elif p.op == "&":
                     # If previous command has heredoc, insert & before heredoc content
+                    # But if it's a pipeline (contains |), append at end instead
                     if (
                         result
                         and "<<" in result[len(result) - 1]
                         and "\n" in result[len(result) - 1]
                     ):
                         last = result[len(result) - 1]
-                        first_nl = last.find("\n")
-                        result[len(result) - 1] = last[:first_nl] + " &" + last[first_nl:]
+                        # If this is a pipeline (has |), append & at the end
+                        if " |" in last or last.startswith("|"):
+                            result[len(result) - 1] = last + " &"
+                        else:
+                            first_nl = last.find("\n")
+                            result[len(result) - 1] = last[:first_nl] + " &" + last[first_nl:]
                     else:
                         result.append(" &")
                 else:

--- a/tests/parable/character-fuzzer/fuzz-74130eba2af064676841bc2a87974742.tests
+++ b/tests/parable/character-fuzzer/fuzz-74130eba2af064676841bc2a87974742.tests
@@ -1,0 +1,5 @@
+=== background in pipe after here-document inside command substitution
+"$(<<d|b&)"
+---
+(command (word "\"$(<<d |\nd\n  b &)\""))
+---


### PR DESCRIPTION
## Summary
- Fixed formatting of background operator (&) when used with a pipeline containing a heredoc inside command substitution
- The & was incorrectly inserted after the pipe instead of at the end
- MRE: `"$(<<d|b&)"` was formatted as `$(<<d | &\nd\n  b)` but should be `$(<<d |\nd\n  b &)`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-74130eba2af064676841bc2a87974742.tests`
- [x] `just check` passes