### PR TITLE
fuzzer fix: handle comments in array assignment paren matching

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -970,6 +970,11 @@ class Word extends Node {
 						i += 1;
 					}
 				}
+			} else if (ch === "#") {
+				// Comment - skip to end of line (but not the newline itself)
+				while (i < value.length && value[i] !== "\n") {
+					i += 1;
+				}
 			} else if (ch === "\\" && i + 1 < value.length) {
 				i += 2;
 			} else if (ch === "(") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -785,7 +785,7 @@ class Word(Node):
         return prefix + "(" + result + ")" + suffix
 
     def _find_matching_paren(self, value: str, open_pos: int) -> int:
-        """Find position of matching ) for ( at open_pos, handling quotes."""
+        """Find position of matching ) for ( at open_pos, handling quotes and comments."""
         if open_pos >= len(value) or value[open_pos] != "(":
             return -1
         i = open_pos + 1
@@ -807,6 +807,10 @@ class Word(Node):
                         break
                     else:
                         i += 1
+            elif ch == "#":
+                # Comment - skip to end of line (but not the newline itself)
+                while i < len(value) and value[i] != "\n":
+                    i += 1
             elif ch == "\\" and i + 1 < len(value):
                 i += 2
             elif ch == "(":


### PR DESCRIPTION
## Summary
- Fixed `_find_matching_paren` to skip over comments when finding the closing `)` of array assignments
- When `#` appears inside an array assignment, everything until end of line is a comment, including any `)` characters
- MRE: `a=(#)\n)+` - the `)` after `#` is part of a comment, so the real closing `)` is on the next line

## Test plan
- [x] Existing test `tests/parable/character-fuzzer/fuzz-49c4f13511bdb2faf7ded4363a63dd80.tests` now passes
- [x] `just check` passes