### PR TITLE
fuzzer fix: strip empty ANSI-C quotes inside param expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -635,8 +635,8 @@ class Word extends Node {
 					expanded.endsWith("'")
 				) {
 					inner = expanded.slice(1, expanded.length - 1);
-					// Only strip if non-empty and no CTLESC
-					if (inner && inner.indexOf("") === -1) {
+					// Only strip if no CTLESC (empty inner is OK for $'')
+					if (inner.indexOf("") === -1) {
 						// Check if we're in a pattern context (%, %%, #, ##, /, //)
 						// For pattern operators, keep quotes; for others (like ~), strip them
 						result_str = result.join("");

--- a/src/parable.py
+++ b/src/parable.py
@@ -555,8 +555,8 @@ class Word(Node):
                     and expanded.endswith("'")
                 ):
                     inner = _substring(expanded, 1, len(expanded) - 1)
-                    # Only strip if non-empty and no CTLESC
-                    if inner and inner.find("\x01") == -1:
+                    # Only strip if no CTLESC (empty inner is OK for $'')
+                    if inner.find("\x01") == -1:
                         # Check if we're in a pattern context (%, %%, #, ##, /, //)
                         # For pattern operators, keep quotes; for others (like ~), strip them
                         result_str = "".join(result)

--- a/tests/parable/character-fuzzer/fuzz-49c4f13511bdb2faf7ded4363a63dd80.tests
+++ b/tests/parable/character-fuzzer/fuzz-49c4f13511bdb2faf7ded4363a63dd80.tests
@@ -1,0 +1,5 @@
+=== dollar single quote inside parameter expansion
+"${$''}"
+---
+(command (word "\"${}\""))
+---


### PR DESCRIPTION
## Summary
- Fix handling of `$''` (empty ANSI-C quoted string) inside `"${...}"` when the outer context is double-quoted
- Previously, empty inner strings were not having their quotes stripped, causing `"${$''}"` to produce `"${''}"` instead of `"${}"` 
- Changed condition in `_expand_all_ansi_c_quotes` from `if inner and inner.find(...) == -1` to `if inner.find(...) == -1` to allow empty strings

MRE: `"${$''}"` 

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-49c4f13511bdb2faf7ded4363a63dd80.tests`
- [x] `just check` passes