### PR TITLE
fuzzer fix: preserve empty 'in' clause in for loops inside command substitutions

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4122,13 +4122,18 @@ function _formatCmdsubNode(
 	if (node.kind === "for") {
 		variable = node.variable;
 		body = _formatCmdsubNode(node.body, indent + 4);
-		if (node.words && node.words.length) {
+		if (node.words != null) {
 			word_vals = [];
 			for (w of node.words) {
 				word_vals.push(w.value);
 			}
 			words = word_vals.join(" ");
-			result = `for ${variable} in ${words};\n${sp}do\n${inner_sp}${body};\n${sp}done`;
+			if (words && words.length) {
+				result = `for ${variable} in ${words};\n${sp}do\n${inner_sp}${body};\n${sp}done`;
+			} else {
+				// Empty 'in' clause: for var in ;
+				result = `for ${variable} in ;\n${sp}do\n${inner_sp}${body};\n${sp}done`;
+			}
 		} else {
 			result = `for ${variable};\n${sp}do\n${inner_sp}${body};\n${sp}done`;
 		}

--- a/src/parable.py
+++ b/src/parable.py
@@ -3437,25 +3437,31 @@ def _format_cmdsub_node(
     if node.kind == "for":
         var = node.var
         body = _format_cmdsub_node(node.body, indent + 4)
-        if node.words:
+        if node.words is not None:
             word_vals = []
             for w in node.words:
                 word_vals.append(w.value)
             words = " ".join(word_vals)
-            result = (
-                "for "
-                + var
-                + " in "
-                + words
-                + ";\n"
-                + sp
-                + "do\n"
-                + inner_sp
-                + body
-                + ";\n"
-                + sp
-                + "done"
-            )
+            if words:
+                result = (
+                    "for "
+                    + var
+                    + " in "
+                    + words
+                    + ";\n"
+                    + sp
+                    + "do\n"
+                    + inner_sp
+                    + body
+                    + ";\n"
+                    + sp
+                    + "done"
+                )
+            else:
+                # Empty 'in' clause: for var in ;
+                result = (
+                    "for " + var + " in ;\n" + sp + "do\n" + inner_sp + body + ";\n" + sp + "done"
+                )
         else:
             result = "for " + var + ";\n" + sp + "do\n" + inner_sp + body + ";\n" + sp + "done"
         if node.redirects:

--- a/tests/parable/character-fuzzer/fuzz-cb351b31c782a6f83d9eec6615c0413e.tests
+++ b/tests/parable/character-fuzzer/fuzz-cb351b31c782a6f83d9eec6615c0413e.tests
@@ -1,0 +1,5 @@
+=== for in with empty word list in command substitution
+$(for c in ; do e; done)
+---
+(command (word "$(for c in ;\ndo\n    e;\ndone)"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where `for c in ;` was incorrectly formatted as `for c;` inside command substitutions
- MRE: `$(for c in ; do e; done)`
- Root cause: `if node.words:` evaluated to False for empty list `[]`, conflating it with `None` (no 'in' clause)
- Fix: Changed to `if node.words is not None:` to properly distinguish between empty word list and missing 'in' clause

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-cb351b31c782a6f83d9eec6615c0413e.tests`
- [x] `just check` passes