### PR TITLE
fuzzer fix: strip trailing backslash from redirect targets at EOF

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -12665,10 +12665,18 @@ class Parser {
 	}
 
 	_findLastWord(node) {
+		let last_redirect;
 		if (node instanceof Word) {
 			return node;
 		}
 		if (node instanceof Command) {
+			// Redirects come after words in s-expression output, so check redirects first
+			if (node.redirects && node.redirects.length) {
+				last_redirect = node.redirects[node.redirects.length - 1];
+				if (last_redirect instanceof Redirect) {
+					return last_redirect.target;
+				}
+			}
 			if (node.words && node.words.length) {
 				return node.words[node.words.length - 1];
 			}

--- a/src/parable.py
+++ b/src/parable.py
@@ -10451,6 +10451,11 @@ class Parser:
         if isinstance(node, Word):
             return node
         if isinstance(node, Command):
+            # Redirects come after words in s-expression output, so check redirects first
+            if node.redirects:
+                last_redirect = node.redirects[len(node.redirects) - 1]
+                if isinstance(last_redirect, Redirect):
+                    return last_redirect.target
             if node.words:
                 return node.words[len(node.words) - 1]
         if isinstance(node, Pipeline):

--- a/tests/parable/character-fuzzer/fuzz-4b025f07e8a1fd33688ad6089bd5c843.tests
+++ b/tests/parable/character-fuzzer/fuzz-4b025f07e8a1fd33688ad6089bd5c843.tests
@@ -1,0 +1,7 @@
+=== trailing backslash at EOF stripped from redirect target with single-quoted newline
+<'
+'\
+---
+(command (redirect "<" "'
+'"))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug where trailing backslash at EOF wasn't stripped from redirect targets containing single-quoted newlines
- Extended `_find_last_word()` to also check redirect targets when finding the last word in a command, not just command words
- MRE: `<'\n'\`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-4b025f07e8a1fd33688ad6089bd5c843.tests`
- [x] `just check` passes