### PR TITLE
fuzzer fix: account for escaped dollar when counting preceding dollars in heredoc delimiter

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9482,6 +9482,10 @@ class Parser {
 						dollar_count += 1;
 						j -= 1;
 					}
+					// If preceded by backslash, first dollar was escaped
+					if (j >= 0 && this.source[j] === "\\") {
+						dollar_count -= 1;
+					}
 					if (dollar_count % 2 === 1) {
 						// Odd number of $ before: this $ pairs with previous to form $$
 						// Don't consume the {, let it end the delimiter
@@ -9512,6 +9516,10 @@ class Parser {
 					while (j >= 0 && this.source[j] === "$") {
 						dollar_count += 1;
 						j -= 1;
+					}
+					// If preceded by backslash, first dollar was escaped
+					if (j >= 0 && this.source[j] === "\\") {
+						dollar_count -= 1;
 					}
 					if (dollar_count % 2 === 1) {
 						// Odd number of $ before: this $ pairs with previous to form $$

--- a/src/parable.py
+++ b/src/parable.py
@@ -7802,6 +7802,9 @@ class Parser:
                     while j >= 0 and self.source[j] == "$":
                         dollar_count += 1
                         j -= 1
+                    # If preceded by backslash, first dollar was escaped
+                    if j >= 0 and self.source[j] == "\\":
+                        dollar_count -= 1
                     if dollar_count % 2 == 1:
                         # Odd number of $ before: this $ pairs with previous to form $$
                         # Don't consume the {, let it end the delimiter
@@ -7825,6 +7828,9 @@ class Parser:
                     while j >= 0 and self.source[j] == "$":
                         dollar_count += 1
                         j -= 1
+                    # If preceded by backslash, first dollar was escaped
+                    if j >= 0 and self.source[j] == "\\":
+                        dollar_count -= 1
                     if dollar_count % 2 == 1:
                         # Odd number of $ before: this $ pairs with previous to form $$
                         # Don't consume the [, let it end the delimiter

--- a/tests/parable/character-fuzzer/fuzz-68aa8056e4596cf49513699a5758a97f.tests
+++ b/tests/parable/character-fuzzer/fuzz-68aa8056e4596cf49513699a5758a97f.tests
@@ -1,0 +1,5 @@
+=== heredoc delimiter with backslash-escaped dollar followed by dollar-bracket
+<<\$$[>]
+---
+(command (redirect "<<" ""))
+---


### PR DESCRIPTION
## Summary
- Fix bug where backslash-escaped dollar signs weren't accounted for when parsing heredoc delimiters
- MRE: `<<\$$[>]` was incorrectly parsed as heredoc + redirect, should be just heredoc with delimiter `$$[>]`
- The code counts preceding `$` to determine if `$[` starts arithmetic expansion or if `$$` forms PID variable, but wasn't accounting for backslash escapes

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-68aa8056e4596cf49513699a5758a97f.tests`
- [x] `just check` passes