### PR TITLE
fuzzer fix: preserve $ for ANSI-C quotes in param expansion

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -8567,8 +8567,8 @@ class Parser {
 				dollar_count =
 					1 + _countConsecutiveDollarsBefore(this.source, this.pos);
 				if (dollar_count % 2 === 1) {
-					// Odd count: locale/ANSI-C string - skip the $ and treat as operator
-					this.advance();
+					// Odd count: locale/ANSI-C string - don't consume $, let argument loop handle it
+					// The $ needs to be preserved for _expand_all_ansi_c_quotes to process $'...'
 					op = "";
 				} else {
 					// Even count: this $ is part of $$ (PID), treat as unknown operator

--- a/src/parable.py
+++ b/src/parable.py
@@ -7098,8 +7098,8 @@ class Parser:
                 # Count consecutive $ chars to check for $$ (PID param)
                 dollar_count = 1 + _count_consecutive_dollars_before(self.source, self.pos)
                 if dollar_count % 2 == 1:
-                    # Odd count: locale/ANSI-C string - skip the $ and treat as operator
-                    self.advance()  # skip $
+                    # Odd count: locale/ANSI-C string - don't consume $, let argument loop handle it
+                    # The $ needs to be preserved for _expand_all_ansi_c_quotes to process $'...'
                     op = ""  # empty operator means no operator
                 else:
                     # Even count: this $ is part of $$ (PID), treat as unknown operator

--- a/tests/parable/character-fuzzer/fuzz-cb351b31c782a6f83d9eec6615c0413e.tests
+++ b/tests/parable/character-fuzzer/fuzz-cb351b31c782a6f83d9eec6615c0413e.tests
@@ -3,3 +3,9 @@ $(for c in ; do e; done)
 ---
 (command (word "$(for c in ;\ndo\n    e;\ndone)"))
 ---
+
+=== ANSI-C quoting inside parameter expansion
+"${x$''}"
+---
+(command (word "\"${x}\""))
+---


### PR DESCRIPTION
## Summary
- When parsing `${x$'...'}`, the `$` before ANSI-C quotes was being consumed during operator detection, preventing `_expand_all_ansi_c_quotes` from properly expanding the `$'...'` sequence.
- MRE: `"${x$''}"`
  - Expected: `(command (word "\"${x}\""))`
  - Was: `(command (word "\"${x''}\""))`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-cb351b31c782a6f83d9eec6615c0413e.tests`
- [x] `just check` passes