### PR TITLE
fuzzer fix: format implicit 'in "$@"' in for loop inside cmdsub

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4135,7 +4135,8 @@ function _formatCmdsubNode(
 				result = `for ${variable} in ;\n${sp}do\n${inner_sp}${body};\n${sp}done`;
 			}
 		} else {
-			result = `for ${variable};\n${sp}do\n${inner_sp}${body};\n${sp}done`;
+			// No 'in' clause - bash implies 'in "$@"'
+			result = `for ${variable} in "$@";\n${sp}do\n${inner_sp}${body};\n${sp}done`;
 		}
 		if (node.redirects && node.redirects.length) {
 			for (r of node.redirects) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3463,7 +3463,10 @@ def _format_cmdsub_node(
                     "for " + var + " in ;\n" + sp + "do\n" + inner_sp + body + ";\n" + sp + "done"
                 )
         else:
-            result = "for " + var + ";\n" + sp + "do\n" + inner_sp + body + ";\n" + sp + "done"
+            # No 'in' clause - bash implies 'in "$@"'
+            result = (
+                "for " + var + ' in "$@";\n' + sp + "do\n" + inner_sp + body + ";\n" + sp + "done"
+            )
         if node.redirects:
             for r in node.redirects:
                 result = result + " " + _format_redirect(r)

--- a/tests/parable/character-fuzzer/fuzz-97cf803ea20c36a2f07700dd21ff2e58.tests
+++ b/tests/parable/character-fuzzer/fuzz-97cf803ea20c36a2f07700dd21ff2e58.tests
@@ -1,0 +1,5 @@
+=== for loop without in clause inside command substitution
+$(for n do for c do e;done done)
+---
+(command (word "$(for n in \"$@\";\ndo\n    for c in \"$@\";\n    do\n        e;\n    done;\ndone)"))
+---


### PR DESCRIPTION
## Summary
- When a for loop has no 'in' clause (e.g., `for x do ... done`), bash implicitly uses `in "$@"`. The `_format_cmdsub_node` function was outputting `for x;` instead of `for x in "$@";`.
- MRE: `$(for n do for c do e;done done)`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-97cf803ea20c36a2f07700dd21ff2e58.tests`
- [x] `just check` passes