### PR TITLE
fuzzer fix: add default fd for bare >& and <& with literal fd targets

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4313,10 +4313,10 @@ function _formatRedirect(r, compact, heredoc_op_only) {
 			(after_amp.length > 0 && /^[0-9]+$/.test(after_amp[0]));
 		if (is_literal_fd) {
 			// Add default fd for bare >&N or <&N
-			if (op === ">") {
+			if (op === ">" || op === ">&") {
 				// If we normalized from <&-, use fd 0 (stdin), otherwise fd 1 (stdout)
 				op = was_input_close ? "0>" : "1>";
-			} else if (op === "<") {
+			} else if (op === "<" || op === "<&") {
 				op = "0<";
 			}
 		} else if (op === "1>") {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3610,10 +3610,10 @@ def _format_redirect(
         is_literal_fd = after_amp == "-" or (len(after_amp) > 0 and after_amp[0].isdigit())
         if is_literal_fd:
             # Add default fd for bare >&N or <&N
-            if op == ">":
+            if op == ">" or op == ">&":
                 # If we normalized from <&-, use fd 0 (stdin), otherwise fd 1 (stdout)
                 op = "0>" if was_input_close else "1>"
-            elif op == "<":
+            elif op == "<" or op == "<&":
                 op = "0<"
         else:
             # Variable target: use bare >& or <&

--- a/tests/parable/character-fuzzer/fuzz-2d2fd589a53e6701334f9c6f50aa0752.tests
+++ b/tests/parable/character-fuzzer/fuzz-2d2fd589a53e6701334f9c6f50aa0752.tests
@@ -1,0 +1,5 @@
+=== >&space-minus should be 1>&-
+$(>& -"")
+---
+(command (word "$(\"\" 1>&-)"))
+---


### PR DESCRIPTION
## Summary
- When a redirect operator is already `>&` or `<&` and the target is a literal fd (digit or `-`), expand to `1>&` or `0<&` respectively
- MRE: `$(>& -"")`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-2d2fd589a53e6701334f9c6f50aa0752.tests`
- [x] `just check` passes