### PR TITLE
fuzzer fix: preserve tabs in nested brackets within array assignments

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1213,7 +1213,8 @@ class Word extends Node {
 			} else if (ch === "[") {
 				// Only start subscript tracking if at word start (for [key]=val patterns)
 				// Mid-word [ like a[ is literal, not a subscript
-				if (in_whitespace) {
+				// But if already inside brackets, track nested brackets
+				if (in_whitespace || bracket_depth > 0) {
 					bracket_depth += 1;
 				}
 				in_whitespace = false;

--- a/src/parable.py
+++ b/src/parable.py
@@ -988,7 +988,8 @@ class Word(Node):
             elif ch == "[":
                 # Only start subscript tracking if at word start (for [key]=val patterns)
                 # Mid-word [ like a[ is literal, not a subscript
-                if in_whitespace:
+                # But if already inside brackets, track nested brackets
+                if in_whitespace or bracket_depth > 0:
                     bracket_depth += 1
                 in_whitespace = False
                 normalized.append(ch)

--- a/tests/parable/character-fuzzer/fuzz-71b58a7108fccd63f9d97624593fc624.tests
+++ b/tests/parable/character-fuzzer/fuzz-71b58a7108fccd63f9d97624593fc624.tests
@@ -1,0 +1,5 @@
+=== tab in array assignment index
+a=([''[]''	])
+---
+(command (word "a=([''[]''\t])"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where tabs inside nested brackets within array assignments were converted to spaces
- When normalizing whitespace inside array assignments, bracket depth tracking was not incrementing for nested brackets after non-whitespace characters
- MRE: `a=([''[]''\t])`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-71b58a7108fccd63f9d97624593fc624.tests`
- [x] `just check` passes