### PR TITLE
fuzzer fix: strip trailing backslash word when redirect present

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -12679,11 +12679,19 @@ class Parser {
 	}
 
 	_findLastWord(node) {
-		let last_redirect;
+		let last_redirect, last_word;
 		if (node instanceof Word) {
 			return node;
 		}
 		if (node instanceof Command) {
+			// For trailing backslash stripping, prioritize words ending with backslash
+			// since that's the word we need to strip from
+			if (node.words && node.words.length) {
+				last_word = node.words[node.words.length - 1];
+				if (last_word.value.endsWith("\\")) {
+					return last_word;
+				}
+			}
 			// Redirects come after words in s-expression output, so check redirects first
 			if (node.redirects && node.redirects.length) {
 				last_redirect = node.redirects[node.redirects.length - 1];

--- a/src/parable.py
+++ b/src/parable.py
@@ -10466,6 +10466,12 @@ class Parser:
         if isinstance(node, Word):
             return node
         if isinstance(node, Command):
+            # For trailing backslash stripping, prioritize words ending with backslash
+            # since that's the word we need to strip from
+            if node.words:
+                last_word = node.words[len(node.words) - 1]
+                if last_word.value.endswith("\\"):
+                    return last_word
             # Redirects come after words in s-expression output, so check redirects first
             if node.redirects:
                 last_redirect = node.redirects[len(node.redirects) - 1]

--- a/tests/parable/character-fuzzer/fuzz-14cd1287a58b6e82cba060e36c5b626c.tests
+++ b/tests/parable/character-fuzzer/fuzz-14cd1287a58b6e82cba060e36c5b626c.tests
@@ -1,0 +1,7 @@
+=== trailing backslash after redirect should be line continuation
+<'
+' \
+---
+(command (redirect "<" "'
+'"))
+---


### PR DESCRIPTION
## Summary
- Fixed bug where trailing backslash at EOF was incorrectly kept as a word when a redirect was present and single-quoted content contained a newline
- The issue was that `_find_last_word` returned the redirect target instead of the word ending with backslash
- The fix prioritizes returning words ending with backslash, since those are what need to be stripped

MRE: `<'\n' \` (redirect with single-quoted newline, followed by trailing backslash)

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-14cd1287a58b6e82cba060e36c5b626c.tests`
- [x] `just check` passes