### PR TITLE
fuzzer fix: skip backticks before heredoc check in cmdsub parsing

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4544,6 +4544,22 @@ function _findCmdsubEnd(value, start) {
 			i += 2;
 			continue;
 		}
+		// Handle backtick command substitution - skip to closing backtick
+		// Must handle this before heredoc check to avoid treating << inside backticks as heredoc
+		if (c === "`") {
+			i += 1;
+			while (i < value.length && value[i] !== "`") {
+				if (value[i] === "\\" && i + 1 < value.length) {
+					i += 2;
+				} else {
+					i += 1;
+				}
+			}
+			if (i < value.length) {
+				i += 1;
+			}
+			continue;
+		}
 		// Handle heredocs (but not << inside arithmetic, which is shift operator)
 		if (arith_depth === 0 && _startsWithAt(value, i, "<<")) {
 			i = _skipHeredoc(value, i);
@@ -6450,6 +6466,23 @@ class Parser {
 				arith_depth -= 1;
 				this.advance();
 				this.advance();
+				continue;
+			}
+			// Backtick command substitution - skip to closing backtick
+			// Must handle this before heredoc check to avoid treating << inside backticks as heredoc
+			if (c === "`") {
+				this.advance();
+				while (!this.atEnd() && this.peek() !== "`") {
+					if (this.peek() === "\\" && this.pos + 1 < this.length) {
+						this.advance();
+						this.advance();
+					} else {
+						this.advance();
+					}
+				}
+				if (!this.atEnd()) {
+					this.advance();
+				}
 				continue;
 			}
 			// Heredoc - skip until delimiter line is found (not inside arithmetic)

--- a/src/parable.py
+++ b/src/parable.py
@@ -3790,6 +3790,18 @@ def _find_cmdsub_end(value: str, start: int) -> int:
             arith_depth -= 1
             i += 2
             continue
+        # Handle backtick command substitution - skip to closing backtick
+        # Must handle this before heredoc check to avoid treating << inside backticks as heredoc
+        if c == "`":
+            i += 1  # Skip opening `
+            while i < len(value) and value[i] != "`":
+                if value[i] == "\\" and i + 1 < len(value):
+                    i += 2
+                else:
+                    i += 1
+            if i < len(value):
+                i += 1  # Skip closing `
+            continue
         # Handle heredocs (but not << inside arithmetic, which is shift operator)
         if arith_depth == 0 and _starts_with_at(value, i, "<<"):
             i = _skip_heredoc(value, i)
@@ -5327,6 +5339,20 @@ class Parser:
                 arith_depth -= 1
                 self.advance()  # )
                 self.advance()  # )
+                continue
+
+            # Backtick command substitution - skip to closing backtick
+            # Must handle this before heredoc check to avoid treating << inside backticks as heredoc
+            if c == "`":
+                self.advance()  # opening `
+                while not self.at_end() and self.peek() != "`":
+                    if self.peek() == "\\" and self.pos + 1 < self.length:
+                        self.advance()  # backslash
+                        self.advance()  # escaped char
+                    else:
+                        self.advance()
+                if not self.at_end():
+                    self.advance()  # closing `
                 continue
 
             # Heredoc - skip until delimiter line is found (not inside arithmetic)

--- a/tests/parable/character-fuzzer/fuzz-ba562c3de41cc7c36ade002cca011070.tests
+++ b/tests/parable/character-fuzzer/fuzz-ba562c3de41cc7c36ade002cca011070.tests
@@ -1,0 +1,6 @@
+=== heredoc delimiter in backtick command substitution inside double quotes
+"$(`<<`
+)"
+---
+(command (word "\"$(`<<`)\""))
+---


### PR DESCRIPTION
## Summary
- Fix parsing of backtick command substitutions containing << inside $(...).
- When `_parse_command_substitution` and `_find_cmdsub_end` see `<<`, they would incorrectly treat it as a heredoc operator even when it was inside backticks.
- This caused the parser to lose track of the closing characters after the command substitution.
- MRE: `"$(\`<<\`
)"`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-ba562c3de41cc7c36ade002cca011070.tests`
- [x] `just check` passes