### PR TITLE
fuzzer fix: normalize pipe in procsub patterns inside param expansion

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-f0b0d4c235c93a2770170d791de7e4eb.tests
+++ b/tests/parable/character-fuzzer/fuzz-f0b0d4c235c93a2770170d791de7e4eb.tests
@@ -1,0 +1,5 @@
+=== process substitution with pipe inside parameter expansion
+${u<(o|r)y}
+---
+(command (word "${u<(o | r)y}"))
+---


### PR DESCRIPTION
## Summary
- When `<(` or `>(` patterns appear inside parameter expansions like `${...}`, the pipes within them need normalization (e.g., `<(o|r)` -> `<(o | r)`)
- Previously this wasn't happening because the early-exit check in `_format_command_substitutions` didn't account for these patterns
- Also fixes handling of `||` operators inside these patterns to keep them together rather than splitting into separate pipes

MRE: `${u<(o|r)y}`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-f0b0d4c235c93a2770170d791de7e4eb.tests`
- [x] `just check` passes