### PR TITLE
fuzzer fix: don't treat # as comment inside arithmetic

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4439,8 +4439,10 @@ function _findCmdsubEnd(value, start) {
 		}
 		// Handle comments - skip from # to end of line
 		// Only treat # as comment if preceded by whitespace or at start
+		// Don't treat # as comment inside arithmetic expressions (arith_depth > 0)
 		if (
 			c === "#" &&
+			arith_depth === 0 &&
 			(i === start ||
 				value[i - 1] === " " ||
 				value[i - 1] === "\t" ||

--- a/src/parable.py
+++ b/src/parable.py
@@ -3712,16 +3712,21 @@ def _find_cmdsub_end(value: str, start: int) -> int:
             continue
         # Handle comments - skip from # to end of line
         # Only treat # as comment if preceded by whitespace or at start
-        if c == "#" and (
-            i == start
-            or value[i - 1] == " "
-            or value[i - 1] == "\t"
-            or value[i - 1] == "\n"
-            or value[i - 1] == ";"
-            or value[i - 1] == "|"
-            or value[i - 1] == "&"
-            or value[i - 1] == "("
-            or value[i - 1] == ")"
+        # Don't treat # as comment inside arithmetic expressions (arith_depth > 0)
+        if (
+            c == "#"
+            and arith_depth == 0
+            and (
+                i == start
+                or value[i - 1] == " "
+                or value[i - 1] == "\t"
+                or value[i - 1] == "\n"
+                or value[i - 1] == ";"
+                or value[i - 1] == "|"
+                or value[i - 1] == "&"
+                or value[i - 1] == "("
+                or value[i - 1] == ")"
+            )
         ):
             while i < len(value) and value[i] != "\n":
                 i += 1

--- a/tests/parable/character-fuzzer/fuzz-c35fc53495700e6c8f06700b1a09f9ce.tests
+++ b/tests/parable/character-fuzzer/fuzz-c35fc53495700e6c8f06700b1a09f9ce.tests
@@ -1,0 +1,5 @@
+=== nested arithmetic expansion with hash inside command substitution
+$(($($((#)))))
+---
+(command (word "$(($($((#)))))"))
+---


### PR DESCRIPTION
## Summary
- In `_find_cmdsub_end`, `#` was being treated as a comment start even when inside arithmetic expressions (`arith_depth > 0`)
- This caused incorrect parsing of nested command substitutions containing arithmetic with `#`
- MRE: `$(($($((#)))))`
- The `#` in `$((#))` is the special variable for number of positional parameters, not a comment
- Fix: add `arith_depth == 0` condition to the comment detection logic

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-c35fc53495700e6c8f06700b1a09f9ce.tests`
- [x] `just check` passes