### PR TITLE
fuzzer fix: preserve ANSI-C quotes when pattern op preceded by non-operator char

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -695,6 +695,33 @@ class Word extends Node {
 										break;
 									}
 								}
+								// If no operator at start and the first char is NOT a known
+								// bash operator character, also check if any operator exists
+								// later (handles cases like ${x{%...} where { precedes the operator)
+								// Known operator start chars: % # / ^ , ~ : + - = ?
+								if (
+									!in_pattern &&
+									op_start &&
+									!"%#/^,~:+-=?".includes(op_start[0])
+								) {
+									for (op of [
+										"//",
+										"%%",
+										"##",
+										"/",
+										"%",
+										"#",
+										"^",
+										"^^",
+										",",
+										",,",
+									]) {
+										if (op_start.includes(op)) {
+											in_pattern = true;
+											break;
+										}
+									}
+								}
 							} else if (var_name_len === 0 && after_brace.length > 1) {
 								// Handle invalid variable names (var_name_len = 0) where first char is not a pattern operator
 								// but there's a pattern operator later (e.g., ${>%$'b'})

--- a/src/parable.py
+++ b/src/parable.py
@@ -594,6 +594,26 @@ class Word(Node):
                                     if op_start.startswith(op):
                                         in_pattern = True
                                         break
+                                # If no operator at start and the first char is NOT a known
+                                # bash operator character, also check if any operator exists
+                                # later (handles cases like ${x{%...} where { precedes the operator)
+                                # Known operator start chars: % # / ^ , ~ : + - = ?
+                                if not in_pattern and op_start and op_start[0] not in "%#/^,~:+-=?":
+                                    for op in [
+                                        "//",
+                                        "%%",
+                                        "##",
+                                        "/",
+                                        "%",
+                                        "#",
+                                        "^",
+                                        "^^",
+                                        ",",
+                                        ",,",
+                                    ]:
+                                        if op in op_start:
+                                            in_pattern = True
+                                            break
                             # Handle invalid variable names (var_name_len = 0) where first char is not a pattern operator
                             # but there's a pattern operator later (e.g., ${>%$'b'})
                             elif var_name_len == 0 and len(after_brace) > 1:

--- a/tests/parable/character-fuzzer/fuzz-b459843381c6db6e514d143ffb74235f.tests
+++ b/tests/parable/character-fuzzer/fuzz-b459843381c6db6e514d143ffb74235f.tests
@@ -1,0 +1,5 @@
+=== pattern operator after non-variable char in double-quoted parameter expansion
+"${x{%$''}"
+---
+(command (word "\"${x{%''}\""))
+---


### PR DESCRIPTION
## Summary
- Fixed quote stripping in `_expand_all_ansi_c_quotes` for edge cases where a non-operator character precedes a pattern operator
- MRE: `"${x{%$''}"`
- Parable was incorrectly stripping `$''` to nothing instead of preserving `''`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-b459843381c6db6e514d143ffb74235f.tests`
- [x] `just check` passes