### PR TITLE
fuzzer fix: preserve deprecated arithmetic content in extglob normalization

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-c3ad71d2646ae3ff02dba6f952e7bf12.tests
+++ b/tests/parable/character-fuzzer/fuzz-c3ad71d2646ae3ff02dba6f952e7bf12.tests
@@ -1,0 +1,5 @@
+=== process substitution inside arithmetic in parameter expansion
+${$[>(]}
+---
+(command (word "${$[>(]}"))
+---


### PR DESCRIPTION
## Summary
- Fixed `_normalize_extglob_whitespace` to track `$[...]` (deprecated arithmetic) depth
- Skip processing `>(` and `<(` patterns inside deprecated arithmetic expressions
- MRE: `${$[>(]}` was being corrupted to `${$[>()}` because the function tried to find a matching `)` for `>(` and lost the `]` content

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-c3ad71d2646ae3ff02dba6f952e7bf12.tests`
- [x] `just check` passes