### PR TITLE
fuzzer fix: don't treat backslash as escape in single quotes during locale string stripping

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -761,8 +761,13 @@ class Word extends Node {
 		bracket_in_double_quote = false;
 		while (i < value.length) {
 			ch = value[i];
-			if (ch === "\\" && i + 1 < value.length) {
-				// Escape - copy both chars
+			if (
+				ch === "\\" &&
+				i + 1 < value.length &&
+				!in_single_quote &&
+				!brace_in_single_quote
+			) {
+				// Escape - copy both chars (but NOT inside single quotes where \ is literal)
 				result.push(ch);
 				result.push(value[i + 1]);
 				i += 2;

--- a/src/parable.py
+++ b/src/parable.py
@@ -639,8 +639,13 @@ class Word(Node):
         bracket_in_double_quote = False  # Track quotes inside brackets
         while i < len(value):
             ch = value[i]
-            if ch == "\\" and i + 1 < len(value):
-                # Escape - copy both chars
+            if (
+                ch == "\\"
+                and i + 1 < len(value)
+                and not in_single_quote
+                and not brace_in_single_quote
+            ):
+                # Escape - copy both chars (but NOT inside single quotes where \ is literal)
                 result.append(ch)
                 result.append(value[i + 1])
                 i += 2

--- a/tests/parable/character-fuzzer/fuzz-9351ff7b67c02c7193313d8dbc5523ce.tests
+++ b/tests/parable/character-fuzzer/fuzz-9351ff7b67c02c7193313d8dbc5523ce.tests
@@ -1,0 +1,5 @@
+=== locale translation $"" should consume dollar sign
+'\'$""
+---
+(command (word "'\\'\"\""))
+---


### PR DESCRIPTION
## Summary
- Fixed a bug in `_strip_locale_string_dollars` where backslashes were incorrectly treated as escape characters inside single-quoted strings
- MRE: `'\'$""` - The `$""` locale string after a single-quoted backslash was not being processed because the backslash incorrectly consumed the closing quote

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-9351ff7b67c02c7193313d8dbc5523ce.tests`
- [x] `just check` passes