### PR TITLE
fuzzer fix: handle $(...) in heredoc line-end scanning

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9753,6 +9753,24 @@ class Parser {
 						line_end += 1;
 					}
 				}
+			} else if (
+				ch === "$" &&
+				line_end + 1 < this.length &&
+				this.source[line_end + 1] === "("
+			) {
+				// Command substitution $(...) - skip to matching close paren
+				line_end += 2;
+				depth = 1;
+				while (line_end < this.length && depth > 0) {
+					c = this.source[line_end];
+					if (c === "(") {
+						depth += 1;
+					} else if (c === ")") {
+						depth -= 1;
+					}
+					line_end += 1;
+				}
+				continue;
 			} else if (ch === "\\") {
 				if (line_end + 1 < this.length) {
 					// Backslash escape - skip both chars

--- a/src/parable.py
+++ b/src/parable.py
@@ -8017,6 +8017,18 @@ class Parser:
                         line_end += 2
                     else:
                         line_end += 1
+            elif ch == "$" and line_end + 1 < self.length and self.source[line_end + 1] == "(":
+                # Command substitution $(...) - skip to matching close paren
+                line_end += 2  # skip $(
+                depth = 1
+                while line_end < self.length and depth > 0:
+                    c = self.source[line_end]
+                    if c == "(":
+                        depth += 1
+                    elif c == ")":
+                        depth -= 1
+                    line_end += 1
+                continue  # don't increment again
             elif ch == "\\":
                 if line_end + 1 < self.length:
                     # Backslash escape - skip both chars

--- a/tests/parable/character-fuzzer/fuzz-873e120235baa6205c3a54813e77664b.tests
+++ b/tests/parable/character-fuzzer/fuzz-873e120235baa6205c3a54813e77664b.tests
@@ -1,0 +1,6 @@
+=== heredoc with command substitution spanning lines
+<<o $(
+)
+---
+(command (word "$()") (redirect "<<" ""))
+---


### PR DESCRIPTION
## Summary
- Fix: The heredoc parser's line-end-finding loop was missing support for command substitution $(...). When scanning for the end of the command line (to determine where heredoc content starts), it would incorrectly stop at newlines inside $(...), causing heredoc content to be miscalculated.
- MRE: `<<o $(` followed by newline then `)`

## Test plan
- [x] New test added to `tests/parable/character-fuzzer/fuzz-873e120235baa6205c3a54813e77664b.tests`
- [x] `just check` passes