### PR TITLE
refactor: two-phase heredoc parsing like bash

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -4415,34 +4415,6 @@ function _formatHeredocBody(r) {
 	return `\n${r.content}${r.delimiter}\n`;
 }
 
-function _normalizeFdRedirects(s) {
-	let i, prev_is_digit, prev_is_same_op, result;
-	// Match >&N or <&N not preceded by a digit, add default fd
-	result = [];
-	i = 0;
-	while (i < s.length) {
-		// Check for >&N or <&N
-		if (i + 2 < s.length && s[i + 1] === "&" && /^[0-9]+$/.test(s[i + 2])) {
-			prev_is_digit = i > 0 && /^[0-9]+$/.test(s[i - 1]);
-			prev_is_same_op = i > 0 && s[i - 1] === s[i];
-			if (s[i] === ">" && !prev_is_digit && !prev_is_same_op) {
-				result.push("1>&");
-				result.push(s[i + 2]);
-				i += 3;
-				continue;
-			} else if (s[i] === "<" && !prev_is_digit && !prev_is_same_op) {
-				result.push("0<&");
-				result.push(s[i + 2]);
-				i += 3;
-				continue;
-			}
-		}
-		result.push(s[i]);
-		i += 1;
-	}
-	return result.join("");
-}
-
 function _findCmdsubEnd(value, start) {
 	let arith_depth,
 		arith_paren_depth,
@@ -5173,9 +5145,6 @@ const RESERVED_WORDS = new Set([
 	"function",
 	"coproc",
 ]);
-// Metacharacters that break words (unquoted)
-// Note: {} are NOT metacharacters - they're only special at command position
-// for brace groups. In words like {a,b,c}, braces are literal.
 const COND_UNARY_OPS = new Set([
 	"-a",
 	"-b",
@@ -5414,10 +5383,6 @@ function _isSemicolonOrNewline(c) {
 	return c === ";" || c === "\n";
 }
 
-function _isRightBracket(c) {
-	return c === ")" || c === "}";
-}
-
 function _isWordStartContext(c) {
 	return (
 		c === " " ||
@@ -5577,16 +5542,8 @@ function _isNewlineOrRightParen(c) {
 	return c === "\n" || c === ")";
 }
 
-function _isNewlineOrRightBracket(c) {
-	return c === "\n" || c === ")" || c === "}";
-}
-
 function _isSemicolonNewlineBrace(c) {
 	return c === ";" || c === "\n" || c === "{";
-}
-
-function _strContains(haystack, needle) {
-	return haystack.indexOf(needle) !== -1;
 }
 
 function _looksLikeAssignment(s) {

--- a/src/parable.py
+++ b/src/parable.py
@@ -3694,31 +3694,6 @@ def _format_heredoc_body(r: "HereDoc") -> str:
     return "\n" + r.content + r.delimiter + "\n"
 
 
-def _normalize_fd_redirects(s: str) -> str:
-    """Normalize fd redirects in a raw string: >&2 -> 1>&2, <&N -> 0<&N."""
-    # Match >&N or <&N not preceded by a digit, add default fd
-    result = []
-    i = 0
-    while i < len(s):
-        # Check for >&N or <&N
-        if i + 2 < len(s) and s[i + 1] == "&" and s[i + 2].isdigit():
-            prev_is_digit = i > 0 and s[i - 1].isdigit()
-            prev_is_same_op = i > 0 and s[i - 1] == s[i]
-            if s[i] == ">" and not prev_is_digit and not prev_is_same_op:
-                result.append("1>&")
-                result.append(s[i + 2])
-                i += 3
-                continue
-            elif s[i] == "<" and not prev_is_digit and not prev_is_same_op:
-                result.append("0<&")
-                result.append(s[i + 2])
-                i += 3
-                continue
-        result.append(s[i])
-        i += 1
-    return "".join(result)
-
-
 def _find_cmdsub_end(value: str, start: int) -> int:
     """Find the end of a $(...) command substitution, handling case statements.
 
@@ -4278,11 +4253,6 @@ RESERVED_WORDS = {
     "coproc",
 }
 
-# Metacharacters that break words (unquoted)
-# Note: {} are NOT metacharacters - they're only special at command position
-# for brace groups. In words like {a,b,c}, braces are literal.
-METACHAR = set(" \t\n|&;()<>")
-
 COND_UNARY_OPS = {
     "-a",
     "-b",
@@ -4484,10 +4454,6 @@ def _is_semicolon_or_newline(c: str) -> bool:
     return c == ";" or c == "\n"
 
 
-def _is_right_bracket(c: str) -> bool:
-    return c == ")" or c == "}"
-
-
 def _is_word_start_context(c: str) -> bool:
     """Check if char is a valid context for starting a word (whitespace or metachar except >)."""
     return (
@@ -4633,17 +4599,8 @@ def _is_newline_or_right_paren(c: str) -> bool:
     return c == "\n" or c == ")"
 
 
-def _is_newline_or_right_bracket(c: str) -> bool:
-    return c == "\n" or c == ")" or c == "}"
-
-
 def _is_semicolon_newline_brace(c: str) -> bool:
     return c == ";" or c == "\n" or c == "{"
-
-
-def _str_contains(haystack: str, needle: str) -> bool:
-    """Check if haystack contains needle substring."""
-    return haystack.find(needle) != -1
 
 
 def _looks_like_assignment(s: str) -> bool:


### PR DESCRIPTION
## Summary
- Refactor heredoc parsing to use bash's two-phase approach: parse delimiter when `<<` is seen, gather bodies after command line completes
- Simplify `_parse_heredoc()` from ~100 lines to ~10 lines
- Add `_pending_heredocs` list and `_gather_heredoc_bodies()` for deferred content gathering
- Remove dead code found by vulture

## Changes
- Extract `_parse_heredoc_delimiter()` for delimiter parsing
- Add helpers: `_read_heredoc_line()`, `_line_matches_delimiter()`, `_count_trailing_backslashes()`
- Rename `_pending_heredoc_end` to `_cmdsub_heredoc_end` (only used for command/process substitution heredocs now)
- Remove unused: `_normalize_fd_redirects`, `METACHAR`, `_is_right_bracket`, `_is_newline_or_right_bracket`, `_str_contains`