### PR TITLE
chore: remove deprecated gpt-4.5 from fuzzer-agent

### DIFF
--- a/.github/workflows/fuzzer-agent.yml
+++ b/.github/workflows/fuzzer-agent.yml
@@ -20,7 +20,6 @@ on:
           - gpt-4.1
           - gpt-4.1-mini
           - gpt-4.1-nano
-          - gpt-4.5
           - gpt-4o
           - gpt-4o-mini
           - gpt-5

--- a/tools/fuzzer-agent/src/fuzzer_agent/agent.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/agent.py
@@ -37,7 +37,6 @@ BEDROCK_MODELS = {
 
 # Azure OpenAI model IDs (deployment names, configure via AZURE_API_BASE)
 AZURE_MODELS = {
-    "gpt-4.5": "azure/gpt-4.5",
     "gpt-4.1": "azure/gpt-4.1",
     "gpt-4.1-mini": "azure/gpt-4.1-mini",
     "gpt-4.1-nano": "azure/gpt-4.1-nano",

--- a/tools/fuzzer-agent/src/fuzzer_agent/pricing.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/pricing.py
@@ -48,7 +48,6 @@ OTHER_PRICING: dict[str, tuple[float, float]] = {
 
 # Azure OpenAI fallback pricing (used if API fetch fails)
 AZURE_PRICING: dict[str, tuple[float, float]] = {
-    "gpt-4.5": (75.00, 150.00),
     "gpt-4.1": (2.00, 8.00),
     "gpt-4.1-mini": (0.40, 1.60),
     "gpt-4.1-nano": (0.10, 0.40),
@@ -71,7 +70,6 @@ GCP_PRICING: dict[str, tuple[float, float]] = {
 
 # Azure OpenAI models to fetch (skuName pattern -> our name)
 AZURE_MODELS = {
-    "gpt 4.5 0227": "gpt-4.5",
     "gpt 4.1 nano": "gpt-4.1-nano",
     "gpt 4.1 mini": "gpt-4.1-mini",
     "gpt 4.1": "gpt-4.1",


### PR DESCRIPTION
## Summary
- Remove gpt-4.5 from fuzzer-agent workflow options and model configs
- GPT-4.5 was deprecated by OpenAI in April 2025 and removed from the API in July 2025
- It is no longer available on Azure OpenAI