### PR TITLE
chore: add just targets and fix fuzzer-agent dependencies

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,6 +32,18 @@ test-pypy: test-pypy311
 [parallel]
 test-all: test-cpy test-pypy
 
+# Run the fuzzer (e.g., just fuzz char --stop-after 10)
+fuzz *ARGS:
+    uv run --directory tools/fuzzer fuzzer {{ARGS}}
+
+# Run the fuzzer agent
+fuzzer-agent *ARGS:
+    uv run --directory tools/fuzzer-agent fuzzer-agent {{ARGS}}
+
+# Run Parable against the bigtable-bash corpus
+run-corpus *ARGS:
+    tools/bash-oracle/src/oracle/run_corpus.py {{ARGS}}
+
 # Verify lock file is up to date
 lock-check:
     uv lock --check 2>&1 | sed -u "s/^/[lock] /" | tee /tmp/{{project}}-{{run_id}}-lock.log

--- a/tools/fuzzer-agent/pyproject.toml
+++ b/tools/fuzzer-agent/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.14"
 dependencies = [
     "azure-identity>=1.25.0",
     "boto3>=1.35.0",
+    "botocore[crt]>=1.42.0",
     "claude-agent-sdk>=0.1.19",
     "google-cloud-billing>=1.18.0",
     "litellm>=1.72.0",

--- a/tools/fuzzer-agent/src/fuzzer_agent/agent.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/agent.py
@@ -18,7 +18,7 @@ from .tools import shell
 
 MODEL_PRICING = {**CLAUDE_PRICING, **OTHER_PRICING, **AZURE_PRICING, **GCP_PRICING}
 
-# Bedrock model IDs (DeepSeek models excluded: Bedrock Converse API doesn't support their tool use)
+# Bedrock model IDs
 BEDROCK_MODELS = {
     "haiku-3": "anthropic.claude-3-haiku-20240307-v1:0",
     "haiku-3.5": "anthropic.claude-3-5-haiku-20241022-v1:0",
@@ -150,14 +150,12 @@ class FuzzerFixer:
                     },
                 )
             else:
-                # DeepSeek R1 doesn't support tool use in streaming mode
-                streaming = self.model_name != "deepseek-r1"
                 model = BedrockModel(
                     model_id=self.model_id,
                     region_name="us-east-2",
                     temperature=0.2,
                     max_tokens=4096,
-                    streaming=streaming,
+                    streaming=True,
                 )
             agent = Agent(
                 model=model,

--- a/tools/fuzzer-agent/src/fuzzer_agent/pricing.py
+++ b/tools/fuzzer-agent/src/fuzzer_agent/pricing.py
@@ -4,7 +4,7 @@ Claude models use hardcoded values because AWS Pricing API is incomplete
 (missing output token prices and newer models).
 
 Sources:
-- AWS Pricing API: Nova, Llama, DeepSeek models
+- AWS Pricing API: Nova, Llama models
 - AWS Bedrock pricing page: Claude models (manually verified)
 - Azure Retail Prices API: Azure OpenAI models
 - GCP Cloud Billing API: Vertex AI Gemini models
@@ -37,7 +37,6 @@ CLAUDE_PRICING: dict[str, tuple[float, float]] = {
 
 # Non-Claude Bedrock pricing (fetched 2026-01-16, can be refreshed with --prices)
 OTHER_PRICING: dict[str, tuple[float, float]] = {
-    "deepseek-r1": (1.35, 5.40),
     "llama-3.1-70b": (0.72, 0.72),
     "llama-3.2-90b": (0.72, 0.72),
     "llama-3.3-70b": (0.72, 0.72),
@@ -82,7 +81,6 @@ AZURE_MODELS = {
 
 # Models to fetch from AWS Pricing API (API name -> our name)
 API_MODELS = {
-    "DeepSeek V3.1": "deepseek-v3.1",
     "Nova Micro": "nova-micro",
     "Nova Lite": "nova-lite",
     "Nova Pro": "nova-pro",
@@ -269,8 +267,6 @@ def _get_provider(model: str) -> str:
     """Get provider name for a model."""
     if model.startswith(("haiku", "sonnet", "opus")):
         return "Anthropic"
-    if model.startswith("deepseek"):
-        return "DeepSeek"
     if model.startswith("llama"):
         return "Meta"
     if model.startswith("nova"):

--- a/tools/fuzzer-agent/uv.lock
+++ b/tools/fuzzer-agent/uv.lock
@@ -117,6 +117,28 @@ wheels = [
 ]
 
 [[package]]
+name = "awscrt"
+version = "0.29.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/90/f985002a50859ea39841e66bc816c224b623c03f943b34bfe08fee17165c/awscrt-0.29.2.tar.gz", hash = "sha256:c78d81b1308d42fda1eb21d27fcf26579137b821043e528550f2cfc6c09ab9ff", size = 38013553, upload-time = "2025-12-04T00:16:36.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/7f/9d7b3d3f72369f80730ee5a0e964a1cd6ccf83d8c117a4d1df629e3ed6f9/awscrt-0.29.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:3ff819a542acc5f11c46223204362c6b065031df0e4a37bf1ce2fc233a7145e4", size = 3407922, upload-time = "2025-12-04T00:15:49.071Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f2/3e61a4683ff8e9bc59871214e833bf3f67e9f08b1884aae9e1166ef06ac3/awscrt-0.29.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:aa3d2f7fc0218a04707384afd871a8c3e97251185038eb921ae2fae4f61b7d90", size = 3817179, upload-time = "2025-12-04T00:15:50.965Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/a7366b0465b998b1d05f8b3a05e5897a431ec101b9a389be6058fbbe5e26/awscrt-0.29.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f86d5a1a3c6d817dc0087d4e25abae1a7a1dd678d31fbcd226a15515719bdac", size = 4091388, upload-time = "2025-12-04T00:15:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/90/a34b1b29612d91baad1273ea1d4e31ab3a90e2db4e516345329fecfbaeb2/awscrt-0.29.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a6451a730c961b73b57dccdcf8599bf8058740053b531d3724efbf3a89e2d191", size = 3719628, upload-time = "2025-12-04T00:15:53.356Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/94/2d93803e93cff7da0f5c9b6422b9f919d86db83640cdfbae569bdf22e606/awscrt-0.29.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:66a82b0960d281e14e7bfb95e9d6934cbc8e949b3f3e829709736b14bf0e6760", size = 3945694, upload-time = "2025-12-04T00:15:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/26/e2517fe8eb2f565ba52274a59f301bc6fac25494e0d28b6257fde237190a/awscrt-0.29.2-cp311-abi3-win32.whl", hash = "sha256:c1c243a7d7b9ed9c1e10acfb44eaab81b88eec24b50915ce3db45a8ffa4f2edb", size = 3959540, upload-time = "2025-12-04T00:15:57.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/49/bc9f3bcf2d49c58b97dd357f617c8331c1be02e5907316eb0ac39096941d/awscrt-0.29.2-cp311-abi3-win_amd64.whl", hash = "sha256:cd7349596f8f7b05805e047d29bfceb2304f5f0277fe0088e13ea8fe41ac3064", size = 4092749, upload-time = "2025-12-04T00:15:58.414Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/41/a564e4537c8e56259d9a9a86239d6b89448a742a5a5769b8cb81e2db7b26/awscrt-0.29.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:2377b9adf0db47fcf74ad6c89afcd901f6cf97f24ba4f0e5e352f5ffe12affef", size = 3406616, upload-time = "2025-12-04T00:15:59.966Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/4f88475ea7a9e4954871ebe188bfc9b5d29a60e1101e50a984afde904c3b/awscrt-0.29.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e0cb67ce813577679dab7ab56cc8bb16a546328589db87a55f7b52314f54504f", size = 3809168, upload-time = "2025-12-04T00:16:01.288Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/f08b3b646198d9a5fb45bc411e6a102ec976efc4acc34c01ac86cf557216/awscrt-0.29.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb7d44ed31baeb1b5720674a0249f48d8d6e548ea544ddfb93000b6bff559f34", size = 4084414, upload-time = "2025-12-04T00:16:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/40/fd45b53bfc5486a31080a767947396f717534dde0ace1c9ee48b96c079b9/awscrt-0.29.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e455776fd0a04929c586a66e590c6eb6f2ca08b96ec13323bfb087ee17fd6e99", size = 3710752, upload-time = "2025-12-04T00:16:04.777Z" },
+    { url = "https://files.pythonhosted.org/packages/53/25/179278c03b84e09332ef4a7770878b93b43f10564b6a94a82faa8d9329e6/awscrt-0.29.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:70fd197fe83b78c25c2c57293466808df6f63287a480984834b4af7b9d18d4c0", size = 3939687, upload-time = "2025-12-04T00:16:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5c/8330d3f8f5f080a85dc79c376c7125f24579dfb9c4e200224292062a36bb/awscrt-0.29.2-cp313-abi3-win32.whl", hash = "sha256:b3c46e4808ce7cfb6a63878e45b30b3410f5c314e352396d1210380787cafee2", size = 3954574, upload-time = "2025-12-04T00:16:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8f/630f3083d07a75e258aae67c0d06c7ed69098d4ca85550e9cd344d3f613d/awscrt-0.29.2-cp313-abi3-win_amd64.whl", hash = "sha256:74f8944e04bfc1508cce784b75927b4fb9895ff6a57310abb523c4b446b4f34f", size = 4085860, upload-time = "2025-12-04T00:16:08.752Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -184,6 +206,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/08/8a8e0255949845f764c5126f97b1bc09a6484077f124c2177b979ecfbbff/botocore-1.42.29.tar.gz", hash = "sha256:0fe869227a1dfe818f691a31b8c1693e39be8056a6dff5d6d4b3fc5b3a5e7d42", size = 14890916, upload-time = "2026-01-15T20:36:28.241Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/76/cfa6a934ee5a8a87f626b38275193a046da894d2f9021e001587fc2e8c7d/botocore-1.42.29-py3-none-any.whl", hash = "sha256:b45f8dfc1de5106a9d040c5612f267582e68b2b2c5237477dff85c707c1c5d11", size = 14563947, upload-time = "2026-01-15T20:36:23.828Z" },
+]
+
+[package.optional-dependencies]
+crt = [
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -458,6 +485,7 @@ source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },
     { name = "boto3" },
+    { name = "botocore", extra = ["crt"] },
     { name = "claude-agent-sdk" },
     { name = "google-cloud-billing" },
     { name = "litellm" },
@@ -472,6 +500,7 @@ dependencies = [
 requires-dist = [
     { name = "azure-identity", specifier = ">=1.25.0" },
     { name = "boto3", specifier = ">=1.35.0" },
+    { name = "botocore", extras = ["crt"], specifier = ">=1.42.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
     { name = "google-cloud-billing", specifier = ">=1.18.0" },
     { name = "litellm", specifier = ">=1.72.0" },


### PR DESCRIPTION
## Summary
- Add `just fuzz` target to run the fuzzer
- Add `just fuzzer-agent` target to run the fuzzer agent
- Add `just run-corpus` target to run Parable against bigtable-bash corpus
- Add `botocore[crt]` dependency to fix AWS pricing API fetch
- Remove all DeepSeek model references