### PR TITLE
refactor: remove dead code from delimiter tracking, keep only DelimiterStack

### DIFF
--- a/INTEGRATION_PLAN.md
+++ b/INTEGRATION_PLAN.md
@@ -1,0 +1,124 @@
+# Integration Plan: Delimiter Tracking
+
+## Current State (Dead Code)
+
+- `_open_brace_count` / `_open_cond_count`: Tracked but never used for decisions
+- `_reserved_word_acceptable()`: Exists but never called
+- `_special_case_tokens()`: Exists but never called
+- `DelimiterStack`: Actually used for better error messages ✓
+
+## Legacy Code to Replace
+
+```python
+# In parse_simple_command() at line 9208:
+if len(words) == 0:
+    reserved = self._lex_peek_reserved_word()
+    if reserved == "}" or reserved == "]]":
+        break
+```
+
+This scattered check should be centralized in `_lex_peek_reserved_word()`.
+
+---
+
+## Integration Steps
+
+### Step 1: Integrate `_reserved_word_acceptable()` into `_lex_peek_reserved_word()`
+
+**Change:**
+```python
+def _lex_peek_reserved_word(self) -> str | None:
+    tok = self._lex_peek_token()
+    if tok.type != TokenType.WORD:
+        return None
+    word = tok.value
+    if word.endswith("\\\n"):
+        word = word[:-2]
+    # Gate reserved word recognition by context
+    if not self._reserved_word_acceptable():
+        return None
+    if word in RESERVED_WORDS or word in ("{", "}", "[[", "]]", "!", "time"):
+        return word
+    return None
+```
+
+**Why this works:**
+- `_reserved_word_acceptable()` checks token history
+- Returns True after `;`, `|`, `\n`, start of input, etc.
+- Returns False after regular WORD tokens
+- This replaces the `len(words) == 0` check with proper token-based context
+
+### Step 2: Remove legacy check in `parse_simple_command()`
+
+**Delete:**
+```python
+if len(words) == 0:
+    reserved = self._lex_peek_reserved_word()
+    if reserved == "}" or reserved == "]]":
+        break
+```
+
+**Why safe:** The check is now inside `_lex_peek_reserved_word()`. When `_reserved_word_acceptable()` is False (not at command position), `_lex_peek_reserved_word()` returns None, so callers don't see `}` or `]]` as reserved.
+
+### Step 3: Remove redundant `_open_brace_count` / `_open_cond_count`
+
+**Analysis:** These counts were intended for bash-style lexer decisions, but:
+- Parable's architecture is different - parser structure handles this
+- `}` at command position always breaks the loop
+- Whether `}` is consumed depends on parser context (inside brace group or not)
+- `DelimiterStack` provides the same depth info plus positions
+
+**Change:**
+- Remove `_open_brace_count` and `_open_cond_count` from Parser
+- Remove from `SavedParserState`
+- Keep `DelimiterStack` (provides positions for error messages)
+- For depth checks, use `_delimiter_stack.depth()`
+
+### Step 4: Verify `_special_case_tokens()` is needed
+
+**Current handling:**
+- Function names: `parse_function()` uses `peek_word()` bypassing tokenization
+- Case values: `parse_case()` uses `parse_word()`
+
+**Question:** Does `_reserved_word_acceptable()` integration break these?
+
+Test: `function if { echo test; }` - function named `if`
+- After `function`, history[0] = WORD("function")
+- `_reserved_word_acceptable()` returns False (after WORD)
+- `_lex_peek_reserved_word()` returns None
+- `if` is not recognized as reserved word ✓
+
+Actually this might break things! Let me check... After consuming `function`:
+- `parse_function()` calls `self._lex_consume_word("function")`
+- Then calls `peek_word()` which bypasses tokenization entirely
+
+So `_special_case_tokens()` may not be needed since `parse_function()` doesn't go through `_lex_peek_reserved_word()` for the function name.
+
+**Decision:** Remove `_special_case_tokens()` - it's documenting cases that are handled differently.
+
+---
+
+## Summary of Changes
+
+| Item | Action |
+|------|--------|
+| `_reserved_word_acceptable()` | **Integrate** into `_lex_peek_reserved_word()` |
+| `_special_case_tokens()` | **Remove** - cases handled by different parse paths |
+| `_open_brace_count` | **Remove** - redundant with DelimiterStack |
+| `_open_cond_count` | **Remove** - not needed |
+| `DelimiterStack` | **Keep** - used for error messages |
+| `len(words) == 0` check | **Remove** - replaced by `_reserved_word_acceptable()` |
+
+---
+
+## Verification
+
+After each step:
+1. `just test` - all 4535 tests pass
+2. `just transpile && just test-js` - JS tests pass
+3. Manual test edge cases:
+   - `}` at top level → error
+   - `{ echo; }` → parses correctly
+   - `echo }` → `}` is argument
+   - `function if { echo; }` → function named `if`
+   - `case if in if) echo ;; esac` → case value `if`

--- a/src/parable.js
+++ b/src/parable.js
@@ -213,17 +213,9 @@ class SavedParserState {
 		ctx_depth,
 		eof_token,
 		eof_depth,
-		open_brace_count,
-		open_cond_count,
 	) {
 		if (eof_depth == null) {
 			eof_depth = 0;
-		}
-		if (open_brace_count == null) {
-			open_brace_count = 0;
-		}
-		if (open_cond_count == null) {
-			open_cond_count = 0;
 		}
 		this.parser_state = parser_state;
 		this.dolbrace_state = dolbrace_state;
@@ -231,8 +223,6 @@ class SavedParserState {
 		this.ctx_depth = ctx_depth;
 		this.eof_token = eof_token;
 		this.eof_depth = eof_depth;
-		this.open_brace_count = open_brace_count;
-		this.open_cond_count = open_cond_count;
 	}
 }
 
@@ -8016,11 +8006,6 @@ class Parser {
 		this._word_context = WORD_CTX_NORMAL;
 		this._at_command_start = false;
 		this._in_array_literal = false;
-		// Brace/bracket counts for bash-style delimiter tracking
-		// } is only a reserved word when _open_brace_count > 0
-		// ]] is only a reserved word when _open_cond_count > 0
-		this._open_brace_count = 0;
-		this._open_cond_count = 0;
 		// Delimiter stack for better error messages on unclosed constructs
 		this._delimiter_stack = new DelimiterStack();
 	}
@@ -8045,8 +8030,6 @@ class Parser {
 			this._ctx.getDepth(),
 			this._eof_token,
 			this._eof_depth,
-			this._open_brace_count,
-			this._open_cond_count,
 		);
 	}
 
@@ -8055,8 +8038,6 @@ class Parser {
 		this._dolbrace_state = saved.dolbrace_state;
 		this._eof_token = saved.eof_token;
 		this._eof_depth = saved.eof_depth;
-		this._open_brace_count = saved.open_brace_count;
-		this._open_cond_count = saved.open_cond_count;
 		// Restore context stack to saved depth (pop any extra contexts)
 		while (this._ctx.getDepth() > saved.ctx_depth) {
 			this._ctx.pop();
@@ -8111,79 +8092,6 @@ class Parser {
 			return null;
 		}
 		return tok.type;
-	}
-
-	_reservedWordAcceptable() {
-		let last_type;
-		last_type = this._lastTokenType();
-		// None means start of input - reserved words acceptable
-		if (last_type == null) {
-			return true;
-		}
-		// After command separators
-		if (
-			[
-				TokenType.NEWLINE,
-				TokenType.SEMI,
-				TokenType.SEMI_SEMI,
-				TokenType.SEMI_AMP,
-				TokenType.SEMI_SEMI_AMP,
-				TokenType.PIPE,
-				TokenType.PIPE_AMP,
-				TokenType.AMP,
-				TokenType.AND_AND,
-				TokenType.OR_OR,
-				TokenType.LPAREN,
-				TokenType.RPAREN,
-				TokenType.LBRACE,
-				TokenType.RBRACE,
-				TokenType.BANG,
-			].includes(last_type)
-		) {
-			return true;
-		}
-		// After reserved words that expect commands to follow
-		if (
-			[
-				TokenType.IF,
-				TokenType.THEN,
-				TokenType.ELSE,
-				TokenType.ELIF,
-				TokenType.WHILE,
-				TokenType.UNTIL,
-				TokenType.DO,
-				TokenType.CASE,
-				TokenType.TIME,
-			].includes(last_type)
-		) {
-			return true;
-		}
-		return false;
-	}
-
-	_specialCaseTokens(word) {
-		let last, prev;
-		last = this._lastToken();
-		if (last == null) {
-			return false;
-		}
-		// After 'function', the next word is a name, not a reserved word
-		if (last.type === TokenType.WORD && last.value === "function") {
-			return true;
-		}
-		// After 'case' (and before 'in'), the word is a value, not reserved
-		if (last.type === TokenType.WORD && last.value === "case") {
-			return true;
-		}
-		// Check two tokens back for 'function' or 'case' patterns
-		prev = this._token_history[1];
-		if (prev != null) {
-			// function name - name is already consumed, don't reclassify
-			if (prev.value === "function") {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	_syncLexer() {
@@ -11068,10 +10976,9 @@ class Parser {
 			if (this._lexIsCommandTerminator()) {
 				break;
 			}
-			// } and ]] are only terminators at command position (closing brace group
-			// or conditional). In argument position, they're regular words.
-			// Check as reserved words since lexer returns them as WORD tokens.
-			// Use len() == 0 instead of 'not words' for JS transpiler compatibility
+			// } and ]] terminate at command position (first word).
+			// Can't use _reserved_word_acceptable() here because newlines aren't
+			// recorded in token history. Use len(words) == 0 for command position.
 			if (words.length === 0) {
 				reserved = this._lexPeekReservedWord();
 				if (reserved === "}" || reserved === "]]") {
@@ -11296,7 +11203,6 @@ class Parser {
 		}
 		this.advance();
 		this.advance();
-		this._open_cond_count += 1;
 		this._setState(ParserStateFlags.PST_CONDEXPR);
 		this._word_context = WORD_CTX_COND;
 		// Parse the conditional expression body
@@ -11312,7 +11218,6 @@ class Parser {
 			this.pos + 1 >= this.length ||
 			this.source[this.pos + 1] !== "]"
 		) {
-			this._open_cond_count -= 1;
 			this._clearState(ParserStateFlags.PST_CONDEXPR);
 			this._word_context = WORD_CTX_NORMAL;
 			throw new ParseError(
@@ -11322,7 +11227,6 @@ class Parser {
 		}
 		this.advance();
 		this.advance();
-		this._open_cond_count -= 1;
 		this._clearState(ParserStateFlags.PST_CONDEXPR);
 		this._word_context = WORD_CTX_NORMAL;
 		return new ConditionalExpr(body, this._collectRedirects());
@@ -11542,12 +11446,10 @@ class Parser {
 		if (!this._lexConsumeWord("{")) {
 			return null;
 		}
-		this._open_brace_count += 1;
 		this._delimiter_stack.push("{", brace_pos);
 		this.skipWhitespaceAndNewlines();
 		body = this.parseList();
 		if (body == null) {
-			this._open_brace_count -= 1;
 			this._delimiter_stack.pop();
 			throw new ParseError(
 				"Expected command in brace group",
@@ -11556,7 +11458,6 @@ class Parser {
 		}
 		this.skipWhitespace();
 		if (!this._lexConsumeWord("}")) {
-			this._open_brace_count -= 1;
 			delim_info = this._delimiter_stack.pop();
 			// Use the opening brace position for better error context
 			open_pos = delim_info ? delim_info[1] : brace_pos;
@@ -11565,7 +11466,6 @@ class Parser {
 				this.pos,
 			);
 		}
-		this._open_brace_count -= 1;
 		this._delimiter_stack.pop();
 		return new BraceGroup(body, this._collectRedirects());
 	}


### PR DESCRIPTION
## Summary

After attempting to integrate bash-style delimiter tracking patterns, found they don't fit Parable's architecture:

- **Removed** `_open_brace_count` / `_open_cond_count` - redundant with parser structure
- **Removed** `_reserved_word_acceptable()` - can't work because newlines aren't recorded in token history
- **Removed** `_special_case_tokens()` - cases are handled by different parse paths
- **Kept** `DelimiterStack` which is actually used for better error messages with opening delimiter positions

The `len(words) == 0` check in `parse_simple_command()` is the correct mechanism for `}` and `]]` handling in Parable, not token history.

All 4535 tests pass.