### PR TITLE
fix: print all discrepancy categories in fuzzer output

### DIFF
--- a/tools/fuzzer/src/fuzzer/character.py
+++ b/tools/fuzzer/src/fuzzer/character.py
@@ -446,6 +446,14 @@ class FuzzerCoordinator:
                 print(f"Parable:  {d.parable_result[:200]}...")
                 print(f"Oracle:   {d.oracle_result[:200]}...")
 
+        if parable_err and not self.config.both_succeed:
+            print("\n=== PARABLE ERRORS, ORACLE SUCCEEDS ===")
+            for d in parable_err[:3]:
+                print()
+                print("-" * 40)
+                print(f"Input:    {d.mutated!r}")
+                print(f"Oracle:   {d.oracle_result[:200]}...")
+
         if oracle_err and not self.config.both_succeed:
             print("\n=== PARABLE SUCCEEDS, ORACLE ERRORS ===")
             for d in oracle_err[:3]:

--- a/tools/fuzzer/src/fuzzer/structural.py
+++ b/tools/fuzzer/src/fuzzer/structural.py
@@ -363,6 +363,26 @@ def main():
             print(f"Parable:  {d.parable_result[:200]}...")
             print(f"Oracle:   {d.oracle_result[:200]}...")
 
+    if parable_err and not args.both_succeed:
+        print("\n=== PARABLE ERRORS, ORACLE SUCCEEDS ===")
+        for d in parable_err[:3]:
+            print()
+            print("-" * 40)
+            print(f"Transform: {d.mutation_desc}")
+            print(f"Original: {d.original!r}")
+            print(f"Mutated:  {d.mutated!r}")
+            print(f"Oracle:   {d.oracle_result[:200]}...")
+
+    if oracle_err and not args.both_succeed:
+        print("\n=== PARABLE SUCCEEDS, ORACLE ERRORS ===")
+        for d in oracle_err[:3]:
+            print()
+            print("-" * 40)
+            print(f"Transform: {d.mutation_desc}")
+            print(f"Original: {d.original!r}")
+            print(f"Mutated:  {d.mutated!r}")
+            print(f"Parable:  {d.parable_result[:200]}...")
+
     sys.exit(1 if discrepancies else 0)
 
 


### PR DESCRIPTION
## Summary
- The fuzzer summary showed counts for all three discrepancy categories but only printed details for some
- `parable_err` (Parable errors, oracle succeeds) was never printed in character.py
- Neither `parable_err` nor `oracle_err` was printed in structural.py
- Now all categories are printed to stdout when not using `--both-succeed`