### PR TITLE
feat: support Python 3.8 as minimum version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           name: logs
           path: |
+            /tmp/parable-test-py3.8.log
+            /tmp/parable-test-py3.9.log
             /tmp/parable-test-py3.10.log
             /tmp/parable-test-py3.11.log
             /tmp/parable-test-py3.12.log

--- a/justfile
+++ b/justfile
@@ -5,6 +5,10 @@ run_id := `head -c 16 /dev/urandom | xxd -p`
 _test version *ARGS:
     UV_PROJECT_ENVIRONMENT=.venv-{{version}} uv run --python {{version}} tests/bin/run-tests.py {{ARGS}} 2>&1 | sed -u "s/^/[{{version}}] /" | tee /tmp/{{project}}-{{run_id}}-test-{{version}}.log
 
+# Run tests on CPython 3.8
+test-cpy38 *ARGS: (_test "3.8" ARGS)
+# Run tests on CPython 3.9
+test-cpy39 *ARGS: (_test "3.9" ARGS)
 # Run tests on CPython 3.10
 test-cpy310 *ARGS: (_test "3.10" ARGS)
 # Run tests on CPython 3.11
@@ -60,7 +64,7 @@ verify-tests:
 
 # Run tests on all supported CPython versions (parallel)
 [parallel]
-test-cpy: test-cpy310 test-cpy311 test-cpy312 test-cpy313 test-cpy314
+test-cpy: test-cpy38 test-cpy39 test-cpy310 test-cpy311 test-cpy312 test-cpy313 test-cpy314
 
 # Run tests on PyPy
 test-pypy: test-pypy311

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "parable"
 version = "0.1.0"
 description = "A recursive descent parser for bash"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 authors = [{ name = "Lily Dayton", email = "lily.dayton.git@gmail.com" }]
 keywords = ["bash", "parser", "shell", "ast"]
@@ -13,6 +13,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tools/transpiler/src/transpiler/check_style.py
+++ b/tools/transpiler/src/transpiler/check_style.py
@@ -224,9 +224,10 @@ def check_file(filepath):
         if isinstance(node, ast.Import):
             errors.append((lineno, "import: not allowed, code must be self-contained"))
 
-        # from ... import
+        # from ... import (allow __future__)
         if isinstance(node, ast.ImportFrom):
-            errors.append((lineno, "from import: not allowed, code must be self-contained"))
+            if node.module != "__future__":
+                errors.append((lineno, "from import: not allowed, code must be self-contained"))
 
     return errors
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 
 [[package]]
 name = "parable"


### PR DESCRIPTION
## Summary
- Lower minimum Python version from 3.10 to 3.8
- Add `from __future__ import annotations` to enable union type syntax on older versions
- Add test targets for Python 3.8 and 3.9 in justfile and CI
- Allow `__future__` imports in style checker