### PR TITLE
fix: handle extglob patterns after $? $* $@ special params

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1471,6 +1471,25 @@ class Lexer {
 					chars.push(this.advance());
 				} else {
 					this._syncFromParser();
+					// Special params $? $* $@ can be followed by () as extglob pattern
+					if (
+						ctx === WORD_CTX_NORMAL &&
+						chars &&
+						chars[chars.length - 1].length === 2 &&
+						chars[chars.length - 1][0] === "$" &&
+						"?*@".includes(chars[chars.length - 1][1]) &&
+						!this.atEnd() &&
+						this.peek() === "("
+					) {
+						chars.push(this.advance());
+						content = this._parseMatchedPair(
+							"(",
+							")",
+							MatchedPairFlags.EXTGLOB,
+						);
+						chars.push(content);
+						chars.push(")");
+					}
 				}
 				continue;
 			}

--- a/tests/parable/character-fuzzer/fuzz-extglob-special-params.tests
+++ b/tests/parable/character-fuzzer/fuzz-extglob-special-params.tests
@@ -1,0 +1,17 @@
+=== $?() extglob after special param
+echo $?()
+---
+(command (word "echo") (word "$?()"))
+---
+
+=== $*() extglob after special param
+echo $*()
+---
+(command (word "echo") (word "$*()"))
+---
+
+=== $@() extglob after special param
+echo $@()
+---
+(command (word "echo") (word "$@()"))
+---


### PR DESCRIPTION
## Summary
- Fix parsing of `$?()`, `$*()`, `$@()` which bash allows as extglob patterns
- These special params end with extglob prefix chars (`?`, `*`, `@`), so `()` following them is valid
- Add fuzzer-discovered test cases