### PR TITLE
fix: handle newlines AFTER list operators, matching bash grammar

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-newline-operator-order.tests
+++ b/tests/parable/character-fuzzer/fuzz-newline-operator-order.tests
@@ -1,0 +1,54 @@
+=== newline then ampersand in subshell
+(:
+&)
+---
+<error>
+---
+
+=== ampersand at end of subshell
+(: &)
+---
+(subshell (background (command (word ":"))))
+---
+
+=== ampersand then newline continuation in subshell
+(: &
+:)
+---
+(subshell (background (command (word ":")) (command (word ":"))))
+---
+
+=== newline then semicolon in subshell
+(:
+;)
+---
+<error>
+---
+
+=== semicolon at end of subshell
+(: ;)
+---
+(subshell (command (word ":")))
+---
+
+=== newline then ampersand in brace group
+{ :
+& }
+---
+<error>
+---
+
+=== ampersand then newline continuation in brace group
+{ : &
+: ; }
+---
+(brace-group (background (command (word ":")) (command (word ":"))))
+---
+
+=== top-level ampersand then newline separates commands
+: &
+:
+---
+(background (command (word ":")))
+(command (word ":"))
+---


### PR DESCRIPTION
## Summary

- Restructures `parse_list()` and `parse_list_until()` to check for operators BEFORE consuming newlines
- Correctly rejects bare `&` or `;` after newline (e.g., `(:\n&)` is now a syntax error)
- Adds `_peek_list_operator()` helper and `_at_list_until_terminator()` to reduce duplication

Bash's grammar distinguishes where newlines are allowed:
- After `&&` and `||`: always allowed
- After `&` and `;`: allowed in compound_list context only  
- Before operators: newline acts as command terminator

Previously `(:\n&)` was incorrectly accepted as `(: &)`. Now it correctly errors like bash.