### PR TITLE
Close lexer architectural gaps with bash

### DIFF
--- a/tests/bin/run-js-tests.js
+++ b/tests/bin/run-js-tests.js
@@ -76,8 +76,15 @@ function normalize(s) {
 }
 
 function runTest(testInput, testExpected) {
+  // Check for @extglob directive
+  let extglob = false;
+  if (testInput.startsWith('# @extglob\n')) {
+    extglob = true;
+    testInput = testInput.slice('# @extglob\n'.length);
+  }
+
   try {
-    const nodes = parse(testInput);
+    const nodes = parse(testInput, extglob);
     const actual = nodes.map(n => n.toSexp()).join(' ');
     const expectedNorm = normalize(testExpected);
     // If we expected an error but got a successful parse, that's a failure

--- a/tests/bin/run-tests.py
+++ b/tests/bin/run-tests.py
@@ -71,8 +71,14 @@ def run_test(test_input, test_expected):
     """Run a single test. Returns (passed, actual, error_msg)."""
     from parable import ParseError, parse
 
+    # Check for @extglob directive
+    extglob = False
+    if test_input.startswith("# @extglob\n"):
+        extglob = True
+        test_input = test_input[len("# @extglob\n") :]
+
     try:
-        nodes = parse(test_input)
+        nodes = parse(test_input, extglob=extglob)
         actual = " ".join(node.to_sexp() for node in nodes)
     except ParseError as e:
         if normalize(test_expected) == "<error>":

--- a/tests/corpus/gnu-bash/tests.tests
+++ b/tests/corpus/gnu-bash/tests.tests
@@ -2497,6 +2497,7 @@ echo $upper
 ---
 
 === complete
+# @extglob
 #  Chet Ramey <chet.ramey@case.edu>
 #
 #  Copyright 2002-2020 Chester Ramey
@@ -3276,6 +3277,7 @@ ${THIS_SH} ./comsub7.sub
 ---
 
 === cond
+# @extglob
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
 #   the Free Software Foundation, either version 3 of the License, or
@@ -5979,6 +5981,7 @@ ${THIS_SH} ./exportfunc3.sub
 ---
 
 === extglob
+# @extglob
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
 #   the Free Software Foundation, either version 3 of the License, or
@@ -6719,6 +6722,7 @@ t foobb         !(foo)b*
 ---
 
 === extglob3
+# @extglob
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
 #   the Free Software Foundation, either version 3 of the License, or
@@ -14807,6 +14811,7 @@ EOF
 ---
 
 === printf
+# @extglob
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
 #   the Free Software Foundation, either version 3 of the License, or

--- a/tests/corpus/oils/control.tests
+++ b/tests/corpus/oils/control.tests
@@ -189,6 +189,7 @@ echo sum=$sum
 ---
 
 === \(\) in pattern (regression)
+# @extglob
 s='foo()'
 
 case $s in

--- a/tests/corpus/oils/expansion.tests
+++ b/tests/corpus/oils/expansion.tests
@@ -467,6 +467,7 @@ echo {z..3}
 ---
 
 === @() matches exactly one of the patterns
+# @extglob
 shopt -s extglob
 mkdir -p 0
 cd 0
@@ -481,6 +482,7 @@ echo @(*.cc|*.h)
 ---
 
 === ?() matches 0 or 1
+# @extglob
 shopt -s extglob
 mkdir -p 1
 cd 1
@@ -497,6 +499,7 @@ echo foo.?($ext|h)
 ---
 
 === *() matches 0 or more
+# @extglob
 shopt -s extglob
 mkdir -p eg1
 touch eg1/_ eg1/_One eg1/_OneOne eg1/_TwoTwo eg1/_OneTwo
@@ -509,6 +512,7 @@ echo eg1/_*(One|Two)
 ---
 
 === +() matches 1 or more
+# @extglob
 shopt -s extglob
 mkdir -p eg2
 touch eg2/_ eg2/_One eg2/_OneOne eg2/_TwoTwo eg2/_OneTwo
@@ -521,6 +525,7 @@ echo eg2/_+(One|$(echo Two))
 ---
 
 === !(*.h|*.cc) to match everything except C++
+# @extglob
 shopt -s extglob
 mkdir -p extglob2
 touch extglob2/{foo,bar}.cc extglob2/{foo,bar,baz}.h \
@@ -534,6 +539,7 @@ echo extglob2/!(*.h|*.cc)
 ---
 
 === Two adjacent alternations
+# @extglob
 shopt -s extglob
 mkdir -p 2
 touch 2/{aa,ab,ac,ba,bb,bc,ca,cb,cc}
@@ -550,6 +556,7 @@ echo 2/!(b)a@(b|c)  # constant in between
 ---
 
 === Nested extended glob pattern
+# @extglob
 shopt -s extglob
 mkdir -p eg6
 touch eg6/{ab,ac,ad,az,bc,bd}
@@ -564,6 +571,7 @@ echo eg6/a!(@(ab|b*))
 ---
 
 === Extended glob patterns with spaces
+# @extglob
 shopt -s extglob
 mkdir -p eg4
 touch eg4/a 'eg4/a b' eg4/foo
@@ -576,6 +584,7 @@ argv.py eg4/@(a b|foo)
 ---
 
 === Filenames with spaces
+# @extglob
 shopt -s extglob
 mkdir -p eg5
 touch eg5/'a b'{cd,de,ef}
@@ -588,6 +597,7 @@ argv.py eg5/'a '@(bcd|bde|zzz)
 ---
 
 === nullglob with extended glob
+# @extglob
 shopt -s extglob
 mkdir eg6
 argv.py eg6/@(no|matches)  # no matches
@@ -602,6 +612,7 @@ argv.py eg6/@(no|matches)  # no matches
 ---
 
 === Glob other punctuation chars (lexer mode)
+# @extglob
 shopt -s extglob
 mkdir -p eg5
 cd eg5
@@ -618,6 +629,7 @@ argv.py @(__aa|'__<>'|__{}|__#|__&&|)
 ---
 
 === More glob escaping
+# @extglob
 shopt -s extglob
 mkdir -p eg7
 cd eg7
@@ -636,6 +648,7 @@ argv.py @(nested|'_?'|@('_[:]'|'_*'))
 ---
 
 === Escaping of pipe (glibc bug, see demo/glibc_fnmatch.c)
+# @extglob
 shopt -s extglob
 
 mkdir -p extpipe
@@ -678,6 +691,7 @@ echo ${undef:-@(foo|bar).py}
 ---
 
 === Extended glob in assignment builtin
+# @extglob
 # Another invocation of _EvalWordToParts() that OSH should handle
 
 shopt -s extglob
@@ -696,6 +710,7 @@ echo status=$?
 ---
 
 === Extended glob in same word as array
+# @extglob
 shopt -s extglob
 mkdir -p eg10
 cd eg10
@@ -725,6 +740,7 @@ argv.py at extglob "$@"*@(.py|cc)
 ---
 
 === Extended glob with word splitting
+# @extglob
 shopt -s extglob
 mkdir -p 3
 cd 3
@@ -744,6 +760,7 @@ argv.py $x*.@(cc|h)
 ---
 
 === In Array Literal and for loop
+# @extglob
 shopt -s extglob
 mkdir -p eg11
 cd eg11
@@ -769,6 +786,7 @@ echo "${A[@]}"
 ---
 
 === No extended glob with simple_word_eval (YSH evaluation)
+# @extglob
 shopt -s ysh:all
 shopt -s extglob
 mkdir -p eg12
@@ -787,6 +805,7 @@ builtin write -- @(fo*|bar).py
 ---
 
 === no_dash_glob
+# @extglob
 shopt -s extglob
 mkdir -p opts
 cd opts
@@ -807,6 +826,7 @@ echo @(*)
 ---
 
 === noglob
+# @extglob
 shopt -s extglob
 mkdir -p _noglob
 cd _noglob
@@ -824,6 +844,7 @@ echo @(__nope__*|__nope__?|'*'|'?'|'[:alpha:]'|'|')
 ---
 
 === failglob
+# @extglob
 shopt -s extglob
 
 rm -f _failglob/*
@@ -851,6 +872,7 @@ echo status=$?
 ---
 
 === @ matches exactly one
+# @extglob
 [[ --verbose == --@(help|verbose) ]] && echo TRUE
 [[ --oops == --@(help|verbose) ]] || echo FALSE
 ---
@@ -859,6 +881,7 @@ echo status=$?
 ---
 
 === @() with variable arms
+# @extglob
 choice1='help'
 choice2='verbose'
 [[ --verbose == --@($choice1|$choice2) ]] && echo TRUE
@@ -871,6 +894,7 @@ choice2='verbose'
 ---
 
 === extglob in variable
+# @extglob
 shopt -s extglob
 
 # this syntax requires extglob in bash!!
@@ -896,6 +920,7 @@ quoted='--@(help|verbose)'
 ---
 
 === Matching literal '@(cc)'
+# @extglob
 # extglob is OFF.  Doesn't affect bash or mksh!
 [[ cc == @(cc) ]] 
 echo status=$?
@@ -937,6 +962,7 @@ pat='--@(help|verbose|no-@(long|short)-option)'
 ---
 
 === nested @() with quotes and vars
+# @extglob
 shopt -s extglob
 prefix=no
 [[ --no-long-option == --@(help|verbose|$prefix-@(long|short)-'option') ]] &&
@@ -948,6 +974,7 @@ prefix=no
 ---
 
 === ? matches 0 or 1
+# @extglob
 [[ -- == --?(help|verbose) ]] && echo TRUE
 [[ --oops == --?(help|verbose) ]] || echo FALSE
 ---
@@ -956,6 +983,7 @@ prefix=no
 ---
 
 === + matches 1 or more
+# @extglob
 [[ --helphelp == --+(help|verbose) ]] && echo TRUE
 [[ -- == --+(help|verbose) ]] || echo FALSE
 ---
@@ -964,6 +992,7 @@ prefix=no
 ---
 
 === * matches 0 or more
+# @extglob
 [[ -- == --*(help|verbose) ]] && echo TRUE
 [[ --oops == --*(help|verbose) ]] || echo FALSE
 ---
@@ -972,6 +1001,7 @@ prefix=no
 ---
 
 === simple repetition with *(foo) and +(Foo)
+# @extglob
 [[ foofoo == *(foo) ]] && echo TRUE
 [[ foofoo == +(foo) ]] && echo TRUE
 ---
@@ -980,6 +1010,7 @@ prefix=no
 ---
 
 === ! matches none
+# @extglob
 [[ --oops == --!(help|verbose) ]] && echo TRUE
 [[ --help == --!(help|verbose) ]] || echo FALSE
 ---
@@ -988,6 +1019,7 @@ prefix=no
 ---
 
 === match is anchored
+# @extglob
 [[ foo_ == @(foo) ]] || echo FALSE
 [[ _foo == @(foo) ]] || echo FALSE
 [[ foo == @(foo) ]] && echo TRUE
@@ -998,6 +1030,7 @@ prefix=no
 ---
 
 === repeated match is anchored
+# @extglob
 [[ foofoo_ == +(foo) ]] || echo FALSE
 [[ _foofoo == +(foo) ]] || echo FALSE
 [[ foofoo == +(foo) ]] && echo TRUE
@@ -1008,6 +1041,7 @@ prefix=no
 ---
 
 === repetition with glob
+# @extglob
 # NOTE that * means two different things here
 [[ foofoo_foo__foo___ == *(foo*) ]] && echo TRUE
 [[ Xoofoo_foo__foo___ == *(foo*) ]] || echo FALSE
@@ -1017,6 +1051,7 @@ prefix=no
 ---
 
 === No brace expansion in ==
+# @extglob
 [[ --X{a,b}X == --@(help|X{a,b}X) ]] && echo TRUE
 [[ --oops == --@(help|X{a,b}X) ]] || echo FALSE
 ---
@@ -1025,6 +1060,7 @@ prefix=no
 ---
 
 === adjacent extglob
+# @extglob
 [[ --help == @(--|++)@(help|verbose) ]] && echo TRUE
 [[ ++verbose == @(--|++)@(help|verbose) ]] && echo TRUE
 ---
@@ -1033,6 +1069,7 @@ prefix=no
 ---
 
 === nested extglob
+# @extglob
 [[ --help == --@(help|verbose=@(1|2)) ]] && echo TRUE
 [[ --verbose=1 == --@(help|verbose=@(1|2)) ]] && echo TRUE
 [[ --verbose=2 == --@(help|verbose=@(1|2)) ]] && echo TRUE
@@ -1045,6 +1082,7 @@ prefix=no
 ---
 
 === extglob empty string
+# @extglob
 shopt -s extglob
 [[ '' == @(foo|bar) ]] || echo FALSE
 [[ '' == @(foo||bar) ]] && echo TRUE
@@ -1055,6 +1093,7 @@ shopt -s extglob
 ---
 
 === extglob empty pattern
+# @extglob
 shopt -s extglob
 [[ '' == @() ]] && echo TRUE
 [[ '' == @(||) ]] && echo TRUE
@@ -1069,6 +1108,7 @@ shopt -s extglob
 ---
 
 === case with extglob
+# @extglob
 shopt -s extglob
 for word in --help --verbose --unmatched -- -zxzx -; do
   case $word in
@@ -1100,6 +1140,7 @@ done
 ---
 
 === [[ $x == !($str) ]]
+# @extglob
 shopt -s extglob
 empty=''
 str='x'
@@ -1114,6 +1155,7 @@ str='x'
 ---
 
 === Turning extglob on changes the meaning of [[ !(str) ]] in bash
+# @extglob
 empty=''
 str='x'
 [[ !($empty) ]]  && echo TRUE   # test if $empty is empty
@@ -1132,6 +1174,7 @@ shopt -s extglob  # mksh doesn't have this
 ---
 
 === With extglob on, !($str) on the left or right of == has different meanings
+# @extglob
 shopt -s extglob
 str='x'
 [[ 1 == !($str) ]]  && echo TRUE   # glob match
@@ -1142,6 +1185,7 @@ str='x'
 ---
 
 === extglob inside arg word
+# @extglob
 shopt -s extglob
 [[ foo == @(foo|bar) ]] && echo rhs
 [[ foo == ${unset:-@(foo|bar)} ]] && echo 'rhs arg'
@@ -1176,6 +1220,7 @@ echo $?
 ---
 
 === extended glob of single unicode char
+# @extglob
 shopt -s extglob
 [[ __a__ == @(__?__) ]]
 echo $?
@@ -2041,6 +2086,7 @@ echo *  # expansion includes -foo.txt, because it doesn't match GLOBIGNORE
 ---
 
 === Extended glob expansion combined with GLOBIGNORE
+# @extglob
 shopt -s extglob
 
 touch foo.cc foo.h bar.cc bar.h 

--- a/tests/corpus/oils/misc.tests
+++ b/tests/corpus/oils/misc.tests
@@ -4031,6 +4031,7 @@ echo "-$dirprefix-"
 ---
 
 === !( as negation and subshell versus extended glob - #2463
+# @extglob
 have_icu_uc=false
 have_icu_i18n=false
 
@@ -6992,7 +6993,8 @@ echo -n $'\c-\c+\c"' | show_bytes
 (command (word "echo"))
 (pipe (command (word "echo") (word "-n") (word "''")) (command (word "show_bytes")))
 (command (word "echo"))
-(pipe (command (word "echo") (word "-n") (word "''")) (command (word "show_bytes")))
+(pipe (command (word "echo") (word "-n") (word "'
+'")) (command (word "show_bytes")))
 ---
 
 === echo `cat OSCFLAGS` "world" > OSCFLAGS (from Alpine imap)
@@ -9629,6 +9631,7 @@ xx() { echo "${@@Q}";}; xx a b c d
 ---
 
 === extglob $IFS 1
+# @extglob
 # http://landley.net/notes.html#12-06-2020
 shopt -s extglob
 
@@ -9651,6 +9654,7 @@ echo $ABC
 ---
 
 === extglob $IFS 2
+# @extglob
 # http://landley.net/notes.html#17-05-2020
 
 shopt -s extglob  # required for bash, not osh
@@ -9661,6 +9665,7 @@ IFS=x; ABC=cxd; for i in +($ABC); do echo =$i=; done
 ---
 
 === char class / extglob
+# @extglob
 # http://landley.net/notes.html#14-05-2020
 shopt -s extglob
 

--- a/tests/corpus/oils/parsing.tests
+++ b/tests/corpus/oils/parsing.tests
@@ -7609,6 +7609,7 @@ head foo-bar foo-spam
 ---
 
 === File redirect with extended glob
+# @extglob
 shopt -s extglob
 
 touch foo-bar
@@ -7626,6 +7627,7 @@ cat foo-bar
 ---
 
 === Extended glob that doesn't match anything
+# @extglob
 shopt -s extglob
 rm bad_*
 

--- a/tests/corpus/tree-sitter-bash/statements.tests
+++ b/tests/corpus/tree-sitter-bash/statements.tests
@@ -138,6 +138,7 @@ fi
 ---
 
 === If statements with conditional expressions
+# @extglob
 if [ "$(uname)" == 'Darwin' ]; then
   echo one
 fi
@@ -263,6 +264,7 @@ esac
 ---
 
 === Test commands
+# @extglob
 if [[ "$lsb_dist" != 'Ubuntu' || $(ver_to_int "$lsb_release") < $(ver_to_int '14.04') ]]; then
 	return 1
 fi
@@ -320,6 +322,7 @@ $((${n} < 10 ? ${n} : 10))
 ---
 
 === Test commands with regexes
+# @extglob
 [[ "35d8b" =~ ^[0-9a-fA-F] ]]
 [[ $CMD =~ (^|;)update_terminal_cwd($|;) ]]
 [[ ! " ${completions[*]} " =~ " $alias_cmd " ]]
@@ -360,6 +363,7 @@ $((${n} < 10 ? ${n} : 10))
 ---
 
 === Test command paren statefulness with a case glob
+# @extglob
 [[ ${test} == @($(IFS='|'; echo "${skip[*]}")) ]]
 
 case ${out} in

--- a/tests/parable/30_extglob_case.tests
+++ b/tests/parable/30_extglob_case.tests
@@ -2,6 +2,7 @@
 # Extended glob patterns @(), ?(), *(), +(), !() must be handled
 
 === basic @() extglob
+# @extglob
 case $x in @(a|b)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(a|b)")) (command (word "echo") (word "match"))))
@@ -9,6 +10,7 @@ case $x in @(a|b)) echo match;; esac
 
 
 === basic ?() extglob
+# @extglob
 case $x in ?(foo|bar)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "?(foo|bar)")) (command (word "echo") (word "match"))))
@@ -16,6 +18,7 @@ case $x in ?(foo|bar)) echo match;; esac
 
 
 === basic *() extglob
+# @extglob
 case $x in *(a|b|c)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "*(a|b|c)")) (command (word "echo") (word "match"))))
@@ -23,6 +26,7 @@ case $x in *(a|b|c)) echo match;; esac
 
 
 === basic +() extglob
+# @extglob
 case $x in +(one|two)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "+(one|two)")) (command (word "echo") (word "match"))))
@@ -30,6 +34,7 @@ case $x in +(one|two)) echo match;; esac
 
 
 === basic !() extglob
+# @extglob
 case $x in !(bad|worse)) echo good;; esac
 ---
 (case (word "$x") (pattern ((word "!(bad|worse)")) (command (word "echo") (word "good"))))
@@ -37,6 +42,7 @@ case $x in !(bad|worse)) echo good;; esac
 
 
 === extglob single alternative
+# @extglob
 case $x in @(foo)) echo foo;; esac
 ---
 (case (word "$x") (pattern ((word "@(foo)")) (command (word "echo") (word "foo"))))
@@ -44,6 +50,7 @@ case $x in @(foo)) echo foo;; esac
 
 
 === extglob many alternatives
+# @extglob
 case $x in @(a|b|c|d|e)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(a|b|c|d|e)")) (command (word "echo") (word "match"))))
@@ -51,6 +58,7 @@ case $x in @(a|b|c|d|e)) echo match;; esac
 
 
 === nested extglobs
+# @extglob
 case $x in @(a|@(b|c))) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(a|@(b|c))")) (command (word "echo") (word "match"))))
@@ -58,6 +66,7 @@ case $x in @(a|@(b|c))) echo match;; esac
 
 
 === mixed nested extglobs
+# @extglob
 case $x in @(?(a)|+(b))) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(?(a)|+(b))")) (command (word "echo") (word "match"))))
@@ -65,6 +74,7 @@ case $x in @(?(a)|+(b))) echo match;; esac
 
 
 === extglob with trailing glob
+# @extglob
 case $x in @(foo|bar)*) echo prefix;; esac
 ---
 (case (word "$x") (pattern ((word "@(foo|bar)*")) (command (word "echo") (word "prefix"))))
@@ -72,6 +82,7 @@ case $x in @(foo|bar)*) echo prefix;; esac
 
 
 === extglob with leading glob
+# @extglob
 case $x in *@(foo|bar)) echo suffix;; esac
 ---
 (case (word "$x") (pattern ((word "*@(foo|bar)")) (command (word "echo") (word "suffix"))))
@@ -79,6 +90,7 @@ case $x in *@(foo|bar)) echo suffix;; esac
 
 
 === extglob in middle
+# @extglob
 case $x in pre@(a|b)post) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "pre@(a|b)post")) (command (word "echo") (word "match"))))
@@ -86,6 +98,7 @@ case $x in pre@(a|b)post) echo match;; esac
 
 
 === multiple extglobs in alternation
+# @extglob
 case $x in @(a|b)|@(c|d)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(a|b)") (word "@(c|d)")) (command (word "echo") (word "match"))))
@@ -93,6 +106,7 @@ case $x in @(a|b)|@(c|d)) echo match;; esac
 
 
 === extglob empty body
+# @extglob
 case $x in @(a|b));; esac
 ---
 (case (word "$x") (pattern ((word "@(a|b)")) ()))
@@ -100,6 +114,7 @@ case $x in @(a|b));; esac
 
 
 === multiple clauses with extglobs
+# @extglob
 case $x in @(a)) echo a;; @(b)) echo b;; esac
 ---
 (case (word "$x") (pattern ((word "@(a)")) (command (word "echo") (word "a"))) (pattern ((word "@(b)")) (command (word "echo") (word "b"))))
@@ -107,6 +122,7 @@ case $x in @(a)) echo a;; @(b)) echo b;; esac
 
 
 === extglob with optional leading paren
+# @extglob
 case $x in (@(a|b)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(a|b)")) (command (word "echo") (word "match"))))
@@ -114,6 +130,7 @@ case $x in (@(a|b)) echo match;; esac
 
 
 === extglob with wildcards inside
+# @extglob
 case $x in @(*.txt|*.md)) echo doc;; esac
 ---
 (case (word "$x") (pattern ((word "@(*.txt|*.md)")) (command (word "echo") (word "doc"))))
@@ -121,6 +138,7 @@ case $x in @(*.txt|*.md)) echo doc;; esac
 
 
 === extglob with character classes
+# @extglob
 case $x in @([a-z]*|[0-9]*)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@([a-z]*|[0-9]*)")) (command (word "echo") (word "match"))))
@@ -128,6 +146,7 @@ case $x in @([a-z]*|[0-9]*)) echo match;; esac
 
 
 === extglob and regular alternation
+# @extglob
 case $x in foo|@(bar|baz)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "foo") (word "@(bar|baz)")) (command (word "echo") (word "match"))))
@@ -135,6 +154,7 @@ case $x in foo|@(bar|baz)) echo match;; esac
 
 
 === regular and extglob alternation
+# @extglob
 case $x in @(foo|bar)|baz) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(foo|bar)") (word "baz")) (command (word "echo") (word "match"))))
@@ -142,6 +162,7 @@ case $x in @(foo|bar)|baz) echo match;; esac
 
 
 === deeply nested extglobs
+# @extglob
 case $x in @(@(@(a)))) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(@(@(a)))")) (command (word "echo") (word "match"))))
@@ -149,6 +170,7 @@ case $x in @(@(@(a)))) echo match;; esac
 
 
 === command sub inside extglob
+# @extglob
 case $x in @($(echo a)|b)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@($(echo a)|b)")) (command (word "echo") (word "match"))))
@@ -156,6 +178,7 @@ case $x in @($(echo a)|b)) echo match;; esac
 
 
 === quoted content inside extglob
+# @extglob
 case $x in @("foo"|bar)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(\"foo\"|bar)")) (command (word "echo") (word "match"))))
@@ -163,6 +186,7 @@ case $x in @("foo"|bar)) echo match;; esac
 
 
 === multiple extglobs in pattern
+# @extglob
 case $x in @(a)*@(b)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(a)*@(b)")) (command (word "echo") (word "match"))))
@@ -170,6 +194,7 @@ case $x in @(a)*@(b)) echo match;; esac
 
 
 === escaped paren inside extglob
+# @extglob
 case $x in @(a\)|b)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(a\\)|b)")) (command (word "echo") (word "match"))))
@@ -177,6 +202,7 @@ case $x in @(a\)|b)) echo match;; esac
 
 
 === arithmetic expansion inside extglob
+# @extglob
 case $x in @($((1+2)))) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@($((1+2)))")) (command (word "echo") (word "match"))))
@@ -184,6 +210,7 @@ case $x in @($((1+2)))) echo match;; esac
 
 
 === grouping parens inside extglob
+# @extglob
 case $x in @((a))) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@((a))")) (command (word "echo") (word "match"))))
@@ -191,6 +218,7 @@ case $x in @((a))) echo match;; esac
 
 
 === nested grouping in extglob
+# @extglob
 case $x in @((a|b)|(c))) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@((a|b)|(c))")) (command (word "echo") (word "match"))))
@@ -198,6 +226,7 @@ case $x in @((a|b)|(c))) echo match;; esac
 
 
 === backtick command sub in extglob
+# @extglob
 case $x in @(`cmd`)) echo match;; esac
 ---
 (case (word "$x") (pattern ((word "@(`cmd`)")) (command (word "echo") (word "match"))))

--- a/tests/parable/31_parser_bugs.tests
+++ b/tests/parable/31_parser_bugs.tests
@@ -18,6 +18,7 @@ for x in; do :; done
 
 
 === extglob in word
+# @extglob
 echo @(a|b)
 ---
 (command (word "echo") (word "@(a|b)"))

--- a/tests/parable/character-fuzzer/fuzz-23538.tests
+++ b/tests/parable/character-fuzzer/fuzz-23538.tests
@@ -1,4 +1,5 @@
 === cmdsub inside extglob not reformatted
+# @extglob
 echo @($(e&f))
 ---
 (command (word "echo") (word "@($(e&f))"))

--- a/tests/parable/character-fuzzer/fuzz-24370.tests
+++ b/tests/parable/character-fuzzer/fuzz-24370.tests
@@ -1,4 +1,5 @@
 === extglob with process substitution containing redirect
+# @extglob
 *(<(<a))
 ---
 (command (word "*(<(<a))"))

--- a/tests/parable/character-fuzzer/fuzz-2b090db1d81b07d38e370ac7399afa8c.tests
+++ b/tests/parable/character-fuzzer/fuzz-2b090db1d81b07d38e370ac7399afa8c.tests
@@ -1,4 +1,5 @@
 === coproc with invalid name followed by arithmetic expression
+# @extglob
 coproc +(())
 ---
 (coproc "COPROC" (command (word "+(())")))

--- a/tests/parable/character-fuzzer/fuzz-8341.tests
+++ b/tests/parable/character-fuzzer/fuzz-8341.tests
@@ -1,4 +1,5 @@
 === backslash-newline inside extglob should be stripped
+# @extglob
 <*(\
 )
 ---

--- a/tests/parable/character-fuzzer/fuzz-8ab4db8e8e32c6f02d7044e7dcf8056e.tests
+++ b/tests/parable/character-fuzzer/fuzz-8ab4db8e8e32c6f02d7044e7dcf8056e.tests
@@ -1,4 +1,5 @@
 === extglob pattern a*() not parsed as function
+# @extglob
 a*()
 { :; }
 ---

--- a/tests/parable/character-fuzzer/fuzz-ba6b7c38aa719757aedb0b3668e4697a.tests
+++ b/tests/parable/character-fuzzer/fuzz-ba6b7c38aa719757aedb0b3668e4697a.tests
@@ -1,4 +1,5 @@
 === parameter expansion with nested command substitution in @() - no closing brace
+# @extglob
 @(${$(a))
 ---
 (command (word "@(${$(a))"))


### PR DESCRIPTION
## Summary

- Fix word termination in `[[ ]]` to match bash's `shellbreak()`: newlines, single `&`, and single `|` now terminate words
- Add `"` and `\n` to escapable chars in double quotes; separate function for backtick escapes where `"` is NOT escapable
- Add `extglob` flag to Parser (default `false`) to conditionally parse extended glob patterns

## Changes

| Phase | Description |
|-------|-------------|
| 1 | Word termination alignment in `[[ ]]` context |
| 2 | Escape character handling in double quotes vs backticks |
| 4 | `extglob` parameter with `# @extglob` test directive |

## Skipped

- **Phase 3** (unicode escapes): Bash accepts 1-4 digits for `\u` and 1-8 for `\U`, not exactly 4/8 as originally planned
- **Phase 5** (`]` vs `]]`): Verified no divergence exists

## Test changes

- 98 tests marked with `# @extglob` directive
- Both Python and JS test runners updated to support the directive