### PR TITLE
feat: sync extglob flag with bash-oracle --extglob

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-extglob-special-params.tests
+++ b/tests/parable/character-fuzzer/fuzz-extglob-special-params.tests
@@ -1,16 +1,19 @@
 === $?() extglob after special param
+# @extglob
 echo $?()
 ---
 (command (word "echo") (word "$?()"))
 ---
 
 === $*() extglob after special param
+# @extglob
 echo $*()
 ---
 (command (word "echo") (word "$*()"))
 ---
 
 === $@() extglob after special param
+# @extglob
 echo $@()
 ---
 (command (word "echo") (word "$@()"))


### PR DESCRIPTION
## Summary

- Update `verify_tests.py` to pass `--extglob` to bash-oracle only when tests declare `# @extglob` directive
- Update fuzzer `common.py` to support extglob parameter (default false)
- Add `# @extglob` to 3 tests that use extglob patterns after special params (`$?()`, `$*()`, `$@()`)

This syncs with the bash-oracle change that now requires `--extglob` flag to enable extended glob parsing.