### PR TITLE
fix: check extglob flag for $?() $*() $@() patterns

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -1474,6 +1474,7 @@ class Lexer {
 					this._syncFromParser();
 					// Special params $? $* $@ can be followed by () as extglob pattern
 					if (
+						this._extglob &&
 						ctx === WORD_CTX_NORMAL &&
 						chars &&
 						chars[chars.length - 1].length === 2 &&

--- a/src/parable.py
+++ b/src/parable.py
@@ -1303,7 +1303,8 @@ class Lexer:
                     self._sync_from_parser()
                     # Special params $? $* $@ can be followed by () as extglob pattern
                     if (
-                        ctx == WORD_CTX_NORMAL
+                        self._extglob
+                        and ctx == WORD_CTX_NORMAL
                         and chars
                         and len(chars[len(chars) - 1]) == 2
                         and chars[len(chars) - 1][0] == "$"

--- a/tests/parable/character-fuzzer/fuzz-extglob-special-params.tests
+++ b/tests/parable/character-fuzzer/fuzz-extglob-special-params.tests
@@ -18,3 +18,9 @@ echo $@()
 ---
 (command (word "echo") (word "$@()"))
 ---
+
+=== $*() without extglob is syntax error
+$*()
+---
+<error>
+---


### PR DESCRIPTION
## Summary

Special params followed by `()` were being parsed as extglob patterns even when extglob was disabled. Added `self._extglob` check to match the other extglob entry points.

Without this fix, `$*()` would parse successfully with `extglob=False`, but bash-oracle (without `--extglob`) correctly returns a syntax error.

Adds regression test.