### PR TITLE
fix: align brace handling in arithmetic with bash

### DIFF
--- a/tests/parable/character-fuzzer/fuzz-dolbracket-incomplete-brace.tests
+++ b/tests/parable/character-fuzzer/fuzz-dolbracket-incomplete-brace.tests
@@ -1,0 +1,17 @@
+=== incomplete ${ inside $[...] should not error
+$[${]
+---
+(command (word "$[${]"))
+---
+
+=== complete ${foo} inside $[...] works
+$[${foo}]
+---
+(command (word "$[${foo}]"))
+---
+
+=== funsub ${ cmd; } inside $[...] works
+$[${ echo 1; }]
+---
+(command (word "$[${ echo 1; }]"))
+---


### PR DESCRIPTION
## Summary

- Align `_parse_matched_pair` with bash's `P_ARITH` behavior for `${` handling
- In arithmetic context (`$[...]`), only parse `${` as parameter expansion if followed by funsub char (space/tab/newline/pipe)
- Otherwise treat `$` as literal, allowing inputs like `$[${]` to be valid

## Details

Bash's `parse_matched_pair` (parse.y:4137-4145) has special handling when `P_ARITH` flag is set:

```c
else if ((flags & P_ARITH) && (tflags & LEX_WASDOL) && ch == '{')
    /* ${} inside $(( ))/$[ ] */
    {
      int npeek = shell_getc(1);
      shell_ungetc(npeek);
      if (FUNSUB_CHAR(npeek))
        goto parse_dollar_word;
      // Otherwise: fall through, $ is literal
    }
```

Parable was always trying to parse `${` as parameter expansion, causing errors on incomplete forms.