### PR TITLE
fix: use sub-parser for arithmetic command substitution parsing

### DIFF
--- a/src/parable.js
+++ b/src/parable.js
@@ -9829,15 +9829,7 @@ class Parser {
 	}
 
 	_arithParseCmdsub() {
-		let ch,
-			cmd,
-			content,
-			content_start,
-			depth,
-			inner_expr,
-			saved_len,
-			saved_pos,
-			saved_src;
+		let ch, cmd, content, content_start, depth, inner_expr, sub_parser;
 		// We're positioned after $, at (
 		this._arithAdvance();
 		// Check for $(( which is nested arithmetic
@@ -9887,16 +9879,8 @@ class Parser {
 		content = this._arith_src.slice(content_start, this._arith_pos);
 		this._arithAdvance();
 		// Parse the command inside
-		saved_pos = this.pos;
-		saved_src = this.source;
-		saved_len = this.length;
-		this.source = content;
-		this.pos = 0;
-		this.length = content.length;
-		cmd = this.parseList();
-		this.source = saved_src;
-		this.pos = saved_pos;
-		this.length = saved_len;
+		sub_parser = new Parser(content, this._extglob);
+		cmd = sub_parser.parseList();
 		return new CommandSubstitution(cmd);
 	}
 
@@ -10036,7 +10020,7 @@ class Parser {
 	}
 
 	_arithParseBacktick() {
-		let c, cmd, content, content_start, saved_len, saved_pos, saved_src;
+		let c, cmd, content, content_start, sub_parser;
 		this._arithAdvance();
 		content_start = this._arith_pos;
 		while (!this._arithAtEnd() && this._arithPeek() !== "`") {
@@ -10056,16 +10040,8 @@ class Parser {
 			);
 		}
 		// Parse the command inside
-		saved_pos = this.pos;
-		saved_src = this.source;
-		saved_len = this.length;
-		this.source = content;
-		this.pos = 0;
-		this.length = content.length;
-		cmd = this.parseList();
-		this.source = saved_src;
-		this.pos = saved_pos;
-		this.length = saved_len;
+		sub_parser = new Parser(content, this._extglob);
+		cmd = sub_parser.parseList();
 		return new CommandSubstitution(cmd);
 	}
 

--- a/src/parable.py
+++ b/src/parable.py
@@ -8299,16 +8299,8 @@ class Parser:
         self._arith_advance()  # consume )
 
         # Parse the command inside
-        saved_pos = self.pos
-        saved_src = self.source
-        saved_len = self.length
-        self.source = content
-        self.pos = 0
-        self.length = len(content)
-        cmd = self.parse_list()
-        self.source = saved_src
-        self.pos = saved_pos
-        self.length = saved_len
+        sub_parser = Parser(content, extglob=self._extglob)
+        cmd = sub_parser.parse_list()
 
         return CommandSubstitution(cmd)
 
@@ -8433,16 +8425,8 @@ class Parser:
         if not self._arith_consume("`"):
             raise ParseError("Unterminated backtick in arithmetic", pos=self._arith_pos)
         # Parse the command inside
-        saved_pos = self.pos
-        saved_src = self.source
-        saved_len = self.length
-        self.source = content
-        self.pos = 0
-        self.length = len(content)
-        cmd = self.parse_list()
-        self.source = saved_src
-        self.pos = saved_pos
-        self.length = saved_len
+        sub_parser = Parser(content, extglob=self._extglob)
+        cmd = sub_parser.parse_list()
         return CommandSubstitution(cmd)
 
     def _arith_parse_number_or_var(self) -> Node:

--- a/tests/test_arith_cmdsub.py
+++ b/tests/test_arith_cmdsub.py
@@ -7,6 +7,7 @@ original source, causing CommandSubstitution.command to be None.
 """
 
 import sys
+
 sys.path.insert(0, "src")
 
 from parable import parse


### PR DESCRIPTION
## Summary

- Replace swap-and-restore pattern with sub-parser in `_arith_parse_cmdsub()` and `_arith_parse_backtick()`
- After the Lexer refactor, these methods incorrectly swapped `self.source/pos/length` but `parse_list()` still used `self._lexer` pointing to the original source
- This caused `CommandSubstitution.command` to be `None` for arithmetic commands and wrong source parsing for arithmetic expansions

Fixes #358