### PR TITLE
fix: resolve fuzzer output paths relative to invocation directory

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ test-all: test-cpy test-pypy
 
 # Run the fuzzer (e.g., just fuzz char --stop-after 10)
 fuzz *ARGS:
-    uv run --directory tools/fuzzer fuzzer {{ARGS}}
+    FUZZER_ORIG_CWD="{{invocation_directory()}}" uv run --directory tools/fuzzer fuzzer {{ARGS}}
 
 # Run the fuzzer agent
 fuzzer-agent *ARGS:

--- a/tools/fuzzer/src/fuzzer/__init__.py
+++ b/tools/fuzzer/src/fuzzer/__init__.py
@@ -1,6 +1,7 @@
 """Parable fuzzers for differential testing against bash-oracle."""
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -160,6 +161,12 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Resolve output path relative to original cwd (before uv run --directory changed it)
+    if hasattr(args, "output") and args.output and not args.output.is_absolute():
+        orig_cwd = os.environ.get("FUZZER_ORIG_CWD")
+        if orig_cwd:
+            args.output = Path(orig_cwd) / args.output
 
     # Route to appropriate module
     if args.mode in ("character", "char"):


### PR DESCRIPTION
## Summary
- Pass original cwd via `FUZZER_ORIG_CWD` env var from justfile
- Resolve relative output paths against original cwd in fuzzer entry point
- Fixes `-o bugs.tests` writing to `tools/fuzzer/bugs.tests` instead of pwd