### PR TITLE
docs: update line counts and add verify-counts skill

### DIFF
--- a/.claude/skills/verify-counts/SKILL.md
+++ b/.claude/skills/verify-counts/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: verify-counts
+description: Verify numerical claims in documentation are still accurate
+---
+
+Verify all count assertions in documentation against actual values.
+
+## Claims to Verify
+
+| Location | Claim | Verification |
+|----------|-------|--------------|
+| `README.md:17` | 11,000-line parser | Line count of parser source |
+| `README.md:103` | 1,800+ hand-written tests | tests/parable/ test count |
+
+## Verification Commands
+
+**Parser line count:**
+```bash
+wc -l src/parable.py
+```
+
+**Hand-written test count:**
+```bash
+rg -c '^=== ' tests/parable/ | awk -F: '{sum += $2} END {print sum}'
+```
+
+## Output
+
+Report each claim with:
+- Documented value
+- Actual value
+- Status (PASS/FAIL/STALE)
+
+### Status Criteria
+
+- **PASS**: Actual value is within ~10% of documented value
+- **STALE**: Claim is technically true but significantly outdated (e.g., "1,500" when actual is 1,849)
+- **FAIL**: Claim is false
+
+If any claim is STALE or FAIL, note which file(s) need updating.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ node_modules/
 .ruff_cache/
 .pyperf/
 .DS_Store
-.claude/
+.claude/*
+!.claude/skills/
 dippy.toml
 tools/bash-oracle/bash-oracle
 tools/bash-oracle/bin/failures.txt

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Parse bash exactly as bash does. Python or Javascript, your choice. One file, ze
 
 ## Philosophy
 
-**LLM-driven development.** This project is an exercise in maximizing what LLMs can do. A 10,900-line recursive descent parser for one of the gnarliest grammars in computing, built and maintained almost entirely through AI assistance—it wouldn't exist without them. When performance and clarity conflict, clarity wins. Verbose beats clever. The code should be readable by both humans and models.
+**LLM-driven development.** This project is an exercise in maximizing what LLMs can do. An 11,000-line recursive descent parser for one of the gnarliest grammars in computing, built and maintained almost entirely through AI assistance—it wouldn't exist without them. When performance and clarity conflict, clarity wins. Verbose beats clever. The code should be readable by both humans and models.
 
 **Match bash exactly.** Bash is the oracle. We [patched](https://github.com/ldayton/bash-oracle) GNU Bash 5.3 so it reveals its internal parse tree, then test against it. No spec interpretation, no "close enough"—if bash parses it one way, so do we. Bash always tells the truth, even when it's lying.
 
@@ -22,7 +22,7 @@ Parse bash exactly as bash does. Python or Javascript, your choice. One file, ze
 
 ## Javascript + Typescript
 
-The Python implementation uses idiomatic Python that transpiles naturally to idiomatic JavaScript: f-strings become template literals, ternaries stay ternaries, lambdas become arrow functions. A custom transpiler produces perfectly readable JS: not minified, not obfuscated, not transmogrified, but clean code that looks like a human wrote it.
+The Python implementation uses idiomatic Python that transpiles naturally to idiomatic Javascript: f-strings become template literals, ternaries stay ternaries, lambdas become arrow functions. A custom transpiler produces perfectly readable JS: not minified, not obfuscated, not transmogrified, but clean code that looks like a human wrote it.
 
 The Javascript output is then validated the same way as Python. Same tests, same bash AST comparisons, same edge cases. If Python parses it correctly, so does JS. Typescript definitions are auto-generated from the transpiled JS.
 
@@ -100,7 +100,7 @@ Every test validated against real bash 5.3 ASTs.
 - **GNU Bash test corpus:** 19,370 lines
 - **Oils bash corpus:** 2,495 tests
 - **tree-sitter-bash corpus:** 125 tests
-- **Parable hand-written tests:** 1,849 tests
+- **Parable hand-written tests:** 1,800+ tests
 
 ## Usage
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,15 +18,6 @@ just test -f heredoc          # Filter by name
 just test tests/parable/pipes.tests   # Run specific file
 ```
 
-## Coverage
-
-| Corpus                  | Tests        |
-| ----------------------- | ------------ |
-| GNU Bash test corpus    | 19,370 lines |
-| Oils bash corpus        | 2,495 tests  |
-| tree-sitter-bash corpus | 125 tests    |
-| Parable hand-written    | 1,542 tests  |
-
 ## Test Format
 
 Tests use a simple format:


### PR DESCRIPTION
## Summary
- Update parser line count to 11,000 (was 10,900)
- Update hand-written tests count to 1,800+ (was 1,849)
- Remove duplicate coverage table from tests/README.md
- Add `/verify-counts` skill to check documentation claims stay accurate
- Allow `.claude/skills/` to be committed (excluded from .gitignore)