### PR TITLE
transpiler: emit Truthy IR nodes instead of explicit comparisons

### DIFF
--- a/dist/go/parable.go
+++ b/dist/go/parable.go
@@ -709,7 +709,7 @@ func (self *Lexer) isWordTerminator(ctx int, ch string, bracketDepth int, parenD
 		}
 		return isWhitespace(ch)
 	}
-	if (self.parserState&ParserStateFlagsPSTEOFTOKEN) != 0 && self.eofToken != "" && ch == self.eofToken && bracketDepth == 0 {
+	if ((self.parserState & ParserStateFlagsPSTEOFTOKEN) != 0) && self.eofToken != "" && ch == self.eofToken && bracketDepth == 0 {
 		return true
 	}
 	if isRedirectChar(ch) && self.Pos+1 < self.Length && _runeAt(self.Source, self.Pos+1) == "(" {
@@ -837,7 +837,7 @@ func (self *Lexer) parseMatchedPair(openChar string, closeChar string, flags int
 			panic(NewMatchedPairError(fmt.Sprintf("unexpected EOF while looking for matching `%v'", closeChar), start, 0))
 		}
 		ch := self.Advance()
-		if (flags&MatchedPairFlagsDOLBRACE) != 0 && self.dolbraceState == DolbraceStateOP {
+		if ((flags & MatchedPairFlagsDOLBRACE) != 0) && self.dolbraceState == DolbraceStateOP {
 			if !strings.Contains("#%^,~:-=?+/", ch) {
 				self.dolbraceState = DolbraceStateWORD
 			}
@@ -856,7 +856,7 @@ func (self *Lexer) parseMatchedPair(openChar string, closeChar string, flags int
 					break
 				}
 			}
-			if ch == "\\" && (flags&MatchedPairFlagsALLOWESC) != 0 {
+			if ch == "\\" && ((flags & MatchedPairFlagsALLOWESC) != 0) {
 				passNext = true
 			}
 			chars = append(chars, ch)
@@ -888,7 +888,7 @@ func (self *Lexer) parseMatchedPair(openChar string, closeChar string, flags int
 			continue
 		}
 		if ch == openChar && openChar != closeChar {
-			if !((flags&MatchedPairFlagsDOLBRACE) != 0 && openChar == "{") {
+			if !(((flags & MatchedPairFlagsDOLBRACE) != 0) && openChar == "{") {
 				count++
 			}
 			chars = append(chars, ch)
@@ -931,7 +931,7 @@ func (self *Lexer) parseMatchedPair(openChar string, closeChar string, flags int
 				continue
 			}
 		}
-		if ch == "$" && !self.AtEnd() && (flags&MatchedPairFlagsEXTGLOB) == 0 {
+		if ch == "$" && !self.AtEnd() && !((flags & MatchedPairFlagsEXTGLOB) != 0) {
 			nextCh := self.Peek()
 			if wasDollar {
 				chars = append(chars, ch)
@@ -1023,7 +1023,7 @@ func (self *Lexer) parseMatchedPair(openChar string, closeChar string, flags int
 				continue
 			}
 		}
-		if ch == "(" && wasGtlt && (flags&(MatchedPairFlagsDOLBRACE|MatchedPairFlagsARRAYSUB)) != 0 {
+		if ch == "(" && wasGtlt && ((flags & (MatchedPairFlagsDOLBRACE | MatchedPairFlagsARRAYSUB)) != 0) {
 			direction := chars[len(chars)-1]
 			chars = chars[:len(chars)-1]
 			self.Pos--
@@ -1079,7 +1079,7 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 				chars = append(chars, self.Advance())
 				continue
 			}
-			if len(chars) > 0 && atCommandStart && !seenEquals && isArrayAssignmentPrefix(chars) {
+			if (len(chars) > 0) && atCommandStart && !seenEquals && isArrayAssignmentPrefix(chars) {
 				prevChar := chars[len(chars)-1]
 				if _strIsAlnum(prevChar) || prevChar == "_" {
 					bracketStartPos = self.Pos
@@ -1088,7 +1088,7 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 					continue
 				}
 			}
-			if len(chars) == 0 && !seenEquals && inArrayLiteral {
+			if !(len(chars) > 0) && !seenEquals && inArrayLiteral {
 				bracketStartPos = self.Pos
 				bracketDepth++
 				chars = append(chars, self.Advance())
@@ -1126,7 +1126,7 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 		}
 		var content string
 		if ctx == WORDCTXCOND && ch == "(" {
-			if self.extglob && len(chars) > 0 && isExtglobPrefix(chars[len(chars)-1]) {
+			if self.extglob && (len(chars) > 0) && isExtglobPrefix(chars[len(chars)-1]) {
 				chars = append(chars, self.Advance())
 				content = self.parseMatchedPair("(", ")", MatchedPairFlagsEXTGLOB, false)
 				chars = append(chars, content)
@@ -1248,7 +1248,7 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 				chars = append(chars, self.Advance())
 			} else {
 				self.syncFromParser()
-				if self.extglob && ctx == WORDCTXNORMAL && len(chars) > 0 && _runeLen(chars[len(chars)-1]) == 2 && _runeAt(chars[len(chars)-1], 0) == "$" && strings.Contains("?*@", _runeAt(chars[len(chars)-1], 1)) && !self.AtEnd() && self.Peek() == "(" {
+				if self.extglob && ctx == WORDCTXNORMAL && (len(chars) > 0) && _runeLen(chars[len(chars)-1]) == 2 && _runeAt(chars[len(chars)-1], 0) == "$" && strings.Contains("?*@", _runeAt(chars[len(chars)-1], 1)) && !self.AtEnd() && self.Peek() == "(" {
 					chars = append(chars, self.Advance())
 					content = self.parseMatchedPair("(", ")", MatchedPairFlagsEXTGLOB, false)
 					chars = append(chars, content)
@@ -1276,7 +1276,7 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 			if !_isNilInterfaceRef(procsubResult0) {
 				parts = append(parts, procsubResult0)
 				chars = append(chars, procsubResult1)
-			} else if procsubResult1 != "" {
+			} else if len(procsubResult1) > 0 {
 				chars = append(chars, procsubResult1)
 			} else {
 				chars = append(chars, self.Advance())
@@ -1286,7 +1286,7 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 			}
 			continue
 		}
-		if ctx == WORDCTXNORMAL && ch == "(" && len(chars) > 0 && bracketDepth == 0 {
+		if ctx == WORDCTXNORMAL && ch == "(" && (len(chars) > 0) && bracketDepth == 0 {
 			isArrayAssign := false
 			if len(chars) >= 3 && chars[len(chars)-2] == "+" && chars[len(chars)-1] == "=" {
 				isArrayAssign = isArrayAssignmentPrefix(chars[:len(chars)-2])
@@ -1314,8 +1314,8 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 			chars = append(chars, ")")
 			continue
 		}
-		if ctx == WORDCTXNORMAL && (self.parserState&ParserStateFlagsPSTEOFTOKEN) != 0 && self.eofToken != "" && ch == self.eofToken && bracketDepth == 0 {
-			if len(chars) == 0 {
+		if ctx == WORDCTXNORMAL && ((self.parserState & ParserStateFlagsPSTEOFTOKEN) != 0) && self.eofToken != "" && ch == self.eofToken && bracketDepth == 0 {
+			if !(len(chars) > 0) {
 				chars = append(chars, self.Advance())
 			}
 			break
@@ -1328,7 +1328,7 @@ func (self *Lexer) readWordInternal(ctx int, atCommandStart bool, inArrayLiteral
 	if bracketDepth > 0 && bracketStartPos != -1 && self.AtEnd() {
 		panic(NewMatchedPairError("unexpected EOF looking for `]'", bracketStartPos, 0))
 	}
-	if len(chars) == 0 {
+	if !(len(chars) > 0) {
 		return nil
 	}
 	if len(parts) > 0 {
@@ -1372,7 +1372,7 @@ func (self *Lexer) NextToken() *Token {
 		self.lastReadToken = tok
 		return tok
 	}
-	if self.eofToken != "" && self.Peek() == self.eofToken && (self.parserState&ParserStateFlagsPSTCASEPAT) == 0 && (self.parserState&ParserStateFlagsPSTEOFTOKEN) == 0 {
+	if self.eofToken != "" && self.Peek() == self.eofToken && !((self.parserState & ParserStateFlagsPSTCASEPAT) != 0) && !((self.parserState & ParserStateFlagsPSTEOFTOKEN) != 0) {
 		tok = &Token{Type: TokenTypeEOF, Value: "", Pos: self.Pos}
 		self.lastReadToken = tok
 		return tok
@@ -1384,7 +1384,7 @@ func (self *Lexer) NextToken() *Token {
 			self.lastReadToken = tok
 			return tok
 		}
-		if self.eofToken != "" && self.Peek() == self.eofToken && (self.parserState&ParserStateFlagsPSTCASEPAT) == 0 && (self.parserState&ParserStateFlagsPSTEOFTOKEN) == 0 {
+		if self.eofToken != "" && self.Peek() == self.eofToken && !((self.parserState & ParserStateFlagsPSTCASEPAT) != 0) && !((self.parserState & ParserStateFlagsPSTEOFTOKEN) != 0) {
 			tok = &Token{Type: TokenTypeEOF, Value: "", Pos: self.Pos}
 			self.lastReadToken = tok
 			return tok
@@ -1810,7 +1810,7 @@ func (self *Lexer) readBracedParam(start int, inDquote bool) (Node, string) {
 	if ch == "#" {
 		self.Advance()
 		param = self.consumeParamName()
-		if param != "" && !self.AtEnd() && self.Peek() == "}" {
+		if (len(param) > 0) && !self.AtEnd() && self.Peek() == "}" {
 			self.Advance()
 			text = substring(self.Source, start, self.Pos)
 			self.dolbraceState = savedDolbrace
@@ -1826,7 +1826,7 @@ func (self *Lexer) readBracedParam(start int, inDquote bool) (Node, string) {
 			self.Advance()
 		}
 		param = self.consumeParamName()
-		if param != "" {
+		if len(param) > 0 {
 			for !self.AtEnd() && isWhitespaceNoNewline(self.Peek()) {
 				self.Advance()
 			}
@@ -1863,7 +1863,7 @@ func (self *Lexer) readBracedParam(start int, inDquote bool) (Node, string) {
 		}
 	}
 	param = self.consumeParamName()
-	if param == "" {
+	if !(len(param) > 0) {
 		if !self.AtEnd() && (strings.Contains("-=+?", self.Peek()) || self.Peek() == ":" && self.Pos+1 < self.Length && isSimpleParamOp(_runeAt(self.Source, self.Pos+1))) {
 			param = ""
 		} else {
@@ -2094,7 +2094,7 @@ func (self *Word) normalizeParamExpansionNewlines(value string) string {
 }
 
 func (self *Word) shSingleQuote(s string) string {
-	if s == "" {
+	if !(len(s) > 0) {
 		return "''"
 	}
 	if s == "'" {
@@ -2135,7 +2135,7 @@ func (self *Word) ansiCToBytes(inner string) []byte {
 					if j < _runeLen(inner) && _runeAt(inner, j) == "}" {
 						j++
 					}
-					if hexStr == "" {
+					if !(len(hexStr) > 0) {
 						return result
 					}
 					byteVal := (_parseInt(hexStr, 16) & 255)
@@ -2339,7 +2339,7 @@ func (self *Word) expandAllAnsiCQuotes(value string) string {
 					if lastBraceIdx >= 0 {
 						afterBrace := _Substring(resultStr, lastBraceIdx+2, _runeLen(resultStr))
 						varNameLen := 0
-						if afterBrace != "" {
+						if len(afterBrace) > 0 {
 							if strings.Contains("@*#?-$!0123456789_", _runeAt(afterBrace, 0)) {
 								varNameLen = 1
 							} else if _strIsAlpha(_runeAt(afterBrace, 0)) || _runeAt(afterBrace, 0) == "_" {
@@ -2363,7 +2363,7 @@ func (self *Word) expandAllAnsiCQuotes(value string) string {
 									break
 								}
 							}
-							if !inPattern && opStart != "" && !strings.Contains("%#/^,~:+-=?", _runeAt(opStart, 0)) {
+							if !inPattern && (len(opStart) > 0) && !strings.Contains("%#/^,~:+-=?", _runeAt(opStart, 0)) {
 								for _, op := range []string{"//", "%%", "##", "/", "%", "#", "^", "^^", ",", ",,"} {
 									if strings.Contains(opStart, op) {
 										inPattern = true
@@ -2579,7 +2579,7 @@ func (self *Word) normalizeArrayInner(inner string) string {
 	for i < _runeLen(inner) {
 		ch := _runeAt(inner, i)
 		if isWhitespace(ch) {
-			if !inWhitespace && len(normalized) > 0 && braceDepth == 0 && bracketDepth == 0 {
+			if !inWhitespace && (len(normalized) > 0) && braceDepth == 0 && bracketDepth == 0 {
 				normalized = append(normalized, " ")
 				inWhitespace = true
 			}
@@ -2951,7 +2951,7 @@ func (self *Word) formatCommandSubstitutions(value string, inArith bool) string 
 		}
 	}
 	hasParamWithProcsubPattern := strings.Contains(value, "${") && (strings.Contains(value, "<(") || strings.Contains(value, ">("))
-	if len(cmdsubParts) == 0 && len(procsubParts) == 0 && !hasBraceCmdsub && !hasUntrackedCmdsub && !hasUntrackedProcsub && !hasParamWithProcsubPattern {
+	if !(len(cmdsubParts) > 0) && !(len(procsubParts) > 0) && !hasBraceCmdsub && !hasUntrackedCmdsub && !hasUntrackedProcsub && !hasParamWithProcsubPattern {
 		return value
 	}
 	result := []string{}
@@ -3108,7 +3108,7 @@ func (self *Word) formatCommandSubstitutions(value string, inArith bool) string 
 				origInner := substring(value, i+2, j-1)
 				endsWithNewline := strings.HasSuffix(origInner, "\n")
 				var suffix string
-				if formatted == "" || _strIsSpace(formatted) {
+				if !(len(formatted) > 0) || _strIsSpace(formatted) {
 					suffix = "}"
 				} else if strings.HasSuffix(formatted, "&") || strings.HasSuffix(formatted, "& ") {
 					suffix = func() string {
@@ -3158,7 +3158,7 @@ func (self *Word) formatCommandSubstitutions(value string, inArith bool) string 
 					leadingWs := _Substring(rawContent, 0, leadingWsEnd)
 					stripped = _Substring(rawContent, leadingWsEnd, _runeLen(rawContent))
 					if strings.HasPrefix(stripped, "(") {
-						if leadingWs != "" {
+						if len(leadingWs) > 0 {
 							normalizedWs := strings.ReplaceAll(strings.ReplaceAll(leadingWs, "\n", " "), "\t", " ")
 							spaced := formatCmdsubNode(node.(*ProcessSubstitution).Command, 0, false, false, false)
 							result = append(result, direction+"("+normalizedWs+spaced+")")
@@ -3181,7 +3181,7 @@ func (self *Word) formatCommandSubstitutions(value string, inArith bool) string 
 				}
 				procsubIdx++
 				i = j
-			} else if isProcsub && len(self.Parts) != 0 {
+			} else if isProcsub && (len(self.Parts) != 0) {
 				direction = _runeAt(value, i)
 				j = findCmdsubEnd(value, i+2)
 				if j > _runeLen(value) || j > 0 && j <= _runeLen(value) && _runeAt(value, j-1) != ")" {
@@ -3218,7 +3218,7 @@ func (self *Word) formatCommandSubstitutions(value string, inArith bool) string 
 				inner = substring(value, i+2, j-1)
 				if inArith {
 					result = append(result, direction+"("+inner+")")
-				} else if strings.TrimSpace(inner) != "" {
+				} else if len(strings.TrimSpace(inner)) > 0 {
 					stripped = strings.TrimLeft(inner, " \t")
 					result = append(result, direction+"("+stripped+")")
 				} else {
@@ -3451,7 +3451,7 @@ func (self *Command) ToSexp() string {
 		parts = append(parts, r.ToSexp())
 	}
 	inner := strings.Join(parts, " ")
-	if inner == "" {
+	if !(len(inner) > 0) {
 		return "(command)"
 	}
 	return "(command " + inner + ")"
@@ -3596,16 +3596,16 @@ func (self *List) toSexpWithPrecedence(parts []Node, opNames map[string]string) 
 		var seg []Node
 		for _, pos := range semiPositions {
 			seg = parts[start:pos]
-			if len(seg) > 0 && seg[0].GetKind() != "operator" {
+			if (len(seg) > 0) && seg[0].GetKind() != "operator" {
 				segments = append(segments, seg)
 			}
 			start = pos + 1
 		}
 		seg = parts[start:len(parts)]
-		if len(seg) > 0 && seg[0].GetKind() != "operator" {
+		if (len(seg) > 0) && seg[0].GetKind() != "operator" {
 			segments = append(segments, seg)
 		}
-		if len(segments) == 0 {
+		if !(len(segments) > 0) {
 			return "()"
 		}
 		result := self.toSexpAmpAndHigher(segments[0], opNames)
@@ -3949,21 +3949,21 @@ func (self *ForArith) ToSexp() string {
 		suffix = " " + strings.Join(redirectParts, " ")
 	}
 	initVal := func() string {
-		if self.Init != "" {
+		if len(self.Init) > 0 {
 			return self.Init
 		} else {
 			return "1"
 		}
 	}()
 	condVal := func() string {
-		if self.Cond != "" {
+		if len(self.Cond) > 0 {
 			return self.Cond
 		} else {
 			return "1"
 		}
 	}()
 	incrVal := func() string {
-		if self.Incr != "" {
+		if len(self.Incr) > 0 {
 			return self.Incr
 		} else {
 			return "1"
@@ -4609,7 +4609,7 @@ type Array struct {
 func (self *Array) GetKind() string { return self.Kind }
 
 func (self *Array) ToSexp() string {
-	if len(self.Elements) == 0 {
+	if !(len(self.Elements) > 0) {
 		return "(array)"
 	}
 	parts := []string{}
@@ -4630,7 +4630,7 @@ func (self *Coproc) GetKind() string { return self.Kind }
 
 func (self *Coproc) ToSexp() string {
 	var name string
-	if self.Name != "" {
+	if len(self.Name) > 0 {
 		name = self.Name
 	} else {
 		name = "COPROC"
@@ -5475,7 +5475,7 @@ func (self *Parser) parseBacktickSubstitution() (Node, string) {
 				}
 			}
 			delimiter := strings.Join(delimiterChars, "")
-			if delimiter != "" {
+			if len(delimiter) > 0 {
 				pendingHeredocs = append(pendingHeredocs, struct {
 					F0 string
 					F1 bool
@@ -6181,14 +6181,14 @@ func (self *Parser) arithParseExpansion() Node {
 		ch := self.arithPeek(0)
 		if _strIsAlnum(ch) || ch == "_" {
 			nameChars = append(nameChars, self.arithAdvance())
-		} else if (isSpecialParamOrDigit(ch) || ch == "#") && len(nameChars) == 0 {
+		} else if (isSpecialParamOrDigit(ch) || ch == "#") && !(len(nameChars) > 0) {
 			nameChars = append(nameChars, self.arithAdvance())
 			break
 		} else {
 			break
 		}
 	}
-	if len(nameChars) == 0 {
+	if !(len(nameChars) > 0) {
 		panic(NewParseError("Expected variable name after $", self.arithPos, 0))
 	}
 	return &ParamExpansion{Param: strings.Join(nameChars, ""), Kind: "param"}
@@ -6485,14 +6485,14 @@ func (self *Parser) ParseRedirect() Node {
 		}
 		varname := strings.Join(varnameChars, "")
 		isValidVarfd := false
-		if varname != "" {
+		if len(varname) > 0 {
 			if _strIsAlpha(_runeAt(varname, 0)) || _runeAt(varname, 0) == "_" {
 				if strings.Contains(varname, "[") || strings.Contains(varname, "]") {
 					left := strings.Index(varname, "[")
 					right := strings.LastIndex(varname, "]")
 					if left != -1 && right == _runeLen(varname)-1 && right > left+1 {
 						base := _Substring(varname, 0, left)
-						if base != "" && (_strIsAlpha(_runeAt(base, 0)) || _runeAt(base, 0) == "_") {
+						if (len(base) > 0) && (_strIsAlpha(_runeAt(base, 0)) || _runeAt(base, 0) == "_") {
 							isValidVarfd = true
 							for _, c := range _Substring(base, 1, _runeLen(base)) {
 								if !(_strIsAlnum(string(c)) || c == '_') {
@@ -6521,7 +6521,7 @@ func (self *Parser) ParseRedirect() Node {
 		}
 	}
 	var fdChars []string
-	if varfd == "" && self.Peek() != "" && _strIsDigit(self.Peek()) {
+	if varfd == "" && (len(self.Peek()) > 0) && _strIsDigit(self.Peek()) {
 		fdChars = []string{}
 		for !self.AtEnd() && _strIsDigit(self.Peek()) {
 			fdChars = append(fdChars, self.Advance())
@@ -7011,13 +7011,13 @@ func (self *Parser) ParseCommand() *Command {
 			}
 		}
 		inAssignBuiltin := len(words) > 0 && _mapHas(ASSIGNMENTBUILTINS, words[0].Value)
-		word := self.ParseWord(len(words) == 0 || allAssignments && len(redirects) == 0, false, inAssignBuiltin)
+		word := self.ParseWord(!(len(words) > 0) || allAssignments && len(redirects) == 0, false, inAssignBuiltin)
 		if word == nil {
 			break
 		}
 		words = append(words, word)
 	}
-	if len(words) == 0 && len(redirects) == 0 {
+	if !(len(words) > 0) && !(len(redirects) > 0) {
 		return nil
 	}
 	return &Command{Words: words, Redirects: redirects, Kind: "command"}
@@ -7798,7 +7798,7 @@ func (self *Parser) ParseCase() *Case {
 			}
 		}
 		pattern := strings.Join(patternChars, "")
-		if pattern == "" {
+		if !(len(pattern) > 0) {
 			panic(NewParseError("Expected pattern in case statement", self.lexPeekToken().Pos, 0))
 		}
 		self.SkipWhitespace()
@@ -7867,7 +7867,7 @@ func (self *Parser) ParseCoproc() *Coproc {
 	}
 	wordStart := self.Pos
 	potentialName := self.PeekWord()
-	if potentialName != "" {
+	if len(potentialName) > 0 {
 		for !self.AtEnd() && !isMetachar(self.Peek()) && !isQuote(self.Peek()) {
 			self.Advance()
 		}
@@ -7955,7 +7955,7 @@ func (self *Parser) ParseFunction() *Function {
 		self.Advance()
 	}
 	name = substring(self.Source, nameStart, self.Pos)
-	if name == "" {
+	if !(len(name) > 0) {
 		self.Pos = savedPos
 		return nil
 	}
@@ -7979,7 +7979,7 @@ func (self *Parser) ParseFunction() *Function {
 	posAfterName := self.Pos
 	self.SkipWhitespace()
 	hasWhitespace := self.Pos > posAfterName
-	if !hasWhitespace && name != "" && strings.Contains("*?@+!$", _runeAt(name, _runeLen(name)-1)) {
+	if !hasWhitespace && (len(name) > 0) && strings.Contains("*?@+!$", _runeAt(name, _runeLen(name)-1)) {
 		self.Pos = savedPos
 		return nil
 	}
@@ -8479,7 +8479,7 @@ func (self *Parser) ParseComment() Node {
 
 func (self *Parser) Parse() []Node {
 	source := strings.TrimSpace(self.Source)
-	if source == "" {
+	if !(len(source) > 0) {
 		return []Node{&Empty{Kind: "empty"}}
 	}
 	results := []Node{}
@@ -8517,10 +8517,10 @@ func (self *Parser) Parse() []Node {
 			panic(NewParseError("Syntax error", self.Pos, 0))
 		}
 	}
-	if len(results) == 0 {
+	if !(len(results) > 0) {
 		return []Node{&Empty{Kind: "empty"}}
 	}
-	if self.sawNewlineInSingleQuote && self.Source != "" && _runeAt(self.Source, _runeLen(self.Source)-1) == "\\" && !(_runeLen(self.Source) >= 3 && _Substring(self.Source, _runeLen(self.Source)-3, _runeLen(self.Source)-1) == "\\\n") {
+	if self.sawNewlineInSingleQuote && (len(self.Source) > 0) && _runeAt(self.Source, _runeLen(self.Source)-1) == "\\" && !(_runeLen(self.Source) >= 3 && _Substring(self.Source, _runeLen(self.Source)-3, _runeLen(self.Source)-1) == "\\\n") {
 		if !self.lastWordOnOwnLine(results) {
 			self.stripTrailingBackslashFromLastWord(results)
 		}
@@ -8533,14 +8533,14 @@ func (self *Parser) lastWordOnOwnLine(nodes []Node) bool {
 }
 
 func (self *Parser) stripTrailingBackslashFromLastWord(nodes []Node) {
-	if len(nodes) == 0 {
+	if !(len(nodes) > 0) {
 		return
 	}
 	lastNode := nodes[len(nodes)-1]
 	lastWord := self.findLastWord(lastNode)
 	if lastWord != nil && strings.HasSuffix(lastWord.Value, "\\") {
 		lastWord.Value = substring(lastWord.Value, 0, _runeLen(lastWord.Value)-1)
-		if lastWord.Value == "" && func() bool { _, ok := lastNode.(*Command); return ok }() && len(lastNode.(*Command).Words) > 0 {
+		if !(len(lastWord.Value) > 0) && func() bool { _, ok := lastNode.(*Command); return ok }() && (len(lastNode.(*Command).Words) > 0) {
 			lastNode.(*Command).Words = lastNode.(*Command).Words[:len(lastNode.(*Command).Words)-1]
 		}
 	}
@@ -8883,7 +8883,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 			parts = append(parts, formatRedirect(r, compactRedirects, true))
 		}
 		var result string
-		if compactRedirects && len(node.Words) > 0 && len(node.Redirects) > 0 {
+		if compactRedirects && (len(node.Words) > 0) && (len(node.Redirects) > 0) {
 			wordParts := parts[:len(node.Words)]
 			var redirectParts []string = parts[len(node.Words):]
 			result = strings.Join(wordParts, " ") + strings.Join(redirectParts, "")
@@ -8935,7 +8935,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 			formatted := formatCmdsubNode(cmd, indent, inProcsub, false, procsubFirst && idx == 0)
 			isLast := idx == len(cmds)-1
 			hasHeredoc := false
-			if cmd.GetKind() == "command" && len(cmd.(*Command).Redirects) > 0 {
+			if cmd.GetKind() == "command" && (len(cmd.(*Command).Redirects) > 0) {
 				for _, r := range cmd.(*Command).Redirects {
 					switch r.(type) {
 					case *HereDoc:
@@ -8968,7 +8968,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 			}
 			idx++
 		}
-		compactPipe := inProcsub && len(cmds) > 0 && cmds[0].F0.GetKind() == "subshell"
+		compactPipe := inProcsub && (len(cmds) > 0) && cmds[0].F0.GetKind() == "subshell"
 		result := ""
 		idx = 0
 		for idx < len(resultParts) {
@@ -8992,7 +8992,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 	case *List:
 		hasHeredoc := false
 		for _, p := range node.Parts {
-			if p.GetKind() == "command" && len(p.(*Command).Redirects) > 0 {
+			if p.GetKind() == "command" && (len(p.(*Command).Redirects) > 0) {
 				for _, r := range p.(*Command).Redirects {
 					switch r.(type) {
 					case *HereDoc:
@@ -9004,7 +9004,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 				switch p := p.(type) {
 				case *Pipeline:
 					for _, cmd := range p.Commands {
-						if cmd.GetKind() == "command" && len(cmd.(*Command).Redirects) > 0 {
+						if cmd.GetKind() == "command" && (len(cmd.(*Command).Redirects) > 0) {
 							for _, r := range cmd.(*Command).Redirects {
 								switch r.(type) {
 								case *HereDoc:
@@ -9027,7 +9027,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 			switch p := p.(type) {
 			case *Operator:
 				if p.Op == ";" {
-					if len(result) > 0 && strings.HasSuffix(result[len(result)-1], "\n") {
+					if (len(result) > 0) && strings.HasSuffix(result[len(result)-1], "\n") {
 						skippedSemi = true
 						continue
 					}
@@ -9038,11 +9038,11 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 					result = append(result, ";")
 					skippedSemi = false
 				} else if p.Op == "\n" {
-					if len(result) > 0 && result[len(result)-1] == ";" {
+					if (len(result) > 0) && result[len(result)-1] == ";" {
 						skippedSemi = false
 						continue
 					}
-					if len(result) > 0 && strings.HasSuffix(result[len(result)-1], "\n") {
+					if (len(result) > 0) && strings.HasSuffix(result[len(result)-1], "\n") {
 						result = append(result, func() string {
 							if skippedSemi {
 								return " "
@@ -9056,7 +9056,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 					result = append(result, "\n")
 					skippedSemi = false
 				} else if p.Op == "&" {
-					if len(result) > 0 && strings.Contains(result[len(result)-1], "<<") && strings.Contains(result[len(result)-1], "\n") {
+					if (len(result) > 0) && strings.Contains(result[len(result)-1], "<<") && strings.Contains(result[len(result)-1], "\n") {
 						last := result[len(result)-1]
 						if strings.Contains(last, " |") || strings.HasPrefix(last, "|") {
 							result[len(result)-1] = last + " &"
@@ -9067,7 +9067,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 					} else {
 						result = append(result, " &")
 					}
-				} else if len(result) > 0 && strings.Contains(result[len(result)-1], "<<") && strings.Contains(result[len(result)-1], "\n") {
+				} else if (len(result) > 0) && strings.Contains(result[len(result)-1], "<<") && strings.Contains(result[len(result)-1], "\n") {
 					last := result[len(result)-1]
 					firstNl := strings.Index(last, "\n")
 					result[len(result)-1] = _Substring(last, 0, firstNl) + " " + p.Op + " " + _Substring(last, firstNl, _runeLen(last))
@@ -9076,7 +9076,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 				}
 			default:
 				p = p.(Node)
-				if len(result) > 0 && !strings.HasSuffix(result[len(result)-1], " ") && !strings.HasSuffix(result[len(result)-1], "\n") {
+				if (len(result) > 0) && !strings.HasSuffix(result[len(result)-1], " ") && !strings.HasSuffix(result[len(result)-1], "\n") {
 					result = append(result, " ")
 				}
 				formattedCmd := formatCmdsubNode(p, indent, inProcsub, compactRedirects, procsubFirst && cmdCount == 0)
@@ -9155,7 +9155,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 				wordVals = append(wordVals, w.Value)
 			}
 			words := strings.Join(wordVals, " ")
-			if words != "" {
+			if len(words) > 0 {
 				result = "for " + var_ + " in " + words + ";\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done"
 			} else {
 				result = "for " + var_ + " in ;\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done"
@@ -9199,7 +9199,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 			patIndent := strings.Repeat(" ", indent+8)
 			termIndent := strings.Repeat(" ", indent+4)
 			bodyPart := func() string {
-				if body != "" {
+				if len(body) > 0 {
 					return patIndent + body + "\n"
 				} else {
 					return "\n"
@@ -9248,12 +9248,12 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 			redirects = strings.Join(redirectParts, " ")
 		}
 		if procsubFirst {
-			if redirects != "" {
+			if len(redirects) > 0 {
 				return "(" + body + ") " + redirects
 			}
 			return "(" + body + ")"
 		}
-		if redirects != "" {
+		if len(redirects) > 0 {
 			return "( " + body + " ) " + redirects
 		}
 		return "( " + body + " )"
@@ -9277,7 +9277,7 @@ func formatCmdsubNode(node Node, indent int, inProcsub bool, compactRedirects bo
 			}
 			redirects = strings.Join(redirectParts, " ")
 		}
-		if redirects != "" {
+		if len(redirects) > 0 {
 			return "{ " + body + terminator + " " + redirects
 		}
 		return "{ " + body + terminator
@@ -9902,7 +9902,7 @@ func findHeredocContentEnd(source string, start int, delimiters []struct {
 	F0 string
 	F1 bool
 }) (int, int) {
-	if len(delimiters) == 0 {
+	if !(len(delimiters) > 0) {
 		return start, start
 	}
 	pos := start
@@ -10174,7 +10174,7 @@ func skipMatchedPair(s string, start int, open string, close string, flags int) 
 			continue
 		}
 		literal := (flags & SMPLITERAL)
-		if (literal) == 0 && c == "\\" {
+		if !(literal != 0) && c == "\\" {
 			passNext = true
 			i++
 			continue
@@ -10186,28 +10186,28 @@ func skipMatchedPair(s string, start int, open string, close string, flags int) 
 			i++
 			continue
 		}
-		if (literal) == 0 && c == "`" {
+		if !(literal != 0) && c == "`" {
 			backq = true
 			i++
 			continue
 		}
-		if (literal) == 0 && c == "'" {
+		if !(literal != 0) && c == "'" {
 			i = skipSingleQuoted(s, i+1)
 			continue
 		}
-		if (literal) == 0 && c == "\"" {
+		if !(literal != 0) && c == "\"" {
 			i = skipDoubleQuoted(s, i+1)
 			continue
 		}
-		if (literal) == 0 && isExpansionStart(s, i, "$(") {
+		if !(literal != 0) && isExpansionStart(s, i, "$(") {
 			i = findCmdsubEnd(s, i+2)
 			continue
 		}
-		if (literal) == 0 && isExpansionStart(s, i, "${") {
+		if !(literal != 0) && isExpansionStart(s, i, "${") {
 			i = findBracedParamEnd(s, i+2)
 			continue
 		}
-		if (literal) == 0 && c == open {
+		if !(literal != 0) && c == open {
 			depth++
 		} else if c == close {
 			depth--
@@ -10225,7 +10225,7 @@ func skipSubscript(s string, start int, flags int) int {
 }
 
 func assignment(s string, flags int) int {
-	if s == "" {
+	if !(len(s) > 0) {
 		return -1
 	}
 	if !(_strIsAlpha(_runeAt(s, 0)) || _runeAt(s, 0) == "_") {
@@ -10273,7 +10273,7 @@ func assignment(s string, flags int) int {
 }
 
 func isArrayAssignmentPrefix(chars []string) bool {
-	if len(chars) == 0 {
+	if !(len(chars) > 0) {
 		return false
 	}
 	if !(_strIsAlpha(chars[0]) || chars[0] == "_") {
@@ -10366,7 +10366,7 @@ func looksLikeAssignment(s string) bool {
 }
 
 func isValidIdentifier(name string) bool {
-	if name == "" {
+	if !(len(name) > 0) {
 		return false
 	}
 	if !(_strIsAlpha(_runeAt(name, 0)) || _runeAt(name, 0) == "_") {

--- a/dist/java/Parable.java
+++ b/dist/java/Parable.java
@@ -181,7 +181,7 @@ class Token {
         if (this.word != null) {
             return String.format("Token(%s, %s, %s, word=%s)", this.type, this.value, this.pos, this.word);
         }
-        if (!this.parts.isEmpty()) {
+        if ((!this.parts.isEmpty())) {
             return String.format("Token(%s, %s, %s, parts=%s)", this.type, this.value, this.pos, this.parts.size());
         }
         return String.format("Token(%s, %s, %s)", this.type, this.value, this.pos);
@@ -235,7 +235,7 @@ class QuoteState {
     }
 
     public void pop() {
-        if (!this._stack.isEmpty()) {
+        if ((!this._stack.isEmpty())) {
             Tuple1 _entry1 = this._stack.remove(this._stack.size() - 1);
             this.single = _entry1.f0();
             this.double_ = _entry1.f1();
@@ -255,7 +255,7 @@ class QuoteState {
     }
 
     public boolean outerDouble() {
-        if (this._stack.isEmpty()) {
+        if (this._stack.size() == 0) {
             return false;
         }
         return this._stack.get(this._stack.size() - 1).f1();
@@ -614,7 +614,7 @@ class Lexer {
             }
             return ParableFunctions._isWhitespace(ch);
         }
-        if ((this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN) != 0 && !this._eofToken.equals("") && ch.equals(this._eofToken) && bracketDepth == 0) {
+        if ((((this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN)) != 0) && !this._eofToken.equals("") && ch.equals(this._eofToken) && bracketDepth == 0) {
             return true;
         }
         if (ParableFunctions._isRedirectChar(ch) && this.pos + 1 < this.length && this.source.charAt(this.pos + 1) == '(') {
@@ -748,7 +748,7 @@ class Lexer {
                 throw new RuntimeException(String.format("unexpected EOF while looking for matching `%s'", closeChar));
             }
             String ch = this.advance();
-            if ((flags & Constants.MATCHEDPAIRFLAGS_DOLBRACE) != 0 && this._dolbraceState == Constants.DOLBRACESTATE_OP) {
+            if ((((flags & Constants.MATCHEDPAIRFLAGS_DOLBRACE)) != 0) && this._dolbraceState == Constants.DOLBRACESTATE_OP) {
                 if ("#%^,~:-=?+/".indexOf(ch) == -1) {
                     this._dolbraceState = Constants.DOLBRACESTATE_WORD;
                 }
@@ -767,7 +767,7 @@ class Lexer {
                         break;
                     }
                 }
-                if (ch.equals("\\") && (flags & Constants.MATCHEDPAIRFLAGS_ALLOWESC) != 0) {
+                if (ch.equals("\\") && (((flags & Constants.MATCHEDPAIRFLAGS_ALLOWESC)) != 0)) {
                     passNext = true;
                 }
                 chars.add(ch);
@@ -799,7 +799,7 @@ class Lexer {
                 continue;
             }
             if (ch.equals(openChar) && !openChar.equals(closeChar)) {
-                if (!((flags & Constants.MATCHEDPAIRFLAGS_DOLBRACE) != 0 && openChar.equals("{"))) {
+                if (!((((flags & Constants.MATCHEDPAIRFLAGS_DOLBRACE)) != 0) && openChar.equals("{"))) {
                     count += 1;
                 }
                 chars.add(ch);
@@ -840,7 +840,7 @@ class Lexer {
                     }
                 }
             }
-            if (ch.equals("$") && !this.atEnd() && !((flags & Constants.MATCHEDPAIRFLAGS_EXTGLOB) != 0)) {
+            if (ch.equals("$") && !this.atEnd() && !(((flags & Constants.MATCHEDPAIRFLAGS_EXTGLOB)) != 0)) {
                 String nextCh = this.peek();
                 if (wasDollar) {
                     chars.add(ch);
@@ -849,7 +849,7 @@ class Lexer {
                     continue;
                 }
                 if (nextCh.equals("{")) {
-                    if ((flags & Constants.MATCHEDPAIRFLAGS_ARITH) != 0) {
+                    if ((((flags & Constants.MATCHEDPAIRFLAGS_ARITH)) != 0)) {
                         int afterBracePos = this.pos + 1;
                         if (afterBracePos >= this.length || !ParableFunctions._isFunsubChar(String.valueOf(this.source.charAt(afterBracePos)))) {
                             chars.add(ch);
@@ -948,7 +948,7 @@ class Lexer {
                     }
                 }
             }
-            if (ch.equals("(") && wasGtlt && (flags & (Constants.MATCHEDPAIRFLAGS_DOLBRACE | Constants.MATCHEDPAIRFLAGS_ARRAYSUB)) != 0) {
+            if (ch.equals("(") && wasGtlt && (((flags & (Constants.MATCHEDPAIRFLAGS_DOLBRACE | Constants.MATCHEDPAIRFLAGS_ARRAYSUB))) != 0)) {
                 String direction = chars.get(chars.size() - 1);
                 chars = new ArrayList<>(chars.subList(0, chars.size() - 1));
                 this.pos -= 1;
@@ -1006,7 +1006,7 @@ class Lexer {
                     chars.add(this.advance());
                     continue;
                 }
-                if (!chars.isEmpty() && atCommandStart && !seenEquals && ParableFunctions._isArrayAssignmentPrefix(chars)) {
+                if ((!chars.isEmpty()) && atCommandStart && !seenEquals && ParableFunctions._isArrayAssignmentPrefix(chars)) {
                     String prevChar = chars.get(chars.size() - 1);
                     if ((prevChar.length() > 0 && prevChar.chars().allMatch(Character::isLetterOrDigit)) || prevChar.equals("_")) {
                         bracketStartPos = this.pos;
@@ -1053,7 +1053,7 @@ class Lexer {
             }
             String content = "";
             if (ctx == Constants.WORD_CTX_COND && ch.equals("(")) {
-                if (this._extglob && !chars.isEmpty() && ParableFunctions._isExtglobPrefix(chars.get(chars.size() - 1))) {
+                if (this._extglob && (!chars.isEmpty()) && ParableFunctions._isExtglobPrefix(chars.get(chars.size() - 1))) {
                     chars.add(this.advance());
                     content = this._parseMatchedPair("(", ")", Constants.MATCHEDPAIRFLAGS_EXTGLOB, false);
                     chars.add(content);
@@ -1188,7 +1188,7 @@ class Lexer {
                     chars.add(this.advance());
                 } else {
                     this._syncFromParser();
-                    if (this._extglob && ctx == Constants.WORD_CTX_NORMAL && !chars.isEmpty() && chars.get(chars.size() - 1).length() == 2 && chars.get(chars.size() - 1).charAt(0) == '$' && "?*@".indexOf(String.valueOf(chars.get(chars.size() - 1).charAt(1))) != -1 && !this.atEnd() && this.peek().equals("(")) {
+                    if (this._extglob && ctx == Constants.WORD_CTX_NORMAL && (!chars.isEmpty()) && chars.get(chars.size() - 1).length() == 2 && chars.get(chars.size() - 1).charAt(0) == '$' && "?*@".indexOf(String.valueOf(chars.get(chars.size() - 1).charAt(1))) != -1 && !this.atEnd() && this.peek().equals("(")) {
                         chars.add(this.advance());
                         content = this._parseMatchedPair("(", ")", Constants.MATCHEDPAIRFLAGS_EXTGLOB, false);
                         chars.add(content);
@@ -1221,7 +1221,7 @@ class Lexer {
                     parts.add(procsubResult0);
                     chars.add(procsubResult1);
                 } else {
-                    if (!procsubResult1.equals("")) {
+                    if ((!procsubResult1.isEmpty())) {
                         chars.add(procsubResult1);
                     } else {
                         chars.add(this.advance());
@@ -1232,7 +1232,7 @@ class Lexer {
                 }
                 continue;
             }
-            if (ctx == Constants.WORD_CTX_NORMAL && ch.equals("(") && !chars.isEmpty() && bracketDepth == 0) {
+            if (ctx == Constants.WORD_CTX_NORMAL && ch.equals("(") && (!chars.isEmpty()) && bracketDepth == 0) {
                 boolean isArrayAssign = false;
                 if (chars.size() >= 3 && chars.get(chars.size() - 2).equals("+") && chars.get(chars.size() - 1).equals("=")) {
                     isArrayAssign = ParableFunctions._isArrayAssignmentPrefix(new ArrayList<>(chars.subList(0, chars.size() - 2)));
@@ -1264,7 +1264,7 @@ class Lexer {
                 chars.add(")");
                 continue;
             }
-            if (ctx == Constants.WORD_CTX_NORMAL && (this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN) != 0 && !this._eofToken.equals("") && ch.equals(this._eofToken) && bracketDepth == 0) {
+            if (ctx == Constants.WORD_CTX_NORMAL && (((this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN)) != 0) && !this._eofToken.equals("") && ch.equals(this._eofToken) && bracketDepth == 0) {
                 if (!(!chars.isEmpty())) {
                     chars.add(this.advance());
                 }
@@ -1281,7 +1281,7 @@ class Lexer {
         if (!(!chars.isEmpty())) {
             return null;
         }
-        if (!parts.isEmpty()) {
+        if ((!parts.isEmpty())) {
             return new Word(String.join("", chars), parts, "word");
         }
         return new Word(String.join("", chars), new ArrayList<>(), "word");
@@ -1322,7 +1322,7 @@ class Lexer {
             this._lastReadToken = tok;
             return tok;
         }
-        if (!this._eofToken.equals("") && this.peek().equals(this._eofToken) && !((this._parserState & Constants.PARSERSTATEFLAGS_PST_CASEPAT) != 0) && !((this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN) != 0)) {
+        if (!this._eofToken.equals("") && this.peek().equals(this._eofToken) && !(((this._parserState & Constants.PARSERSTATEFLAGS_PST_CASEPAT)) != 0) && !(((this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN)) != 0)) {
             tok = new Token(Constants.TOKENTYPE_EOF, "", this.pos, new ArrayList<>(), null);
             this._lastReadToken = tok;
             return tok;
@@ -1334,7 +1334,7 @@ class Lexer {
                 this._lastReadToken = tok;
                 return tok;
             }
-            if (!this._eofToken.equals("") && this.peek().equals(this._eofToken) && !((this._parserState & Constants.PARSERSTATEFLAGS_PST_CASEPAT) != 0) && !((this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN) != 0)) {
+            if (!this._eofToken.equals("") && this.peek().equals(this._eofToken) && !(((this._parserState & Constants.PARSERSTATEFLAGS_PST_CASEPAT)) != 0) && !(((this._parserState & Constants.PARSERSTATEFLAGS_PST_EOFTOKEN)) != 0)) {
                 tok = new Token(Constants.TOKENTYPE_EOF, "", this.pos, new ArrayList<>(), null);
                 this._lastReadToken = tok;
                 return tok;
@@ -1529,7 +1529,7 @@ class Lexer {
         if (this._dolbraceState == Constants.DOLBRACESTATE_NONE) {
             return;
         }
-        if (op.equals("") || op.isEmpty()) {
+        if (op.equals("") || op.length() == 0) {
             return;
         }
         String firstChar = String.valueOf(op.charAt(0));
@@ -1728,7 +1728,7 @@ class Lexer {
                     }
                 }
             }
-            if (!nameChars.isEmpty()) {
+            if ((!nameChars.isEmpty())) {
                 return String.join("", nameChars);
             } else {
                 return "";
@@ -1792,7 +1792,7 @@ class Lexer {
         if (ch.equals("#")) {
             this.advance();
             param = this._consumeParamName();
-            if (!param.equals("") && !this.atEnd() && this.peek().equals("}")) {
+            if ((!param.isEmpty()) && !this.atEnd() && this.peek().equals("}")) {
                 this.advance();
                 text = ParableFunctions._substring(this.source, start, this.pos);
                 this._dolbraceState = savedDolbrace;
@@ -1808,7 +1808,7 @@ class Lexer {
                 this.advance();
             }
             param = this._consumeParamName();
-            if (!param.equals("")) {
+            if ((!param.isEmpty())) {
                 while (!this.atEnd() && ParableFunctions._isWhitespaceNoNewline(this.peek())) {
                     this.advance();
                 }
@@ -1845,7 +1845,7 @@ class Lexer {
             }
         }
         param = this._consumeParamName();
-        if (!(!param.equals(""))) {
+        if (!(!param.isEmpty())) {
             if (!this.atEnd() && ("-=+?".indexOf(this.peek()) != -1 || this.peek().equals(":") && this.pos + 1 < this.length && ParableFunctions._isSimpleParamOp(String.valueOf(this.source.charAt(this.pos + 1))))) {
                 param = "";
             } else {
@@ -1914,7 +1914,7 @@ class Lexer {
                 }
             }
         }
-        this._updateDolbraceForOp(op, !param.isEmpty());
+        this._updateDolbraceForOp(op, param.length() > 0);
         try {
             int flags = (inDquote ? Constants.MATCHEDPAIRFLAGS_DQUOTE : Constants.MATCHEDPAIRFLAGS_NONE);
             boolean paramEndsWithDollar = !param.equals("") && param.endsWith("$");
@@ -2091,7 +2091,7 @@ class Word implements Node {
     }
 
     public String _shSingleQuote(String s) {
-        if (!(!s.equals(""))) {
+        if (!(!s.isEmpty())) {
             return "''";
         }
         if (s.equals("'")) {
@@ -2137,7 +2137,7 @@ class Word implements Node {
                                 if (j < inner.length() && inner.charAt(j) == '}') {
                                     j += 1;
                                 }
-                                if (!(!hexStr.equals(""))) {
+                                if (!(!hexStr.isEmpty())) {
                                     return result;
                                 }
                                 byteVal = ((int) Long.parseLong(hexStr, 16) & 255);
@@ -2361,7 +2361,7 @@ class Word implements Node {
                                     if (lastBraceIdx >= 0) {
                                         String afterBrace = resultStr.substring(lastBraceIdx + 2);
                                         int varNameLen = 0;
-                                        if (!afterBrace.equals("")) {
+                                        if ((!afterBrace.isEmpty())) {
                                             if ("@*#?-$!0123456789_".indexOf(String.valueOf(afterBrace.charAt(0))) != -1) {
                                                 varNameLen = 1;
                                             } else {
@@ -2387,7 +2387,7 @@ class Word implements Node {
                                                     break;
                                                 }
                                             }
-                                            if (!inPattern && !opStart.equals("") && "%#/^,~:+-=?".indexOf(String.valueOf(opStart.charAt(0))) == -1) {
+                                            if (!inPattern && (!opStart.isEmpty()) && "%#/^,~:+-=?".indexOf(String.valueOf(opStart.charAt(0))) == -1) {
                                                 for (String op : new ArrayList<>(Arrays.asList("//", "%%", "##", "/", "%", "#", "^", "^^", ",", ",,"))) {
                                                     if (opStart.indexOf(op) != -1) {
                                                         inPattern = true;
@@ -2634,7 +2634,7 @@ class Word implements Node {
         while (i < inner.length()) {
             String ch = String.valueOf(inner.charAt(i));
             if (ParableFunctions._isWhitespace(ch)) {
-                if (!inWhitespace && !normalized.isEmpty() && braceDepth == 0 && bracketDepth == 0) {
+                if (!inWhitespace && (!normalized.isEmpty()) && braceDepth == 0 && bracketDepth == 0) {
                     normalized.add(" ");
                     inWhitespace = true;
                 }
@@ -3189,7 +3189,7 @@ class Word implements Node {
                             String origInner = ParableFunctions._substring(value, i + 2, j - 1);
                             boolean endsWithNewline = origInner.endsWith("\n");
                             String suffix = "";
-                            if (!(!formatted.equals("")) || (formatted.length() > 0 && formatted.chars().allMatch(Character::isWhitespace))) {
+                            if (!(!formatted.isEmpty()) || (formatted.length() > 0 && formatted.chars().allMatch(Character::isWhitespace))) {
                                 suffix = "}";
                             } else {
                                 if (formatted.endsWith("&") || formatted.endsWith("& ")) {
@@ -3238,7 +3238,7 @@ class Word implements Node {
                                     String leadingWs = rawContent.substring(0, leadingWsEnd);
                                     stripped = rawContent.substring(leadingWsEnd);
                                     if (stripped.startsWith("(")) {
-                                        if (!leadingWs.equals("")) {
+                                        if ((!leadingWs.isEmpty())) {
                                             String normalizedWs = leadingWs.replace("\n", " ").replace("\t", " ");
                                             String spaced = ParableFunctions._formatCmdsubNode(((ProcessSubstitution) node).command, 0, false, false, false);
                                             result.add(direction + "(" + normalizedWs + spaced + ")");
@@ -3262,7 +3262,7 @@ class Word implements Node {
                                 procsubIdx += 1;
                                 i = j;
                             } else {
-                                if (isProcsub && !this.parts.isEmpty()) {
+                                if (isProcsub && (this.parts.size() != 0)) {
                                     direction = String.valueOf(value.charAt(i));
                                     j = ParableFunctions._findCmdsubEnd(value, i + 2);
                                     if (j > value.length() || j > 0 && j <= value.length() && value.charAt(j - 1) != ')') {
@@ -3298,7 +3298,7 @@ class Word implements Node {
                                         if (inArith) {
                                             result.add(direction + "(" + inner + ")");
                                         } else {
-                                            if (!inner.trim().equals("")) {
+                                            if ((!inner.trim().isEmpty())) {
                                                 stripped = inner.replaceFirst("^[" + " \t" + "]+", "");
                                                 result.add(direction + "(" + stripped + ")");
                                             } else {
@@ -3568,7 +3568,7 @@ class Command implements Node {
             parts.add(((Node) r).toSexp());
         }
         String inner = String.join(" ", parts);
-        if (!(!inner.equals(""))) {
+        if (!(!inner.isEmpty())) {
             return "(command)";
         }
         return "(command " + inner + ")";
@@ -3706,19 +3706,19 @@ class ListNode implements Node {
                 semiPositions.add(i);
             }
         }
-        if (!semiPositions.isEmpty()) {
+        if ((!semiPositions.isEmpty())) {
             List<List<Node>> segments = new ArrayList<>();
             int start = 0;
             List<Node> seg = new ArrayList<>();
             for (int pos : semiPositions) {
                 seg = ParableFunctions._sublist(parts, start, pos);
-                if (!seg.isEmpty() && seg.get(0).getKind() != "operator") {
+                if ((!seg.isEmpty()) && seg.get(0).getKind() != "operator") {
                     segments.add(seg);
                 }
                 start = pos + 1;
             }
             seg = ParableFunctions._sublist(parts, start, parts.size());
-            if (!seg.isEmpty() && seg.get(0).getKind() != "operator") {
+            if ((!seg.isEmpty()) && seg.get(0).getKind() != "operator") {
                 segments.add(seg);
             }
             if (!(!segments.isEmpty())) {
@@ -3743,7 +3743,7 @@ class ListNode implements Node {
                 ampPositions.add(i);
             }
         }
-        if (!ampPositions.isEmpty()) {
+        if ((!ampPositions.isEmpty())) {
             List<List<Node>> segments = new ArrayList<>();
             int start = 0;
             for (int pos : ampPositions) {
@@ -4082,7 +4082,7 @@ class For implements Node {
 
     public String toSexp() {
         String suffix = "";
-        if (!this.redirects.isEmpty()) {
+        if ((!this.redirects.isEmpty())) {
             List<String> redirectParts = new ArrayList<>();
             for (Node r : this.redirects) {
                 redirectParts.add(((Node) r).toSexp());
@@ -4095,7 +4095,7 @@ class For implements Node {
         if (this.words == null) {
             return "(for (word \"" + varEscaped + "\") (in (word \"\\\"$@\\\"\")) " + ((Node) this.body).toSexp() + ")" + suffix;
         } else {
-            if (this.words.isEmpty()) {
+            if (this.words.size() == 0) {
                 return "(for (word \"" + varEscaped + "\") (in) " + ((Node) this.body).toSexp() + ")" + suffix;
             } else {
                 List<String> wordParts = new ArrayList<>();
@@ -4130,16 +4130,16 @@ class ForArith implements Node {
 
     public String toSexp() {
         String suffix = "";
-        if (!this.redirects.isEmpty()) {
+        if ((!this.redirects.isEmpty())) {
             List<String> redirectParts = new ArrayList<>();
             for (Node r : this.redirects) {
                 redirectParts.add(((Node) r).toSexp());
             }
             suffix = " " + String.join(" ", redirectParts);
         }
-        String initVal = (!this.init.equals("") ? this.init : "1");
-        String condVal = (!this.cond.equals("") ? this.cond : "1");
-        String incrVal = (!this.incr.equals("") ? this.incr : "1");
+        String initVal = ((!this.init.isEmpty()) ? this.init : "1");
+        String condVal = ((!this.cond.isEmpty()) ? this.cond : "1");
+        String incrVal = ((!this.incr.isEmpty()) ? this.incr : "1");
         String initStr = ParableFunctions._formatArithVal(initVal);
         String condStr = ParableFunctions._formatArithVal(condVal);
         String incrStr = ParableFunctions._formatArithVal(incrVal);
@@ -4167,7 +4167,7 @@ class Select implements Node {
 
     public String toSexp() {
         String suffix = "";
-        if (!this.redirects.isEmpty()) {
+        if ((!this.redirects.isEmpty())) {
             List<String> redirectParts = new ArrayList<>();
             for (Node r : this.redirects) {
                 redirectParts.add(((Node) r).toSexp());
@@ -4182,7 +4182,7 @@ class Select implements Node {
                 wordParts.add(((Node) w).toSexp());
             }
             String wordStrs = String.join(" ", wordParts);
-            if (!this.words.isEmpty()) {
+            if ((!this.words.isEmpty())) {
                 inClause = "(in " + wordStrs + ")";
             } else {
                 inClause = "(in)";
@@ -4484,7 +4484,7 @@ class ArithmeticCommand implements Node {
         String formatted = new Word(this.rawContent, new ArrayList<>(), "word")._formatCommandSubstitutions(this.rawContent, true);
         String escaped = formatted.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\t", "\\t");
         String result = "(arith (word \"" + escaped + "\"))";
-        if (!this.redirects.isEmpty()) {
+        if ((!this.redirects.isEmpty())) {
             List<String> redirectParts = new ArrayList<>();
             for (Node r : this.redirects) {
                 redirectParts.add(((Node) r).toSexp());
@@ -4894,7 +4894,7 @@ class ConditionalExpr implements Node {
         } else {
             result = "(cond " + ((Node) body).toSexp() + ")";
         }
-        if (!this.redirects.isEmpty()) {
+        if ((!this.redirects.isEmpty())) {
             List<String> redirectParts = new ArrayList<>();
             for (Node r : this.redirects) {
                 redirectParts.add(((Node) r).toSexp());
@@ -5054,7 +5054,7 @@ class Coproc implements Node {
 
     public String toSexp() {
         String name = "";
-        if (!this.name.equals("")) {
+        if ((!this.name.isEmpty())) {
             name = this.name;
         } else {
             name = "COPROC";
@@ -5141,7 +5141,7 @@ class Parser {
         if (this._dolbraceState == Constants.DOLBRACESTATE_NONE) {
             return;
         }
-        if (op.equals("") || op.isEmpty()) {
+        if (op.equals("") || op.length() == 0) {
             return;
         }
         String firstChar = String.valueOf(op.charAt(0));
@@ -5435,7 +5435,7 @@ class Parser {
             }
             redirects.add(redirect);
         }
-        return (!redirects.isEmpty() ? redirects : new ArrayList<>());
+        return ((!redirects.isEmpty()) ? redirects : new ArrayList<>());
     }
 
     public Node _parseLoopBody(String context) {
@@ -5484,7 +5484,7 @@ class Parser {
             chars.add(this.advance());
         }
         String word = "";
-        if (!chars.isEmpty()) {
+        if ((!chars.isEmpty())) {
             word = String.join("", chars);
         } else {
             word = "";
@@ -5730,7 +5730,7 @@ class Parser {
                         this.advance();
                     }
                     inHeredocBody = false;
-                    if (!pendingHeredocs.isEmpty()) {
+                    if (pendingHeredocs.size() > 0) {
                         Tuple2 _entry28 = pendingHeredocs.remove(0);
                         currentHeredocDelim = _entry28.f0();
                         currentHeredocStrip = _entry28.f1();
@@ -5746,7 +5746,7 @@ class Parser {
                         }
                         this.pos = lineStart + endPos;
                         inHeredocBody = false;
-                        if (!pendingHeredocs.isEmpty()) {
+                        if (pendingHeredocs.size() > 0) {
                             Tuple2 _entry29 = pendingHeredocs.remove(0);
                             currentHeredocDelim = _entry29.f0();
                             currentHeredocStrip = _entry29.f1();
@@ -5936,7 +5936,7 @@ class Parser {
                     }
                 }
                 String delimiter = String.join("", delimiterChars);
-                if (!delimiter.equals("")) {
+                if ((!delimiter.isEmpty())) {
                     pendingHeredocs.add(new Tuple2(delimiter, stripTabs));
                 }
                 continue;
@@ -5945,7 +5945,7 @@ class Parser {
                 ch = this.advance();
                 contentChars.add(ch);
                 textChars.add(ch);
-                if (!pendingHeredocs.isEmpty()) {
+                if (pendingHeredocs.size() > 0) {
                     Tuple2 _entry30 = pendingHeredocs.remove(0);
                     currentHeredocDelim = _entry30.f0();
                     currentHeredocStrip = _entry30.f1();
@@ -5964,7 +5964,7 @@ class Parser {
         textChars.add("`");
         String text = String.join("", textChars);
         String content = String.join("", contentChars);
-        if (!pendingHeredocs.isEmpty()) {
+        if (pendingHeredocs.size() > 0) {
             Tuple9 _tuple31 = ParableFunctions._findHeredocContentEnd(this.source, this.pos, pendingHeredocs);
             int heredocStart = _tuple31.f0();
             int heredocEnd = _tuple31.f1();
@@ -6977,14 +6977,14 @@ class Parser {
             }
             String varname = String.join("", varnameChars);
             boolean isValidVarfd = false;
-            if (!varname.equals("")) {
+            if ((!varname.isEmpty())) {
                 if ((String.valueOf(varname.charAt(0)).length() > 0 && String.valueOf(varname.charAt(0)).chars().allMatch(Character::isLetter)) || varname.charAt(0) == '_') {
                     if (varname.indexOf("[") != -1 || varname.indexOf("]") != -1) {
                         int left = varname.indexOf("[");
                         int right = varname.lastIndexOf("]");
                         if (left != -1 && right == varname.length() - 1 && right > left + 1) {
                             String base = varname.substring(0, left);
-                            if (!base.equals("") && ((String.valueOf(base.charAt(0)).length() > 0 && String.valueOf(base.charAt(0)).chars().allMatch(Character::isLetter)) || base.charAt(0) == '_')) {
+                            if ((!base.isEmpty()) && ((String.valueOf(base.charAt(0)).length() > 0 && String.valueOf(base.charAt(0)).chars().allMatch(Character::isLetter)) || base.charAt(0) == '_')) {
                                 isValidVarfd = true;
                                 for (int _i = 0; _i < base.substring(1).length(); _i++) {
                                     String c = String.valueOf(base.substring(1).charAt(_i));
@@ -7015,7 +7015,7 @@ class Parser {
             }
         }
         List<String> fdChars = new ArrayList<>();
-        if (varfd.equals("") && !this.peek().equals("") && (this.peek().length() > 0 && this.peek().chars().allMatch(Character::isDigit))) {
+        if (varfd.equals("") && (!this.peek().isEmpty()) && (this.peek().length() > 0 && this.peek().chars().allMatch(Character::isDigit))) {
             fdChars = new ArrayList<>();
             while (!this.atEnd() && (this.peek().length() > 0 && this.peek().chars().allMatch(Character::isDigit))) {
                 fdChars.add(this.advance());
@@ -7134,7 +7134,7 @@ class Parser {
                         fdChars.add(this.advance());
                     }
                     String fdTarget = "";
-                    if (!fdChars.isEmpty()) {
+                    if ((!fdChars.isEmpty())) {
                         fdTarget = String.join("", fdChars);
                     } else {
                         fdTarget = "";
@@ -7518,7 +7518,7 @@ class Parser {
             if (this._lexIsCommandTerminator()) {
                 break;
             }
-            if (words.isEmpty()) {
+            if (words.size() == 0) {
                 String reserved = this._lexPeekReservedWord();
                 if (reserved.equals("}") || reserved.equals("]]")) {
                     break;
@@ -7536,8 +7536,8 @@ class Parser {
                     break;
                 }
             }
-            boolean inAssignBuiltin = !words.isEmpty() && Constants.ASSIGNMENT_BUILTINS.contains(words.get(0).value);
-            Word word = this.parseWord(!(!words.isEmpty()) || allAssignments && redirects.isEmpty(), false, inAssignBuiltin);
+            boolean inAssignBuiltin = words.size() > 0 && Constants.ASSIGNMENT_BUILTINS.contains(words.get(0).value);
+            Word word = this.parseWord(!(!words.isEmpty()) || allAssignments && redirects.size() == 0, false, inAssignBuiltin);
             if (word == null) {
                 break;
             }
@@ -8376,7 +8376,7 @@ class Parser {
                 }
             }
             String pattern = String.join("", patternChars);
-            if (!(!pattern.equals(""))) {
+            if (!(!pattern.isEmpty())) {
                 throw new RuntimeException("Expected pattern in case statement");
             }
             this.skipWhitespace();
@@ -8445,7 +8445,7 @@ class Parser {
         }
         int wordStart = this.pos;
         String potentialName = this.peekWord();
-        if (!potentialName.equals("")) {
+        if ((!potentialName.isEmpty())) {
             while (!this.atEnd() && !ParableFunctions._isMetachar(this.peek()) && !ParableFunctions._isQuote(this.peek())) {
                 this.advance();
             }
@@ -8537,7 +8537,7 @@ class Parser {
             this.advance();
         }
         name = ParableFunctions._substring(this.source, nameStart, this.pos);
-        if (!(!name.equals(""))) {
+        if (!(!name.isEmpty())) {
             this.pos = savedPos;
             return null;
         }
@@ -8561,7 +8561,7 @@ class Parser {
         int posAfterName = this.pos;
         this.skipWhitespace();
         boolean hasWhitespace = this.pos > posAfterName;
-        if (!hasWhitespace && !name.equals("") && "*?@+!$".indexOf(String.valueOf(name.charAt(name.length() - 1))) != -1) {
+        if (!hasWhitespace && (!name.isEmpty()) && "*?@+!$".indexOf(String.valueOf(name.charAt(name.length() - 1))) != -1) {
             this.pos = savedPos;
             return null;
         }
@@ -9080,7 +9080,7 @@ class Parser {
 
     public List<Node> parse() {
         String source = this.source.trim();
-        if (!(!source.equals(""))) {
+        if (!(!source.isEmpty())) {
             return new ArrayList<>(Arrays.asList(new Empty("empty")));
         }
         List<Node> results = new ArrayList<>();
@@ -9121,7 +9121,7 @@ class Parser {
         if (!(!results.isEmpty())) {
             return new ArrayList<>(Arrays.asList(new Empty("empty")));
         }
-        if (this._sawNewlineInSingleQuote && !this.source.equals("") && this.source.charAt(this.source.length() - 1) == '\\' && !(this.source.length() >= 3 && this.source.substring(this.source.length() - 3, this.source.length() - 1).equals("\\\n"))) {
+        if (this._sawNewlineInSingleQuote && (!this.source.isEmpty()) && this.source.charAt(this.source.length() - 1) == '\\' && !(this.source.length() >= 3 && this.source.substring(this.source.length() - 3, this.source.length() - 1).equals("\\\n"))) {
             if (!this._lastWordOnOwnLine(results)) {
                 this._stripTrailingBackslashFromLastWord(results);
             }
@@ -9141,7 +9141,7 @@ class Parser {
         Word lastWord = this._findLastWord(lastNode);
         if (lastWord != null && lastWord.value.endsWith("\\")) {
             lastWord.value = ParableFunctions._substring(lastWord.value, 0, lastWord.value.length() - 1);
-            if (!(!lastWord.value.equals("")) && (lastNode instanceof Command) && !((Command) lastNode).words.isEmpty()) {
+            if (!(!lastWord.value.isEmpty()) && (lastNode instanceof Command) && (!((Command) lastNode).words.isEmpty())) {
                 ((Command) lastNode).words.remove(((Command) lastNode).words.size() - 1);
             }
         }
@@ -9152,29 +9152,29 @@ class Parser {
             return nodeWord;
         }
         if (node instanceof Command nodeCommand) {
-            if (!nodeCommand.words.isEmpty()) {
+            if ((!nodeCommand.words.isEmpty())) {
                 Word lastWord = nodeCommand.words.get(nodeCommand.words.size() - 1);
                 if (lastWord.value.endsWith("\\")) {
                     return lastWord;
                 }
             }
-            if (!nodeCommand.redirects.isEmpty()) {
+            if ((!nodeCommand.redirects.isEmpty())) {
                 Node lastRedirect = nodeCommand.redirects.get(nodeCommand.redirects.size() - 1);
                 if (lastRedirect instanceof Redirect lastRedirectRedirect) {
                     return lastRedirectRedirect.target;
                 }
             }
-            if (!nodeCommand.words.isEmpty()) {
+            if ((!nodeCommand.words.isEmpty())) {
                 return nodeCommand.words.get(nodeCommand.words.size() - 1);
             }
         }
         if (node instanceof Pipeline nodePipeline) {
-            if (!nodePipeline.commands.isEmpty()) {
+            if ((!nodePipeline.commands.isEmpty())) {
                 return this._findLastWord(nodePipeline.commands.get(nodePipeline.commands.size() - 1));
             }
         }
         if (node instanceof ListNode nodeList) {
-            if (!nodeList.parts.isEmpty()) {
+            if ((!nodeList.parts.isEmpty())) {
                 return this._findLastWord(nodeList.parts.get(nodeList.parts.size() - 1));
             }
         }
@@ -9310,7 +9310,7 @@ final class ParableFunctions {
     }
 
     static String _appendRedirects(String base, List<Node> redirects) {
-        if (!redirects.isEmpty()) {
+        if ((!redirects.isEmpty())) {
             List<String> parts = new ArrayList<>();
             for (Node r : redirects) {
                 parts.add(((Node) r).toSexp());
@@ -9465,7 +9465,7 @@ final class ParableFunctions {
             return false;
         }
         if (node instanceof Pipeline nodePipeline) {
-            if (!nodePipeline.commands.isEmpty()) {
+            if ((!nodePipeline.commands.isEmpty())) {
                 return ParableFunctions._startsWithSubshell(nodePipeline.commands.get(0));
             }
             return false;
@@ -9501,7 +9501,7 @@ final class ParableFunctions {
                 parts.add(ParableFunctions._formatRedirect(r, compactRedirects, true));
             }
             String result = "";
-            if (compactRedirects && !nodeCommand.words.isEmpty() && !nodeCommand.redirects.isEmpty()) {
+            if (compactRedirects && (!nodeCommand.words.isEmpty()) && (!nodeCommand.redirects.isEmpty())) {
                 List<String> wordParts = new ArrayList<>(parts.subList(0, nodeCommand.words.size()));
                 List<String> redirectParts = new ArrayList<>(parts.subList(nodeCommand.words.size(), parts.size()));
                 result = String.join(" ", wordParts) + String.join("", redirectParts);
@@ -9539,7 +9539,7 @@ final class ParableFunctions {
                 String formatted = ParableFunctions._formatCmdsubNode(cmd, indent, inProcsub, false, procsubFirst && idx == 0);
                 boolean isLast = idx == cmds.size() - 1;
                 boolean hasHeredoc = false;
-                if (cmd.getKind() == "command" && !((Command) cmd).redirects.isEmpty()) {
+                if (cmd.getKind() == "command" && (!((Command) cmd).redirects.isEmpty())) {
                     for (Node r : ((Command) cmd).redirects) {
                         if (r instanceof HereDoc rHereDoc) {
                             hasHeredoc = true;
@@ -9571,7 +9571,7 @@ final class ParableFunctions {
                 }
                 idx += 1;
             }
-            boolean compactPipe = inProcsub && !cmds.isEmpty() && cmds.get(0).f0().getKind() == "subshell";
+            boolean compactPipe = inProcsub && (!cmds.isEmpty()) && cmds.get(0).f0().getKind() == "subshell";
             String result = "";
             idx = 0;
             while (idx < resultParts.size()) {
@@ -9596,7 +9596,7 @@ final class ParableFunctions {
         if (node instanceof ListNode nodeList) {
             boolean hasHeredoc = false;
             for (Node p : nodeList.parts) {
-                if (p.getKind() == "command" && !((Command) p).redirects.isEmpty()) {
+                if (p.getKind() == "command" && (!((Command) p).redirects.isEmpty())) {
                     for (Node r : ((Command) p).redirects) {
                         if (r instanceof HereDoc rHereDoc) {
                             hasHeredoc = true;
@@ -9606,7 +9606,7 @@ final class ParableFunctions {
                 } else {
                     if (p instanceof Pipeline pPipeline) {
                         for (Node cmd : pPipeline.commands) {
-                            if (cmd.getKind() == "command" && !((Command) cmd).redirects.isEmpty()) {
+                            if (cmd.getKind() == "command" && (!((Command) cmd).redirects.isEmpty())) {
                                 for (Node r : ((Command) cmd).redirects) {
                                     if (r instanceof HereDoc rHereDoc) {
                                         hasHeredoc = true;
@@ -9627,7 +9627,7 @@ final class ParableFunctions {
             for (Node p : nodeList.parts) {
                 if (p instanceof Operator pOperator) {
                     if (pOperator.op.equals(";")) {
-                        if (!result.isEmpty() && result.get(result.size() - 1).endsWith("\n")) {
+                        if ((!result.isEmpty()) && result.get(result.size() - 1).endsWith("\n")) {
                             skippedSemi = true;
                             continue;
                         }
@@ -9639,11 +9639,11 @@ final class ParableFunctions {
                         skippedSemi = false;
                     } else {
                         if (pOperator.op.equals("\n")) {
-                            if (!result.isEmpty() && result.get(result.size() - 1).equals(";")) {
+                            if ((!result.isEmpty()) && result.get(result.size() - 1).equals(";")) {
                                 skippedSemi = false;
                                 continue;
                             }
-                            if (!result.isEmpty() && result.get(result.size() - 1).endsWith("\n")) {
+                            if ((!result.isEmpty()) && result.get(result.size() - 1).endsWith("\n")) {
                                 result.add((skippedSemi ? " " : "\n"));
                                 skippedSemi = false;
                                 continue;
@@ -9654,7 +9654,7 @@ final class ParableFunctions {
                             String last = "";
                             int firstNl = 0;
                             if (pOperator.op.equals("&")) {
-                                if (!result.isEmpty() && result.get(result.size() - 1).indexOf("<<") != -1 && result.get(result.size() - 1).indexOf("\n") != -1) {
+                                if ((!result.isEmpty()) && result.get(result.size() - 1).indexOf("<<") != -1 && result.get(result.size() - 1).indexOf("\n") != -1) {
                                     last = result.get(result.size() - 1);
                                     if (last.indexOf(" |") != -1 || last.startsWith("|")) {
                                         result.set(result.size() - 1, last + " &");
@@ -9666,7 +9666,7 @@ final class ParableFunctions {
                                     result.add(" &");
                                 }
                             } else {
-                                if (!result.isEmpty() && result.get(result.size() - 1).indexOf("<<") != -1 && result.get(result.size() - 1).indexOf("\n") != -1) {
+                                if ((!result.isEmpty()) && result.get(result.size() - 1).indexOf("<<") != -1 && result.get(result.size() - 1).indexOf("\n") != -1) {
                                     last = result.get(result.size() - 1);
                                     firstNl = last.indexOf("\n");
                                     result.set(result.size() - 1, last.substring(0, firstNl) + " " + pOperator.op + " " + last.substring(firstNl));
@@ -9677,11 +9677,11 @@ final class ParableFunctions {
                         }
                     }
                 } else {
-                    if (!result.isEmpty() && !(result.get(result.size() - 1).endsWith(" ") || result.get(result.size() - 1).endsWith("\n"))) {
+                    if ((!result.isEmpty()) && !(result.get(result.size() - 1).endsWith(" ") || result.get(result.size() - 1).endsWith("\n"))) {
                         result.add(" ");
                     }
                     String formattedCmd = ParableFunctions._formatCmdsubNode(p, indent, inProcsub, compactRedirects, procsubFirst && cmdCount == 0);
-                    if (!result.isEmpty()) {
+                    if (result.size() > 0) {
                         String last = result.get(result.size() - 1);
                         if (last.indexOf(" || \n") != -1 || last.indexOf(" && \n") != -1) {
                             formattedCmd = " " + formattedCmd;
@@ -9724,7 +9724,7 @@ final class ParableFunctions {
             String cond = ParableFunctions._formatCmdsubNode(nodeWhile.condition, indent, false, false, false);
             String body = ParableFunctions._formatCmdsubNode(nodeWhile.body, indent + 4, false, false, false);
             String result = "while " + cond + "; do\n" + innerSp + body + ";\n" + sp + "done";
-            if (!nodeWhile.redirects.isEmpty()) {
+            if ((!nodeWhile.redirects.isEmpty())) {
                 for (Node r : nodeWhile.redirects) {
                     result = result + " " + ParableFunctions._formatRedirect(r, false, false);
                 }
@@ -9735,7 +9735,7 @@ final class ParableFunctions {
             String cond = ParableFunctions._formatCmdsubNode(nodeUntil.condition, indent, false, false, false);
             String body = ParableFunctions._formatCmdsubNode(nodeUntil.body, indent + 4, false, false, false);
             String result = "until " + cond + "; do\n" + innerSp + body + ";\n" + sp + "done";
-            if (!nodeUntil.redirects.isEmpty()) {
+            if ((!nodeUntil.redirects.isEmpty())) {
                 for (Node r : nodeUntil.redirects) {
                     result = result + " " + ParableFunctions._formatRedirect(r, false, false);
                 }
@@ -9752,7 +9752,7 @@ final class ParableFunctions {
                     wordVals.add(w.value);
                 }
                 String words = String.join(" ", wordVals);
-                if (!words.equals("")) {
+                if ((!words.isEmpty())) {
                     result = "for " + var + " in " + words + ";\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
                 } else {
                     result = "for " + var + " in ;\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
@@ -9760,7 +9760,7 @@ final class ParableFunctions {
             } else {
                 result = "for " + var + " in \"$@\";\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
             }
-            if (!nodeFor.redirects.isEmpty()) {
+            if ((!nodeFor.redirects.isEmpty())) {
                 for (Node r : nodeFor.redirects) {
                     result = result + " " + ParableFunctions._formatRedirect(r, false, false);
                 }
@@ -9770,7 +9770,7 @@ final class ParableFunctions {
         if (node instanceof ForArith nodeForArith) {
             String body = ParableFunctions._formatCmdsubNode(nodeForArith.body, indent + 4, false, false, false);
             String result = "for ((" + nodeForArith.init + "; " + nodeForArith.cond + "; " + nodeForArith.incr + "))\ndo\n" + innerSp + body + ";\n" + sp + "done";
-            if (!nodeForArith.redirects.isEmpty()) {
+            if ((!nodeForArith.redirects.isEmpty())) {
                 for (Node r : nodeForArith.redirects) {
                     result = result + " " + ParableFunctions._formatRedirect(r, false, false);
                 }
@@ -9793,7 +9793,7 @@ final class ParableFunctions {
                 String term = ((CasePattern) p).terminator;
                 String patIndent = ParableFunctions._repeatStr(" ", indent + 8);
                 String termIndent = ParableFunctions._repeatStr(" ", indent + 4);
-                String bodyPart = (!body.equals("") ? patIndent + body + "\n" : "\n");
+                String bodyPart = ((!body.isEmpty()) ? patIndent + body + "\n" : "\n");
                 if (i == 0) {
                     patterns.add(" " + pat + ")\n" + bodyPart + termIndent + term);
                 } else {
@@ -9803,7 +9803,7 @@ final class ParableFunctions {
             }
             Object patternStr = String.join("\n" + ParableFunctions._repeatStr(" ", indent + 4), patterns);
             String redirects = "";
-            if (!nodeCase.redirects.isEmpty()) {
+            if ((!nodeCase.redirects.isEmpty())) {
                 List<String> redirectParts = new ArrayList<>();
                 for (Node r : nodeCase.redirects) {
                     redirectParts.add(ParableFunctions._formatRedirect(r, false, false));
@@ -9821,7 +9821,7 @@ final class ParableFunctions {
         if (node instanceof Subshell nodeSubshell) {
             String body = ParableFunctions._formatCmdsubNode(nodeSubshell.body, indent, inProcsub, compactRedirects, false);
             String redirects = "";
-            if (!nodeSubshell.redirects.isEmpty()) {
+            if ((!nodeSubshell.redirects.isEmpty())) {
                 List<String> redirectParts = new ArrayList<>();
                 for (Node r : nodeSubshell.redirects) {
                     redirectParts.add(ParableFunctions._formatRedirect(r, false, false));
@@ -9829,12 +9829,12 @@ final class ParableFunctions {
                 redirects = String.join(" ", redirectParts);
             }
             if (procsubFirst) {
-                if (!redirects.equals("")) {
+                if ((!redirects.isEmpty())) {
                     return "(" + body + ") " + redirects;
                 }
                 return "(" + body + ")";
             }
-            if (!redirects.equals("")) {
+            if ((!redirects.isEmpty())) {
                 return "( " + body + " ) " + redirects;
             }
             return "( " + body + " )";
@@ -9844,14 +9844,14 @@ final class ParableFunctions {
             body = body.replaceFirst("[" + ";" + "]+$", "");
             String terminator = (body.endsWith(" &") ? " }" : "; }");
             String redirects = "";
-            if (!nodeBraceGroup.redirects.isEmpty()) {
+            if ((!nodeBraceGroup.redirects.isEmpty())) {
                 List<String> redirectParts = new ArrayList<>();
                 for (Node r : nodeBraceGroup.redirects) {
                     redirectParts.add(ParableFunctions._formatRedirect(r, false, false));
                 }
                 redirects = String.join(" ", redirectParts);
             }
-            if (!redirects.equals("")) {
+            if ((!redirects.isEmpty())) {
                 return "{ " + body + terminator + " " + redirects;
             }
             return "{ " + body + terminator;
@@ -9920,7 +9920,7 @@ final class ParableFunctions {
                 op = ParableFunctions._substring(op, 0, op.length() - 1) + ">";
             }
             String afterAmp = ParableFunctions._substring(target, 1, target.length());
-            boolean isLiteralFd = afterAmp.equals("-") || !afterAmp.isEmpty() && (String.valueOf(afterAmp.charAt(0)).length() > 0 && String.valueOf(afterAmp.charAt(0)).chars().allMatch(Character::isDigit));
+            boolean isLiteralFd = afterAmp.equals("-") || afterAmp.length() > 0 && (String.valueOf(afterAmp.charAt(0)).length() > 0 && String.valueOf(afterAmp.charAt(0)).chars().allMatch(Character::isDigit));
             if (isLiteralFd) {
                 if (op.equals(">") || op.equals(">&")) {
                     op = (wasInputClose ? "0>" : "1>");
@@ -10739,7 +10739,7 @@ final class ParableFunctions {
     static int _skipMatchedPair(String s, int start, String open, String close, int flags) {
         int n = s.length();
         int i = 0;
-        if ((flags & Constants.SMP_PAST_OPEN) != 0) {
+        if ((((flags & Constants.SMP_PAST_OPEN)) != 0)) {
             i = start;
         } else {
             if (start >= n || !String.valueOf(s.charAt(start)).equals(open)) {
@@ -10808,7 +10808,7 @@ final class ParableFunctions {
     }
 
     static int _assignment(String s, int flags) {
-        if (!(!s.equals(""))) {
+        if (!(!s.isEmpty())) {
             return -1;
         }
         if (!((String.valueOf(s.charAt(0)).length() > 0 && String.valueOf(s.charAt(0)).chars().allMatch(Character::isLetter)) || s.charAt(0) == '_')) {
@@ -10821,7 +10821,7 @@ final class ParableFunctions {
                 return i;
             }
             if (c.equals("[")) {
-                int subFlags = ((flags & 2) != 0 ? Constants.SMP_LITERAL : 0);
+                int subFlags = ((((flags & 2)) != 0) ? Constants.SMP_LITERAL : 0);
                 int end = ParableFunctions._skipSubscript(s, i, subFlags);
                 if (end == -1) {
                     return -1;
@@ -10943,7 +10943,7 @@ final class ParableFunctions {
     }
 
     static boolean _isValidIdentifier(String name) {
-        if (!(!name.equals(""))) {
+        if (!(!name.isEmpty())) {
             return false;
         }
         if (!((String.valueOf(name.charAt(0)).length() > 0 && String.valueOf(name.charAt(0)).chars().allMatch(Character::isLetter)) || name.charAt(0) == '_')) {

--- a/dist/js/parable.js
+++ b/dist/js/parable.js
@@ -179,7 +179,7 @@ var Token = /** @class */ (function () {
         if (this.word !== null) {
             return "Token(".concat(this.typeName, ", ").concat(this.value, ", ").concat(this.pos, ", word=").concat(this.word, ")");
         }
-        if (this.parts.length > 0) {
+        if ((this.parts.length > 0)) {
             return "Token(".concat(this.typeName, ", ").concat(this.value, ", ").concat(this.pos, ", parts=").concat(this.parts.length, ")");
         }
         return "Token(".concat(this.typeName, ", ").concat(this.value, ", ").concat(this.pos, ")");
@@ -232,7 +232,7 @@ var QuoteState = /** @class */ (function () {
     };
     QuoteState.prototype.pop = function () {
         var _a;
-        if (this.Stack.length > 0) {
+        if ((this.Stack.length > 0)) {
             _a = this.Stack.pop(), this.single = _a[0], this.double = _a[1];
         }
     };
@@ -583,7 +583,7 @@ var Lexer = /** @class */ (function () {
             }
             return IsWhitespace(ch);
         }
-        if ((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0 && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
+        if (((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0) && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
             return true;
         }
         if (IsRedirectChar(ch) && this.pos + 1 < this.length && this.source[this.pos + 1] === "(") {
@@ -721,7 +721,7 @@ var Lexer = /** @class */ (function () {
                 throw new MatchedPairError();
             }
             var ch = this.advance();
-            if ((flags & MatchedPairFlags_DOLBRACE) !== 0 && this.DolbraceState === DolbraceState_OP) {
+            if (((flags & MatchedPairFlags_DOLBRACE) !== 0) && this.DolbraceState === DolbraceState_OP) {
                 if (!"#%^,~:-=?+/".includes(ch)) {
                     this.DolbraceState = DolbraceState_WORD;
                 }
@@ -740,7 +740,7 @@ var Lexer = /** @class */ (function () {
                         break;
                     }
                 }
-                if (ch === "\\" && (flags & MatchedPairFlags_ALLOWESC) !== 0) {
+                if (ch === "\\" && ((flags & MatchedPairFlags_ALLOWESC) !== 0)) {
                     passNext = true;
                 }
                 chars.push(ch);
@@ -772,7 +772,7 @@ var Lexer = /** @class */ (function () {
                 continue;
             }
             if (ch === openChar && openChar !== closeChar) {
-                if (!((flags & MatchedPairFlags_DOLBRACE) !== 0 && openChar === "{")) {
+                if (!(((flags & MatchedPairFlags_DOLBRACE) !== 0) && openChar === "{")) {
                     count += 1;
                 }
                 chars.push(ch);
@@ -814,7 +814,7 @@ var Lexer = /** @class */ (function () {
                     }
                 }
             }
-            if (ch === "$" && !this.atEnd() && (flags & MatchedPairFlags_EXTGLOB) === 0) {
+            if (ch === "$" && !this.atEnd() && !((flags & MatchedPairFlags_EXTGLOB) !== 0)) {
                 var nextCh = this.peek();
                 if (wasDollar) {
                     chars.push(ch);
@@ -823,7 +823,7 @@ var Lexer = /** @class */ (function () {
                     continue;
                 }
                 if (nextCh === "{") {
-                    if ((flags & MatchedPairFlags_ARITH) !== 0) {
+                    if (((flags & MatchedPairFlags_ARITH) !== 0)) {
                         var afterBracePos = this.pos + 1;
                         if (afterBracePos >= this.length || !IsFunsubChar(this.source[afterBracePos])) {
                             chars.push(ch);
@@ -916,7 +916,7 @@ var Lexer = /** @class */ (function () {
                     }
                 }
             }
-            if (ch === "(" && wasGtlt && (flags & (MatchedPairFlags_DOLBRACE | MatchedPairFlags_ARRAYSUB)) !== 0) {
+            if (ch === "(" && wasGtlt && ((flags & (MatchedPairFlags_DOLBRACE | MatchedPairFlags_ARRAYSUB)) !== 0)) {
                 {
                     var direction = chars[chars.length - 1];
                     chars = chars.slice(0, chars.length - 1);
@@ -974,7 +974,7 @@ var Lexer = /** @class */ (function () {
                     chars.push(this.advance());
                     continue;
                 }
-                if (chars.length > 0 && atCommandStart && !seenEquals && IsArrayAssignmentPrefix(chars)) {
+                if ((chars.length > 0) && atCommandStart && !seenEquals && IsArrayAssignmentPrefix(chars)) {
                     var prevChar = chars[chars.length - 1];
                     if (/^[a-zA-Z0-9]$/.test(prevChar) || prevChar === "_") {
                         bracketStartPos = this.pos;
@@ -1020,7 +1020,7 @@ var Lexer = /** @class */ (function () {
                 continue;
             }
             if (ctx === WORD_CTX_COND && ch === "(") {
-                if (this.Extglob && chars.length > 0 && IsExtglobPrefix(chars[chars.length - 1])) {
+                if (this.Extglob && (chars.length > 0) && IsExtglobPrefix(chars[chars.length - 1])) {
                     chars.push(this.advance());
                     var content = this.ParseMatchedPair("(", ")", MatchedPairFlags_EXTGLOB, false);
                     chars.push(content);
@@ -1157,7 +1157,7 @@ var Lexer = /** @class */ (function () {
                 }
                 else {
                     this.SyncFromParser();
-                    if (this.Extglob && ctx === WORD_CTX_NORMAL && chars.length > 0 && chars[chars.length - 1].length === 2 && chars[chars.length - 1][0] === "$" && "?*@".includes(chars[chars.length - 1][1]) && !this.atEnd() && this.peek() === "(") {
+                    if (this.Extglob && ctx === WORD_CTX_NORMAL && (chars.length > 0) && chars[chars.length - 1].length === 2 && chars[chars.length - 1][0] === "$" && "?*@".includes(chars[chars.length - 1][1]) && !this.atEnd() && this.peek() === "(") {
                         chars.push(this.advance());
                         var content = this.ParseMatchedPair("(", ")", MatchedPairFlags_EXTGLOB, false);
                         chars.push(content);
@@ -1188,7 +1188,7 @@ var Lexer = /** @class */ (function () {
                     chars.push(procsubResult1);
                 }
                 else {
-                    if (procsubResult1 !== "") {
+                    if ((procsubResult1.length > 0)) {
                         chars.push(procsubResult1);
                     }
                     else {
@@ -1200,7 +1200,7 @@ var Lexer = /** @class */ (function () {
                 }
                 continue;
             }
-            if (ctx === WORD_CTX_NORMAL && ch === "(" && chars.length > 0 && bracketDepth === 0) {
+            if (ctx === WORD_CTX_NORMAL && ch === "(" && (chars.length > 0) && bracketDepth === 0) {
                 var isArrayAssign = false;
                 if (chars.length >= 3 && chars[chars.length - 2] === "+" && chars[chars.length - 1] === "=") {
                     isArrayAssign = IsArrayAssignmentPrefix(chars.slice(0, chars.length - 2));
@@ -1232,7 +1232,7 @@ var Lexer = /** @class */ (function () {
                 chars.push(")");
                 continue;
             }
-            if (ctx === WORD_CTX_NORMAL && (this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0 && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
+            if (ctx === WORD_CTX_NORMAL && ((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0) && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
                 if (!(chars.length > 0)) {
                     chars.push(this.advance());
                 }
@@ -1249,7 +1249,7 @@ var Lexer = /** @class */ (function () {
         if (!(chars.length > 0)) {
             return null;
         }
-        if (parts.length > 0) {
+        if ((parts.length > 0)) {
             return new Word(chars.join(""), parts, "word");
         }
         return new Word(chars.join(""), null, "word");
@@ -1287,7 +1287,7 @@ var Lexer = /** @class */ (function () {
             this.LastReadToken = tok;
             return tok;
         }
-        if (this.EofToken !== "" && this.peek() === this.EofToken && (this.ParserState & ParserStateFlags_PST_CASEPAT) === 0 && (this.ParserState & ParserStateFlags_PST_EOFTOKEN) === 0) {
+        if (this.EofToken !== "" && this.peek() === this.EofToken && !((this.ParserState & ParserStateFlags_PST_CASEPAT) !== 0) && !((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0)) {
             var tok = new Token(TokenType_EOF, "", this.pos, [], null);
             this.LastReadToken = tok;
             return tok;
@@ -1299,7 +1299,7 @@ var Lexer = /** @class */ (function () {
                 this.LastReadToken = tok;
                 return tok;
             }
-            if (this.EofToken !== "" && this.peek() === this.EofToken && (this.ParserState & ParserStateFlags_PST_CASEPAT) === 0 && (this.ParserState & ParserStateFlags_PST_EOFTOKEN) === 0) {
+            if (this.EofToken !== "" && this.peek() === this.EofToken && !((this.ParserState & ParserStateFlags_PST_CASEPAT) !== 0) && !((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0)) {
                 var tok = new Token(TokenType_EOF, "", this.pos, [], null);
                 this.LastReadToken = tok;
                 return tok;
@@ -1690,7 +1690,7 @@ var Lexer = /** @class */ (function () {
                     }
                 }
             }
-            if (nameChars.length > 0) {
+            if ((nameChars.length > 0)) {
                 return nameChars.join("");
             }
             else {
@@ -1751,7 +1751,7 @@ var Lexer = /** @class */ (function () {
         if (ch === "#") {
             this.advance();
             var param = this.ConsumeParamName();
-            if (param !== "" && !this.atEnd() && this.peek() === "}") {
+            if ((param.length > 0) && !this.atEnd() && this.peek() === "}") {
                 this.advance();
                 var text = Substring(this.source, start, this.pos);
                 this.DolbraceState = savedDolbrace;
@@ -1765,7 +1765,7 @@ var Lexer = /** @class */ (function () {
                 this.advance();
             }
             var param = this.ConsumeParamName();
-            if (param !== "") {
+            if ((param.length > 0)) {
                 while (!this.atEnd() && IsWhitespaceNoNewline(this.peek())) {
                     this.advance();
                 }
@@ -1803,7 +1803,7 @@ var Lexer = /** @class */ (function () {
             }
         }
         var param = this.ConsumeParamName();
-        if (param === "") {
+        if (!(param.length > 0)) {
             if (!this.atEnd() && ("-=+?".includes(this.peek()) || this.peek() === ":" && this.pos + 1 < this.length && IsSimpleParamOp(this.source[this.pos + 1]))) {
                 param = "";
             }
@@ -2062,7 +2062,7 @@ var Word = /** @class */ (function () {
         return result.join("");
     };
     Word.prototype.ShSingleQuote = function (s) {
-        if (s === "") {
+        if (!(s.length > 0)) {
             return "''";
         }
         if (s === "'") {
@@ -2108,7 +2108,7 @@ var Word = /** @class */ (function () {
                                 if (j < inner.length && inner[j] === "}") {
                                     j += 1;
                                 }
-                                if (hexStr === "") {
+                                if (!(hexStr.length > 0)) {
                                     return result;
                                 }
                                 var byteVal = parseInt(hexStr, 16) & 255;
@@ -2349,7 +2349,7 @@ var Word = /** @class */ (function () {
                                     if (lastBraceIdx >= 0) {
                                         var afterBrace = resultStr.slice(lastBraceIdx + 2);
                                         var varNameLen = 0;
-                                        if (afterBrace !== "") {
+                                        if ((afterBrace.length > 0)) {
                                             if ("@*#?-$!0123456789_".includes(afterBrace[0])) {
                                                 varNameLen = 1;
                                             }
@@ -2377,7 +2377,7 @@ var Word = /** @class */ (function () {
                                                     break;
                                                 }
                                             }
-                                            if (!inPattern && opStart !== "" && !"%#/^,~:+-=?".includes(opStart[0])) {
+                                            if (!inPattern && (opStart.length > 0) && !"%#/^,~:+-=?".includes(opStart[0])) {
                                                 for (var _b = 0, _c = ["//", "%%", "##", "/", "%", "#", "^", "^^", ",", ",,"]; _b < _c.length; _b++) {
                                                     var op = _c[_b];
                                                     if (opStart.includes(op)) {
@@ -2640,7 +2640,7 @@ var Word = /** @class */ (function () {
         while (i < inner.length) {
             var ch = inner[i];
             if (IsWhitespace(ch)) {
-                if (!inWhitespace && normalized.length > 0 && braceDepth === 0 && bracketDepth === 0) {
+                if (!inWhitespace && (normalized.length > 0) && braceDepth === 0 && bracketDepth === 0) {
                     normalized.push(" ");
                     inWhitespace = true;
                 }
@@ -3247,7 +3247,7 @@ var Word = /** @class */ (function () {
                             var prefix = (hasPipe ? "${|" : "${ ");
                             var origInner = Substring(value, i + 2, j - 1);
                             var endsWithNewline = origInner.endsWith("\n");
-                            if (formatted === "" || /^\s$/.test(formatted)) {
+                            if (!(formatted.length > 0) || /^\s$/.test(formatted)) {
                                 var suffix = "}";
                             }
                             else {
@@ -3298,7 +3298,7 @@ var Word = /** @class */ (function () {
                                     var leadingWs = rawContent.slice(0, leadingWsEnd);
                                     var stripped = rawContent.slice(leadingWsEnd);
                                     if (stripped.startsWith("(")) {
-                                        if (leadingWs !== "") {
+                                        if ((leadingWs.length > 0)) {
                                             var normalizedWs = leadingWs.replace(/\n/g, " ").replace(/\t/g, " ");
                                             var spaced = FormatCmdsubNode(node.command, 0, false, false, false);
                                             result.push(direction + "(" + normalizedWs + spaced + ")");
@@ -3325,7 +3325,7 @@ var Word = /** @class */ (function () {
                                 i = j;
                             }
                             else {
-                                if (isProcsub && this.parts.length !== 0) {
+                                if (isProcsub && (this.parts.length !== 0)) {
                                     var direction = value[i];
                                     var j = FindCmdsubEnd(value, i + 2);
                                     if (j > value.length || j > 0 && j <= value.length && value[j - 1] !== ")") {
@@ -3365,7 +3365,7 @@ var Word = /** @class */ (function () {
                                             result.push(direction + "(" + inner + ")");
                                         }
                                         else {
-                                            if (inner.trim() !== "") {
+                                            if ((inner.trim().length > 0)) {
                                                 var stripped = inner.replace(/^[ \t]+/, '');
                                                 result.push(direction + "(" + stripped + ")");
                                             }
@@ -3651,7 +3651,7 @@ var Command = /** @class */ (function () {
         parts.push.apply(parts, this.words.map(function (w) { return w.toSexp(); }));
         parts.push.apply(parts, this.redirects.map(function (r) { return r.toSexp(); }));
         var inner = parts.join(" ");
-        if (inner === "") {
+        if (!(inner.length > 0)) {
             return "(command)";
         }
         return "(command " + inner + ")";
@@ -3781,19 +3781,19 @@ var List = /** @class */ (function () {
                 semiPositions.push(i);
             }
         }
-        if (semiPositions.length > 0) {
+        if ((semiPositions.length > 0)) {
             var segments = [];
             var start = 0;
             for (var _b = 0, _c = semiPositions; _b < _c.length; _b++) {
                 var pos = _c[_b];
                 var seg = Sublist(parts, start, pos);
-                if (seg.length > 0 && seg[0].kind !== "operator") {
+                if ((seg.length > 0) && seg[0].kind !== "operator") {
                     segments.push(seg);
                 }
                 start = pos + 1;
             }
             seg = Sublist(parts, start, parts.length);
-            if (seg.length > 0 && seg[0].kind !== "operator") {
+            if ((seg.length > 0) && seg[0].kind !== "operator") {
                 segments.push(seg);
             }
             if (!(segments.length > 0)) {
@@ -3819,7 +3819,7 @@ var List = /** @class */ (function () {
                 ampPositions.push(i);
             }
         }
-        if (ampPositions.length > 0) {
+        if ((ampPositions.length > 0)) {
             var segments = [];
             var start = 0;
             for (var _b = 0, _c = ampPositions; _b < _c.length; _b++) {
@@ -4152,7 +4152,7 @@ var For = /** @class */ (function () {
     };
     For.prototype.toSexp = function () {
         var suffix = "";
-        if (this.redirects.length > 0) {
+        if ((this.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, this.redirects.map(function (r) { return r.toSexp(); }));
             suffix = " " + redirectParts.join(" ");
@@ -4197,14 +4197,14 @@ var ForArith = /** @class */ (function () {
     };
     ForArith.prototype.toSexp = function () {
         var suffix = "";
-        if (this.redirects.length > 0) {
+        if ((this.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, this.redirects.map(function (r) { return r.toSexp(); }));
             suffix = " " + redirectParts.join(" ");
         }
-        var initVal = (this.init !== "" ? this.init : "1");
-        var condVal = (this.cond !== "" ? this.cond : "1");
-        var incrVal = (this.incr !== "" ? this.incr : "1");
+        var initVal = ((this.init.length > 0) ? this.init : "1");
+        var condVal = ((this.cond.length > 0) ? this.cond : "1");
+        var incrVal = ((this.incr.length > 0) ? this.incr : "1");
         var initStr = FormatArithVal(initVal);
         var condStr = FormatArithVal(condVal);
         var incrStr = FormatArithVal(incrVal);
@@ -4231,7 +4231,7 @@ var Select = /** @class */ (function () {
     };
     Select.prototype.toSexp = function () {
         var suffix = "";
-        if (this.redirects.length > 0) {
+        if ((this.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, this.redirects.map(function (r) { return r.toSexp(); }));
             suffix = " " + redirectParts.join(" ");
@@ -4241,7 +4241,7 @@ var Select = /** @class */ (function () {
             var wordParts = [];
             wordParts.push.apply(wordParts, this.words.map(function (w) { return w.toSexp(); }));
             var wordStrs = wordParts.join(" ");
-            if (this.words.length > 0) {
+            if ((this.words.length > 0)) {
                 var inClause = "(in " + wordStrs + ")";
             }
             else {
@@ -4533,7 +4533,7 @@ var ArithmeticCommand = /** @class */ (function () {
         var formatted = new Word(this.rawContent, [], "word").FormatCommandSubstitutions(this.rawContent, true);
         var escaped = formatted.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
         var result = "(arith (word \"" + escaped + "\"))";
-        if (this.redirects.length > 0) {
+        if ((this.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, this.redirects.map(function (r) { return r.toSexp(); }));
             var redirectSexps = redirectParts.join(" ");
@@ -4918,7 +4918,7 @@ var ConditionalExpr = /** @class */ (function () {
         else {
             var result = "(cond " + body.toSexp() + ")";
         }
-        if (this.redirects.length > 0) {
+        if ((this.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, this.redirects.map(function (r) { return r.toSexp(); }));
             var redirectSexps = redirectParts.join(" ");
@@ -5065,7 +5065,7 @@ var Coproc = /** @class */ (function () {
         return this.kind;
     };
     Coproc.prototype.toSexp = function () {
-        if (this.name !== "") {
+        if ((this.name.length > 0)) {
             var name = this.name;
         }
         else {
@@ -5421,7 +5421,7 @@ var Parser = /** @class */ (function () {
             }
             redirects.push(redirect);
         }
-        return (redirects.length > 0 ? redirects : null);
+        return ((redirects.length > 0) ? redirects : null);
     };
     Parser.prototype.ParseLoopBody = function (context) {
         if (this.peek() === "{") {
@@ -5467,7 +5467,7 @@ var Parser = /** @class */ (function () {
             }
             chars.push(this.advance());
         }
-        if (chars.length > 0) {
+        if ((chars.length > 0)) {
             var word = chars.join("");
         }
         else {
@@ -5906,7 +5906,7 @@ var Parser = /** @class */ (function () {
                     }
                 }
                 var delimiter = delimiterChars.join("");
-                if (delimiter !== "") {
+                if ((delimiter.length > 0)) {
                     pendingHeredocs.push([delimiter, stripTabs]);
                 }
                 continue;
@@ -6940,14 +6940,14 @@ var Parser = /** @class */ (function () {
             }
             var varname = varnameChars.join("");
             var isValidVarfd = false;
-            if (varname !== "") {
+            if ((varname.length > 0)) {
                 if (/^[a-zA-Z]$/.test(varname[0]) || varname[0] === "_") {
                     if (varname.includes("[") || varname.includes("]")) {
                         var left = varname.indexOf("[");
                         var right = varname.lastIndexOf("]");
                         if (left !== -1 && right === varname.length - 1 && right > left + 1) {
                             var base = varname.slice(0, left);
-                            if (base !== "" && (/^[a-zA-Z]$/.test(base[0]) || base[0] === "_")) {
+                            if ((base.length > 0) && (/^[a-zA-Z]$/.test(base[0]) || base[0] === "_")) {
                                 isValidVarfd = true;
                                 for (var _i = 0, _a = base.slice(1); _i < _a.length; _i++) {
                                     var c = _a[_i];
@@ -6979,7 +6979,7 @@ var Parser = /** @class */ (function () {
                 this.pos = saved;
             }
         }
-        if (varfd === "" && this.peek() !== "" && /^[0-9]+$/.test(this.peek())) {
+        if (varfd === "" && (this.peek().length > 0) && /^[0-9]+$/.test(this.peek())) {
             var fdChars = [];
             while (!this.atEnd() && /^[0-9]+$/.test(this.peek())) {
                 fdChars.push(this.advance());
@@ -7105,7 +7105,7 @@ var Parser = /** @class */ (function () {
                     while (!this.atEnd() && /^[0-9]+$/.test(this.peek())) {
                         fdChars.push(this.advance());
                     }
-                    if (fdChars.length > 0) {
+                    if ((fdChars.length > 0)) {
                         var fdTarget = fdChars.join("");
                     }
                     else {
@@ -8382,7 +8382,7 @@ var Parser = /** @class */ (function () {
                 }
             }
             var pattern = patternChars.join("");
-            if (pattern === "") {
+            if (!(pattern.length > 0)) {
                 throw new ParseError("Expected pattern in case statement at position ".concat(this.LexPeekToken().pos), this.LexPeekToken().pos);
             }
             this.skipWhitespace();
@@ -8449,7 +8449,7 @@ var Parser = /** @class */ (function () {
         }
         var wordStart = this.pos;
         var potentialName = this.peekWord();
-        if (potentialName !== "") {
+        if ((potentialName.length > 0)) {
             while (!this.atEnd() && !IsMetachar(this.peek()) && !IsQuote(this.peek())) {
                 this.advance();
             }
@@ -8541,7 +8541,7 @@ var Parser = /** @class */ (function () {
             this.advance();
         }
         name = Substring(this.source, nameStart, this.pos);
-        if (name === "") {
+        if (!(name.length > 0)) {
             this.pos = savedPos;
             return null;
         }
@@ -8565,7 +8565,7 @@ var Parser = /** @class */ (function () {
         var posAfterName = this.pos;
         this.skipWhitespace();
         var hasWhitespace = this.pos > posAfterName;
-        if (!hasWhitespace && name !== "" && "*?@+!$".includes(name[name.length - 1])) {
+        if (!hasWhitespace && (name.length > 0) && "*?@+!$".includes(name[name.length - 1])) {
             this.pos = savedPos;
             return null;
         }
@@ -9087,7 +9087,7 @@ var Parser = /** @class */ (function () {
     };
     Parser.prototype.parse = function () {
         var source = this.source.trim();
-        if (source === "") {
+        if (!(source.length > 0)) {
             return [new Empty("empty")];
         }
         var results = [];
@@ -9128,7 +9128,7 @@ var Parser = /** @class */ (function () {
         if (!(results.length > 0)) {
             return [new Empty("empty")];
         }
-        if (this.SawNewlineInSingleQuote && this.source !== "" && this.source[this.source.length - 1] === "\\" && !(this.source.length >= 3 && this.source.slice(this.source.length - 3, this.source.length - 1) === "\\\n")) {
+        if (this.SawNewlineInSingleQuote && (this.source.length > 0) && this.source[this.source.length - 1] === "\\" && !(this.source.length >= 3 && this.source.slice(this.source.length - 3, this.source.length - 1) === "\\\n")) {
             if (!this.LastWordOnOwnLine(results)) {
                 this.StripTrailingBackslashFromLastWord(results);
             }
@@ -9146,7 +9146,7 @@ var Parser = /** @class */ (function () {
         var lastWord = this.FindLastWord(lastNode);
         if (lastWord !== null && lastWord.value.endsWith("\\")) {
             lastWord.value = Substring(lastWord.value, 0, lastWord.value.length - 1);
-            if (lastWord.value === "" && lastNode instanceof Command && lastNode.words.length > 0) {
+            if (!(lastWord.value.length > 0) && lastNode instanceof Command && (lastNode.words.length > 0)) {
                 lastNode.words.pop();
             }
         }
@@ -9156,29 +9156,29 @@ var Parser = /** @class */ (function () {
             return node;
         }
         if (node instanceof Command) {
-            if (node.words.length > 0) {
+            if ((node.words.length > 0)) {
                 var lastWord = node.words[node.words.length - 1];
                 if (lastWord.value.endsWith("\\")) {
                     return lastWord;
                 }
             }
-            if (node.redirects.length > 0) {
+            if ((node.redirects.length > 0)) {
                 var lastRedirect = node.redirects[node.redirects.length - 1];
                 if (lastRedirect instanceof Redirect) {
                     return lastRedirect.target;
                 }
             }
-            if (node.words.length > 0) {
+            if ((node.words.length > 0)) {
                 return node.words[node.words.length - 1];
             }
         }
         if (node instanceof Pipeline) {
-            if (node.commands.length > 0) {
+            if ((node.commands.length > 0)) {
                 return this.FindLastWord(node.commands[node.commands.length - 1]);
             }
         }
         if (node instanceof List) {
-            if (node.parts.length > 0) {
+            if ((node.parts.length > 0)) {
                 return this.FindLastWord(node.parts[node.parts.length - 1]);
             }
         }
@@ -9295,7 +9295,7 @@ function StripLineContinuationsCommentAware(text) {
     return result.join("");
 }
 function AppendRedirects(base, redirects) {
-    if (redirects.length > 0) {
+    if ((redirects.length > 0)) {
         var parts = [];
         parts.push.apply(parts, redirects.map(function (r) { return r.toSexp(); }));
         return base + " " + parts.join(" ");
@@ -9442,7 +9442,7 @@ function StartsWithSubshell(node) {
         return false;
     }
     if (node instanceof Pipeline) {
-        if (node.commands.length > 0) {
+        if ((node.commands.length > 0)) {
             return StartsWithSubshell(node.commands[0]);
         }
         return false;
@@ -9476,7 +9476,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
             }
         }
         parts.push.apply(parts, node.redirects.map(function (r) { return FormatRedirect(r, compactRedirects, true); }));
-        if (compactRedirects && node.words.length > 0 && node.redirects.length > 0) {
+        if (compactRedirects && (node.words.length > 0) && (node.redirects.length > 0)) {
             var wordParts = parts.slice(0, node.words.length);
             var redirectParts = parts.slice(node.words.length);
             var result = wordParts.join(" ") + redirectParts.join("");
@@ -9514,7 +9514,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
             var formatted = FormatCmdsubNode(cmd, indent, inProcsub, false, procsubFirst && idx === 0);
             var isLast = idx === cmds.length - 1;
             var hasHeredoc = false;
-            if (cmd.kind === "command" && cmd.redirects.length > 0) {
+            if (cmd.kind === "command" && (cmd.redirects.length > 0)) {
                 for (var _g = 0, _h = cmd.redirects; _g < _h.length; _g++) {
                     var r = _h[_g];
                     if (r instanceof HereDoc) {
@@ -9549,7 +9549,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
             }
             idx += 1;
         }
-        var compactPipe = inProcsub && cmds.length > 0 && cmds[0][0].kind === "subshell";
+        var compactPipe = inProcsub && (cmds.length > 0) && cmds[0][0].kind === "subshell";
         var result = "";
         idx = 0;
         while (idx < resultParts.length) {
@@ -9578,7 +9578,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
         var hasHeredoc = false;
         for (var _j = 0, _k = node.parts; _j < _k.length; _j++) {
             var p_1 = _k[_j];
-            if (p_1.kind === "command" && p_1.redirects.length > 0) {
+            if (p_1.kind === "command" && (p_1.redirects.length > 0)) {
                 for (var _l = 0, _m = p_1.redirects; _l < _m.length; _l++) {
                     var r = _m[_l];
                     if (r instanceof HereDoc) {
@@ -9591,7 +9591,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
                 if (p_1 instanceof Pipeline) {
                     for (var _o = 0, _p = p_1.commands; _o < _p.length; _o++) {
                         var cmd_1 = _p[_o];
-                        if (cmd_1.kind === "command" && cmd_1.redirects.length > 0) {
+                        if (cmd_1.kind === "command" && (cmd_1.redirects.length > 0)) {
                             for (var _q = 0, _r = cmd_1.redirects; _q < _r.length; _q++) {
                                 var r = _r[_q];
                                 if (r instanceof HereDoc) {
@@ -9614,7 +9614,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
             var p_2 = _t[_s];
             if (p_2 instanceof Operator) {
                 if (p_2.op === ";") {
-                    if (result.length > 0 && result[result.length - 1].endsWith("\n")) {
+                    if ((result.length > 0) && result[result.length - 1].endsWith("\n")) {
                         skippedSemi = true;
                         continue;
                     }
@@ -9627,11 +9627,11 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
                 }
                 else {
                     if (p_2.op === "\n") {
-                        if (result.length > 0 && result[result.length - 1] === ";") {
+                        if ((result.length > 0) && result[result.length - 1] === ";") {
                             skippedSemi = false;
                             continue;
                         }
-                        if (result.length > 0 && result[result.length - 1].endsWith("\n")) {
+                        if ((result.length > 0) && result[result.length - 1].endsWith("\n")) {
                             result.push((skippedSemi ? " " : "\n"));
                             skippedSemi = false;
                             continue;
@@ -9641,7 +9641,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
                     }
                     else {
                         if (p_2.op === "&") {
-                            if (result.length > 0 && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
+                            if ((result.length > 0) && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
                                 var last = result[result.length - 1];
                                 if (last.includes(" |") || last.startsWith("|")) {
                                     result[result.length - 1] = last + " &";
@@ -9656,7 +9656,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
                             }
                         }
                         else {
-                            if (result.length > 0 && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
+                            if ((result.length > 0) && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
                                 var last = result[result.length - 1];
                                 var firstNl = last.indexOf("\n");
                                 result[result.length - 1] = last.slice(0, firstNl) + " " + p_2.op + " " + last.slice(firstNl);
@@ -9669,7 +9669,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
                 }
             }
             else {
-                if (result.length > 0 && !(result[result.length - 1].endsWith(" ") || result[result.length - 1].endsWith("\n"))) {
+                if ((result.length > 0) && !(result[result.length - 1].endsWith(" ") || result[result.length - 1].endsWith("\n"))) {
                     result.push(" ");
                 }
                 var formattedCmd = FormatCmdsubNode(p_2, indent, inProcsub, compactRedirects, procsubFirst && cmdCount === 0);
@@ -9716,7 +9716,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
         var cond = FormatCmdsubNode(node.condition, indent, false, false, false);
         var body = FormatCmdsubNode(node.body, indent + 4, false, false, false);
         var result = "while " + cond + "; do\n" + innerSp + body + ";\n" + sp + "done";
-        if (node.redirects.length > 0) {
+        if ((node.redirects.length > 0)) {
             for (var _u = 0, _v = node.redirects; _u < _v.length; _u++) {
                 var r = _v[_u];
                 result = result + " " + FormatRedirect(r, false, false);
@@ -9728,7 +9728,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
         var cond = FormatCmdsubNode(node.condition, indent, false, false, false);
         var body = FormatCmdsubNode(node.body, indent + 4, false, false, false);
         var result = "until " + cond + "; do\n" + innerSp + body + ";\n" + sp + "done";
-        if (node.redirects.length > 0) {
+        if ((node.redirects.length > 0)) {
             for (var _w = 0, _x = node.redirects; _w < _x.length; _w++) {
                 var r = _x[_w];
                 result = result + " " + FormatRedirect(r, false, false);
@@ -9743,7 +9743,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
             var wordVals = [];
             wordVals.push.apply(wordVals, node.words.map(function (w) { return w.value; }));
             var words = wordVals.join(" ");
-            if (words !== "") {
+            if ((words.length > 0)) {
                 var result = "for " + varName + " in " + words + ";\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
             }
             else {
@@ -9753,7 +9753,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
         else {
             var result = "for " + varName + " in \"$@\";\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
         }
-        if (node.redirects.length > 0) {
+        if ((node.redirects.length > 0)) {
             for (var _y = 0, _z = node.redirects; _y < _z.length; _y++) {
                 var r = _z[_y];
                 var result = result + " " + FormatRedirect(r, false, false);
@@ -9764,7 +9764,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
     if (node instanceof ForArith) {
         var body = FormatCmdsubNode(node.body, indent + 4, false, false, false);
         var result = "for ((" + node.init + "; " + node.cond + "; " + node.incr + "))\ndo\n" + innerSp + body + ";\n" + sp + "done";
-        if (node.redirects.length > 0) {
+        if ((node.redirects.length > 0)) {
             for (var _0 = 0, _1 = node.redirects; _0 < _1.length; _0++) {
                 var r = _1[_0];
                 result = result + " " + FormatRedirect(r, false, false);
@@ -9788,7 +9788,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
             var term = p.terminator;
             var patIndent = RepeatStr(" ", indent + 8);
             var termIndent = RepeatStr(" ", indent + 4);
-            var bodyPart = (body !== "" ? patIndent + body + "\n" : "\n");
+            var bodyPart = ((body.length > 0) ? patIndent + body + "\n" : "\n");
             if (i === 0) {
                 patterns.push(" " + pat + ")\n" + bodyPart + termIndent + term);
             }
@@ -9799,7 +9799,7 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
         }
         var patternStr = patterns.join("\n" + RepeatStr(" ", indent + 4));
         var redirects = "";
-        if (node.redirects.length > 0) {
+        if ((node.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, node.redirects.map(function (r) { return FormatRedirect(r, false, false); }));
             redirects = " " + redirectParts.join(" ");
@@ -9815,18 +9815,18 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
     if (node instanceof Subshell) {
         var body = FormatCmdsubNode(node.body, indent, inProcsub, compactRedirects, false);
         var redirects = "";
-        if (node.redirects.length > 0) {
+        if ((node.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, node.redirects.map(function (r) { return FormatRedirect(r, false, false); }));
             redirects = redirectParts.join(" ");
         }
         if (procsubFirst) {
-            if (redirects !== "") {
+            if ((redirects.length > 0)) {
                 return "(" + body + ") " + redirects;
             }
             return "(" + body + ")";
         }
-        if (redirects !== "") {
+        if ((redirects.length > 0)) {
             return "( " + body + " ) " + redirects;
         }
         return "( " + body + " )";
@@ -9836,12 +9836,12 @@ function FormatCmdsubNode(node, indent, inProcsub, compactRedirects, procsubFirs
         body = body.replace(/[;]+$/, '');
         var terminator = (body.endsWith(" &") ? " }" : "; }");
         var redirects = "";
-        if (node.redirects.length > 0) {
+        if ((node.redirects.length > 0)) {
             var redirectParts = [];
             redirectParts.push.apply(redirectParts, node.redirects.map(function (r) { return FormatRedirect(r, false, false); }));
             redirects = redirectParts.join(" ");
         }
-        if (redirects !== "") {
+        if ((redirects.length > 0)) {
             return "{ " + body + terminator + " " + redirects;
         }
         return "{ " + body + terminator;
@@ -10749,7 +10749,7 @@ function IsWordEndContext(c) {
 }
 function SkipMatchedPair(s, start, open, close, flags) {
     var n = s.length;
-    if ((flags & _SMP_PAST_OPEN) !== 0) {
+    if (((flags & _SMP_PAST_OPEN) !== 0)) {
         var i = start;
     }
     else {
@@ -10769,7 +10769,7 @@ function SkipMatchedPair(s, start, open, close, flags) {
             continue;
         }
         var literal = flags & _SMP_LITERAL;
-        if (literal === 0 && c === "\\") {
+        if (!(literal !== 0) && c === "\\") {
             passNext = true;
             i += 1;
             continue;
@@ -10781,28 +10781,28 @@ function SkipMatchedPair(s, start, open, close, flags) {
             i += 1;
             continue;
         }
-        if (literal === 0 && c === "`") {
+        if (!(literal !== 0) && c === "`") {
             backq = true;
             i += 1;
             continue;
         }
-        if (literal === 0 && c === "'") {
+        if (!(literal !== 0) && c === "'") {
             var i = SkipSingleQuoted(s, i + 1);
             continue;
         }
-        if (literal === 0 && c === "\"") {
+        if (!(literal !== 0) && c === "\"") {
             var i = SkipDoubleQuoted(s, i + 1);
             continue;
         }
-        if (literal === 0 && IsExpansionStart(s, i, "$(")) {
+        if (!(literal !== 0) && IsExpansionStart(s, i, "$(")) {
             var i = FindCmdsubEnd(s, i + 2);
             continue;
         }
-        if (literal === 0 && IsExpansionStart(s, i, "${")) {
+        if (!(literal !== 0) && IsExpansionStart(s, i, "${")) {
             var i = FindBracedParamEnd(s, i + 2);
             continue;
         }
-        if (literal === 0 && c === open) {
+        if (!(literal !== 0) && c === open) {
             depth += 1;
         }
         else {
@@ -10818,7 +10818,7 @@ function SkipSubscript(s, start, flags) {
     return SkipMatchedPair(s, start, "[", "]", flags);
 }
 function Assignment(s, flags) {
-    if (s === "") {
+    if (!(s.length > 0)) {
         return -1;
     }
     if (!(/^[a-zA-Z]$/.test(s[0]) || s[0] === "_")) {
@@ -10831,7 +10831,7 @@ function Assignment(s, flags) {
             return i;
         }
         if (c === "[") {
-            var subFlags = ((flags & 2) !== 0 ? _SMP_LITERAL : 0);
+            var subFlags = (((flags & 2) !== 0) ? _SMP_LITERAL : 0);
             var end = SkipSubscript(s, i, subFlags);
             if (end === -1) {
                 return -1;
@@ -10937,7 +10937,7 @@ function LooksLikeAssignment(s) {
     return Assignment(s, 0) !== -1;
 }
 function IsValidIdentifier(name) {
-    if (name === "") {
+    if (!(name.length > 0)) {
         return false;
     }
     if (!(/^[a-zA-Z]$/.test(name[0]) || name[0] === "_")) {

--- a/dist/ts/parable.ts
+++ b/dist/ts/parable.ts
@@ -162,7 +162,7 @@ class Token {
     if (this.word !== null) {
       return `Token(${this.typeName}, ${this.value}, ${this.pos}, word=${this.word})`;
     }
-    if (this.parts.length > 0) {
+    if ((this.parts.length > 0)) {
       return `Token(${this.typeName}, ${this.value}, ${this.pos}, parts=${this.parts.length})`;
     }
     return `Token(${this.typeName}, ${this.value}, ${this.pos})`;
@@ -212,7 +212,7 @@ class QuoteState {
   }
 
   pop(): void {
-    if (this.Stack.length > 0) {
+    if ((this.Stack.length > 0)) {
       [this.single, this.double] = this.Stack.pop();
     }
   }
@@ -585,7 +585,7 @@ class Lexer {
       }
       return IsWhitespace(ch);
     }
-    if ((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0 && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
+    if (((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0) && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
       return true;
     }
     if (IsRedirectChar(ch) && this.pos + 1 < this.length && this.source[this.pos + 1] === "(") {
@@ -719,7 +719,7 @@ class Lexer {
         throw new MatchedPairError()
       }
       var ch: any = this.advance();
-      if ((flags & MatchedPairFlags_DOLBRACE) !== 0 && this.DolbraceState === DolbraceState_OP) {
+      if (((flags & MatchedPairFlags_DOLBRACE) !== 0) && this.DolbraceState === DolbraceState_OP) {
         if (!"#%^,~:-=?+/".includes(ch)) {
           this.DolbraceState = DolbraceState_WORD;
         }
@@ -738,7 +738,7 @@ class Lexer {
             break;
           }
         }
-        if (ch === "\\" && (flags & MatchedPairFlags_ALLOWESC) !== 0) {
+        if (ch === "\\" && ((flags & MatchedPairFlags_ALLOWESC) !== 0)) {
           passNext = true;
         }
         chars.push(ch);
@@ -770,7 +770,7 @@ class Lexer {
         continue;
       }
       if (ch === openChar && openChar !== closeChar) {
-        if (!((flags & MatchedPairFlags_DOLBRACE) !== 0 && openChar === "{")) {
+        if (!(((flags & MatchedPairFlags_DOLBRACE) !== 0) && openChar === "{")) {
           count += 1;
         }
         chars.push(ch);
@@ -810,7 +810,7 @@ class Lexer {
           }
         }
       }
-      if (ch === "$" && !this.atEnd() && (flags & MatchedPairFlags_EXTGLOB) === 0) {
+      if (ch === "$" && !this.atEnd() && !((flags & MatchedPairFlags_EXTGLOB) !== 0)) {
         var nextCh: any = this.peek();
         if (wasDollar) {
           chars.push(ch);
@@ -819,7 +819,7 @@ class Lexer {
           continue;
         }
         if (nextCh === "{") {
-          if ((flags & MatchedPairFlags_ARITH) !== 0) {
+          if (((flags & MatchedPairFlags_ARITH) !== 0)) {
             var afterBracePos: any = this.pos + 1;
             if (afterBracePos >= this.length || !IsFunsubChar(this.source[afterBracePos])) {
               chars.push(ch);
@@ -904,7 +904,7 @@ class Lexer {
           }
         }
       }
-      if (ch === "(" && wasGtlt && (flags & (MatchedPairFlags_DOLBRACE | MatchedPairFlags_ARRAYSUB)) !== 0) {
+      if (ch === "(" && wasGtlt && ((flags & (MatchedPairFlags_DOLBRACE | MatchedPairFlags_ARRAYSUB)) !== 0)) {
         {
           var direction: any = chars[chars.length - 1];
           chars = chars.slice(0, chars.length - 1);
@@ -962,7 +962,7 @@ class Lexer {
           chars.push(this.advance());
           continue;
         }
-        if (chars.length > 0 && atCommandStart && !seenEquals && IsArrayAssignmentPrefix(chars)) {
+        if ((chars.length > 0) && atCommandStart && !seenEquals && IsArrayAssignmentPrefix(chars)) {
           var prevChar: any = chars[chars.length - 1];
           if (/^[a-zA-Z0-9]$/.test(prevChar) || prevChar === "_") {
             bracketStartPos = this.pos;
@@ -1008,7 +1008,7 @@ class Lexer {
         continue;
       }
       if (ctx === WORD_CTX_COND && ch === "(") {
-        if (this.Extglob && chars.length > 0 && IsExtglobPrefix(chars[chars.length - 1])) {
+        if (this.Extglob && (chars.length > 0) && IsExtglobPrefix(chars[chars.length - 1])) {
           chars.push(this.advance());
           var content: any = this.ParseMatchedPair("(", ")", MatchedPairFlags_EXTGLOB, false);
           chars.push(content);
@@ -1133,7 +1133,7 @@ class Lexer {
           chars.push(this.advance());
         } else {
           this.SyncFromParser();
-          if (this.Extglob && ctx === WORD_CTX_NORMAL && chars.length > 0 && chars[chars.length - 1].length === 2 && chars[chars.length - 1][0] === "$" && "?*@".includes(chars[chars.length - 1][1]) && !this.atEnd() && this.peek() === "(") {
+          if (this.Extglob && ctx === WORD_CTX_NORMAL && (chars.length > 0) && chars[chars.length - 1].length === 2 && chars[chars.length - 1][0] === "$" && "?*@".includes(chars[chars.length - 1][1]) && !this.atEnd() && this.peek() === "(") {
             chars.push(this.advance());
             var content: any = this.ParseMatchedPair("(", ")", MatchedPairFlags_EXTGLOB, false);
             chars.push(content);
@@ -1162,7 +1162,7 @@ class Lexer {
           parts.push(procsubResult0);
           chars.push(procsubResult1);
         } else {
-          if (procsubResult1 !== "") {
+          if ((procsubResult1.length > 0)) {
             chars.push(procsubResult1);
           } else {
             chars.push(this.advance());
@@ -1173,7 +1173,7 @@ class Lexer {
         }
         continue;
       }
-      if (ctx === WORD_CTX_NORMAL && ch === "(" && chars.length > 0 && bracketDepth === 0) {
+      if (ctx === WORD_CTX_NORMAL && ch === "(" && (chars.length > 0) && bracketDepth === 0) {
         var isArrayAssign: any = false;
         if (chars.length >= 3 && chars[chars.length - 2] === "+" && chars[chars.length - 1] === "=") {
           isArrayAssign = IsArrayAssignmentPrefix(chars.slice(0, chars.length - 2));
@@ -1203,7 +1203,7 @@ class Lexer {
         chars.push(")");
         continue;
       }
-      if (ctx === WORD_CTX_NORMAL && (this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0 && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
+      if (ctx === WORD_CTX_NORMAL && ((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0) && this.EofToken !== "" && ch === this.EofToken && bracketDepth === 0) {
         if (!(chars.length > 0)) {
           chars.push(this.advance());
         }
@@ -1220,7 +1220,7 @@ class Lexer {
     if (!(chars.length > 0)) {
       return null;
     }
-    if (parts.length > 0) {
+    if ((parts.length > 0)) {
       return new Word(chars.join("") as any, parts as any, "word" as any);
     }
     return new Word(chars.join("") as any, null as any, "word" as any);
@@ -1260,7 +1260,7 @@ class Lexer {
       this.LastReadToken = tok;
       return tok;
     }
-    if (this.EofToken !== "" && this.peek() === this.EofToken && (this.ParserState & ParserStateFlags_PST_CASEPAT) === 0 && (this.ParserState & ParserStateFlags_PST_EOFTOKEN) === 0) {
+    if (this.EofToken !== "" && this.peek() === this.EofToken && !((this.ParserState & ParserStateFlags_PST_CASEPAT) !== 0) && !((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0)) {
       var tok: any = new Token(TokenType_EOF as any, "" as any, this.pos as any, [], null);
       this.LastReadToken = tok;
       return tok;
@@ -1272,7 +1272,7 @@ class Lexer {
         this.LastReadToken = tok;
         return tok;
       }
-      if (this.EofToken !== "" && this.peek() === this.EofToken && (this.ParserState & ParserStateFlags_PST_CASEPAT) === 0 && (this.ParserState & ParserStateFlags_PST_EOFTOKEN) === 0) {
+      if (this.EofToken !== "" && this.peek() === this.EofToken && !((this.ParserState & ParserStateFlags_PST_CASEPAT) !== 0) && !((this.ParserState & ParserStateFlags_PST_EOFTOKEN) !== 0)) {
         var tok: any = new Token(TokenType_EOF as any, "" as any, this.pos as any, [], null);
         this.LastReadToken = tok;
         return tok;
@@ -1653,7 +1653,7 @@ class Lexer {
           }
         }
       }
-      if (nameChars.length > 0) {
+      if ((nameChars.length > 0)) {
         return nameChars.join("");
       } else {
         return "";
@@ -1714,7 +1714,7 @@ class Lexer {
     if (ch === "#") {
       this.advance();
       var param: any = this.ConsumeParamName();
-      if (param !== "" && !this.atEnd() && this.peek() === "}") {
+      if ((param.length > 0) && !this.atEnd() && this.peek() === "}") {
         this.advance();
         var text: any = Substring(this.source, start, this.pos);
         this.DolbraceState = savedDolbrace;
@@ -1728,7 +1728,7 @@ class Lexer {
         this.advance();
       }
       var param: any = this.ConsumeParamName();
-      if (param !== "") {
+      if ((param.length > 0)) {
         while (!this.atEnd() && IsWhitespaceNoNewline(this.peek())) {
           this.advance();
         }
@@ -1765,7 +1765,7 @@ class Lexer {
       }
     }
     var param: any = this.ConsumeParamName();
-    if (param === "") {
+    if (!(param.length > 0)) {
       if (!this.atEnd() && ("-=+?".includes(this.peek()) || this.peek() === ":" && this.pos + 1 < this.length && IsSimpleParamOp(this.source[this.pos + 1]))) {
         param = "";
       } else {
@@ -2012,7 +2012,7 @@ class Word implements Node {
   }
 
   ShSingleQuote(s: string): string {
-    if (s === "") {
+    if (!(s.length > 0)) {
       return "''";
     }
     if (s === "'") {
@@ -2055,7 +2055,7 @@ class Word implements Node {
                 if (j < inner.length && inner[j] === "}") {
                   j += 1;
                 }
-                if (hexStr === "") {
+                if (!(hexStr.length > 0)) {
                   return result;
                 }
                 var byteVal: any = parseInt(hexStr, 16) & 255;
@@ -2278,7 +2278,7 @@ class Word implements Node {
                   if (lastBraceIdx >= 0) {
                     var afterBrace: any = resultStr.slice(lastBraceIdx + 2);
                     var varNameLen: any = 0;
-                    if (afterBrace !== "") {
+                    if ((afterBrace.length > 0)) {
                       if ("@*#?-$!0123456789_".includes(afterBrace[0])) {
                         varNameLen = 1;
                       } else {
@@ -2304,7 +2304,7 @@ class Word implements Node {
                           break;
                         }
                       }
-                      if (!inPattern && opStart !== "" && !"%#/^,~:+-=?".includes(opStart[0])) {
+                      if (!inPattern && (opStart.length > 0) && !"%#/^,~:+-=?".includes(opStart[0])) {
                         for (const op of ["//", "%%", "##", "/", "%", "#", "^", "^^", ",", ",,"] as string[]) {
                           if (opStart.includes(op)) {
                             inPattern = true;
@@ -2550,7 +2550,7 @@ class Word implements Node {
     while (i < inner.length) {
       var ch: any = inner[i];
       if (IsWhitespace(ch)) {
-        if (!inWhitespace && normalized.length > 0 && braceDepth === 0 && bracketDepth === 0) {
+        if (!inWhitespace && (normalized.length > 0) && braceDepth === 0 && bracketDepth === 0) {
           normalized.push(" ");
           inWhitespace = true;
         }
@@ -3095,7 +3095,7 @@ class Word implements Node {
               var prefix: any = (hasPipe ? "${|" : "${ ");
               var origInner: any = Substring(value, i + 2, j - 1);
               var endsWithNewline: any = origInner.endsWith("\n");
-              if (formatted === "" || /^\s$/.test(formatted)) {
+              if (!(formatted.length > 0) || /^\s$/.test(formatted)) {
                 var suffix: any = "}";
               } else {
                 if (formatted.endsWith("&") || formatted.endsWith("& ")) {
@@ -3141,7 +3141,7 @@ class Word implements Node {
                   var leadingWs: any = rawContent.slice(0, leadingWsEnd);
                   var stripped: any = rawContent.slice(leadingWsEnd);
                   if (stripped.startsWith("(")) {
-                    if (leadingWs !== "") {
+                    if ((leadingWs.length > 0)) {
                       var normalizedWs: any = leadingWs.replace(/\n/g, " ").replace(/\t/g, " ");
                       var spaced: any = FormatCmdsubNode((node as unknown as ProcessSubstitution).command, 0, false, false, false);
                       result.push(direction + "(" + normalizedWs + spaced + ")");
@@ -3165,7 +3165,7 @@ class Word implements Node {
                 procsubIdx += 1;
                 i = j;
               } else {
-                if (isProcsub && this.parts.length !== 0) {
+                if (isProcsub && (this.parts.length !== 0)) {
                   var direction: any = value[i];
                   var j: any = FindCmdsubEnd(value, i + 2);
                   if (j > value.length || j > 0 && j <= value.length && value[j - 1] !== ")") {
@@ -3201,7 +3201,7 @@ class Word implements Node {
                     if (inArith) {
                       result.push(direction + "(" + inner + ")");
                     } else {
-                      if (inner.trim() !== "") {
+                      if ((inner.trim().length > 0)) {
                         var stripped: any = inner.replace(/^[ \t]+/, '');
                         result.push(direction + "(" + stripped + ")");
                       } else {
@@ -3466,7 +3466,7 @@ class Command implements Node {
     parts.push(...this.words.map(w => w.toSexp()));
     parts.push(...this.redirects.map(r => r.toSexp()));
     var inner: any = parts.join(" ");
-    if (inner === "") {
+    if (!(inner.length > 0)) {
       return "(command)";
     }
     return "(command " + inner + ")";
@@ -3599,18 +3599,18 @@ class List implements Node {
         semiPositions.push(i);
       }
     }
-    if (semiPositions.length > 0) {
+    if ((semiPositions.length > 0)) {
       var segments: any = [];
       var start: any = 0;
       for (const pos of semiPositions as number[]) {
         var seg: any = Sublist(parts, start, pos);
-        if (seg.length > 0 && seg[0].kind !== "operator") {
+        if ((seg.length > 0) && seg[0].kind !== "operator") {
           segments.push(seg);
         }
         start = pos + 1;
       }
       seg = Sublist(parts, start, parts.length);
-      if (seg.length > 0 && seg[0].kind !== "operator") {
+      if ((seg.length > 0) && seg[0].kind !== "operator") {
         segments.push(seg);
       }
       if (!(segments.length > 0)) {
@@ -3635,7 +3635,7 @@ class List implements Node {
         ampPositions.push(i);
       }
     }
-    if (ampPositions.length > 0) {
+    if ((ampPositions.length > 0)) {
       var segments: any = [];
       var start: any = 0;
       for (const pos of ampPositions as number[]) {
@@ -3998,7 +3998,7 @@ class For implements Node {
 
   toSexp(): string {
     var suffix: any = "";
-    if (this.redirects.length > 0) {
+    if ((this.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...this.redirects.map(r => r.toSexp()));
       suffix = " " + redirectParts.join(" ");
@@ -4044,14 +4044,14 @@ class ForArith implements Node {
 
   toSexp(): string {
     var suffix: any = "";
-    if (this.redirects.length > 0) {
+    if ((this.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...this.redirects.map(r => r.toSexp()));
       suffix = " " + redirectParts.join(" ");
     }
-    var initVal: any = (this.init !== "" ? this.init : "1");
-    var condVal: any = (this.cond !== "" ? this.cond : "1");
-    var incrVal: any = (this.incr !== "" ? this.incr : "1");
+    var initVal: any = ((this.init.length > 0) ? this.init : "1");
+    var condVal: any = ((this.cond.length > 0) ? this.cond : "1");
+    var incrVal: any = ((this.incr.length > 0) ? this.incr : "1");
     var initStr: any = FormatArithVal(initVal);
     var condStr: any = FormatArithVal(condVal);
     var incrStr: any = FormatArithVal(incrVal);
@@ -4081,7 +4081,7 @@ class Select implements Node {
 
   toSexp(): string {
     var suffix: any = "";
-    if (this.redirects.length > 0) {
+    if ((this.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...this.redirects.map(r => r.toSexp()));
       suffix = " " + redirectParts.join(" ");
@@ -4091,7 +4091,7 @@ class Select implements Node {
       var wordParts: any = [];
       wordParts.push(...this.words.map(w => w.toSexp()));
       var wordStrs: any = wordParts.join(" ");
-      if (this.words.length > 0) {
+      if ((this.words.length > 0)) {
         var inClause: any = "(in " + wordStrs + ")";
       } else {
         var inClause: any = "(in)";
@@ -4396,7 +4396,7 @@ class ArithmeticCommand implements Node {
     var formatted: any = new Word(this.rawContent as any, [], "word" as any).FormatCommandSubstitutions(this.rawContent, true);
     var escaped: any = formatted.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
     var result: any = "(arith (word \"" + escaped + "\"))";
-    if (this.redirects.length > 0) {
+    if ((this.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...this.redirects.map(r => r.toSexp()));
       var redirectSexps: any = redirectParts.join(" ");
@@ -4845,7 +4845,7 @@ class ConditionalExpr implements Node {
     } else {
       var result: any = "(cond " + body.toSexp() + ")";
     }
-    if (this.redirects.length > 0) {
+    if ((this.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...this.redirects.map(r => r.toSexp()));
       var redirectSexps: any = redirectParts.join(" ");
@@ -5016,7 +5016,7 @@ class Coproc implements Node {
   }
 
   toSexp(): string {
-    if (this.name !== "") {
+    if ((this.name.length > 0)) {
       var name: any = this.name;
     } else {
       var name: any = "COPROC";
@@ -5396,7 +5396,7 @@ class Parser {
       }
       redirects.push(redirect);
     }
-    return (redirects.length > 0 ? redirects : null);
+    return ((redirects.length > 0) ? redirects : null);
   }
 
   ParseLoopBody(context: string): Node {
@@ -5444,7 +5444,7 @@ class Parser {
       }
       chars.push(this.advance());
     }
-    if (chars.length > 0) {
+    if ((chars.length > 0)) {
       var word: any = chars.join("");
     } else {
       var word: any = "";
@@ -5873,7 +5873,7 @@ class Parser {
           }
         }
         var delimiter: any = delimiterChars.join("");
-        if (delimiter !== "") {
+        if ((delimiter.length > 0)) {
           pendingHeredocs.push([delimiter, stripTabs]);
         }
         continue;
@@ -6890,14 +6890,14 @@ class Parser {
       }
       var varname: any = varnameChars.join("");
       var isValidVarfd: any = false;
-      if (varname !== "") {
+      if ((varname.length > 0)) {
         if (/^[a-zA-Z]$/.test(varname[0]) || varname[0] === "_") {
           if (varname.includes("[") || varname.includes("]")) {
             var left: any = varname.indexOf("[");
             var right: any = varname.lastIndexOf("]");
             if (left !== -1 && right === varname.length - 1 && right > left + 1) {
               var base: any = varname.slice(0, left);
-              if (base !== "" && (/^[a-zA-Z]$/.test(base[0]) || base[0] === "_")) {
+              if ((base.length > 0) && (/^[a-zA-Z]$/.test(base[0]) || base[0] === "_")) {
                 isValidVarfd = true;
                 for (const c of base.slice(1)) {
                   if (!(/^[a-zA-Z0-9]$/.test(c) || c === "_")) {
@@ -6925,7 +6925,7 @@ class Parser {
         this.pos = saved;
       }
     }
-    if (varfd === "" && this.peek() !== "" && /^[0-9]+$/.test(this.peek())) {
+    if (varfd === "" && (this.peek().length > 0) && /^[0-9]+$/.test(this.peek())) {
       var fdChars: any = [];
       while (!this.atEnd() && /^[0-9]+$/.test(this.peek())) {
         fdChars.push(this.advance());
@@ -7040,7 +7040,7 @@ class Parser {
           while (!this.atEnd() && /^[0-9]+$/.test(this.peek())) {
             fdChars.push(this.advance());
           }
-          if (fdChars.length > 0) {
+          if ((fdChars.length > 0)) {
             var fdTarget: any = fdChars.join("");
           } else {
             var fdTarget: any = "";
@@ -8268,7 +8268,7 @@ class Parser {
         }
       }
       var pattern: any = patternChars.join("");
-      if (pattern === "") {
+      if (!(pattern.length > 0)) {
         throw new ParseError(`Expected pattern in case statement at position ${this.LexPeekToken().pos}`, this.LexPeekToken().pos)
       }
       this.skipWhitespace();
@@ -8336,7 +8336,7 @@ class Parser {
     }
     var wordStart: any = this.pos;
     var potentialName: any = this.peekWord();
-    if (potentialName !== "") {
+    if ((potentialName.length > 0)) {
       while (!this.atEnd() && !IsMetachar(this.peek()) && !IsQuote(this.peek())) {
         this.advance();
       }
@@ -8426,7 +8426,7 @@ class Parser {
       this.advance();
     }
     name = Substring(this.source, nameStart, this.pos);
-    if (name === "") {
+    if (!(name.length > 0)) {
       this.pos = savedPos;
       return null;
     }
@@ -8450,7 +8450,7 @@ class Parser {
     var posAfterName: any = this.pos;
     this.skipWhitespace();
     var hasWhitespace: any = this.pos > posAfterName;
-    if (!hasWhitespace && name !== "" && "*?@+!$".includes(name[name.length - 1])) {
+    if (!hasWhitespace && (name.length > 0) && "*?@+!$".includes(name[name.length - 1])) {
       this.pos = savedPos;
       return null;
     }
@@ -8963,7 +8963,7 @@ class Parser {
 
   parse(): Node[] {
     var source: any = this.source.trim();
-    if (source === "") {
+    if (!(source.length > 0)) {
       return [new Empty("empty" as any)];
     }
     var results: any = [];
@@ -9004,7 +9004,7 @@ class Parser {
     if (!(results.length > 0)) {
       return [new Empty("empty" as any)];
     }
-    if (this.SawNewlineInSingleQuote && this.source !== "" && this.source[this.source.length - 1] === "\\" && !(this.source.length >= 3 && this.source.slice(this.source.length - 3, this.source.length - 1) === "\\\n")) {
+    if (this.SawNewlineInSingleQuote && (this.source.length > 0) && this.source[this.source.length - 1] === "\\" && !(this.source.length >= 3 && this.source.slice(this.source.length - 3, this.source.length - 1) === "\\\n")) {
       if (!this.LastWordOnOwnLine(results)) {
         this.StripTrailingBackslashFromLastWord(results);
       }
@@ -9024,7 +9024,7 @@ class Parser {
     var lastWord: any = this.FindLastWord(lastNode);
     if (lastWord !== null && lastWord.value.endsWith("\\")) {
       lastWord.value = Substring(lastWord.value, 0, lastWord.value.length - 1);
-      if (lastWord.value === "" && lastNode instanceof Command && (lastNode as unknown as Command).words.length > 0) {
+      if (!(lastWord.value.length > 0) && lastNode instanceof Command && ((lastNode as unknown as Command).words.length > 0)) {
         (lastNode as unknown as Command).words.pop();
       }
     }
@@ -9035,29 +9035,29 @@ class Parser {
       return node;
     }
     if (node instanceof Command) {
-      if (node.words.length > 0) {
+      if ((node.words.length > 0)) {
         var lastWord: any = node.words[node.words.length - 1];
         if (lastWord.value.endsWith("\\")) {
           return lastWord;
         }
       }
-      if (node.redirects.length > 0) {
+      if ((node.redirects.length > 0)) {
         var lastRedirect: any = node.redirects[node.redirects.length - 1];
         if (lastRedirect instanceof Redirect) {
           return lastRedirect.target;
         }
       }
-      if (node.words.length > 0) {
+      if ((node.words.length > 0)) {
         return node.words[node.words.length - 1];
       }
     }
     if (node instanceof Pipeline) {
-      if (node.commands.length > 0) {
+      if ((node.commands.length > 0)) {
         return this.FindLastWord(node.commands[node.commands.length - 1]);
       }
     }
     if (node instanceof List) {
-      if (node.parts.length > 0) {
+      if ((node.parts.length > 0)) {
         return this.FindLastWord(node.parts[node.parts.length - 1]);
       }
     }
@@ -9184,7 +9184,7 @@ function StripLineContinuationsCommentAware(text: string): string {
 }
 
 function AppendRedirects(base: string, redirects: Node[]): string {
-  if (redirects.length > 0) {
+  if ((redirects.length > 0)) {
     var parts: any = [];
     parts.push(...redirects.map(r => r.toSexp()));
     return base + " " + parts.join(" ");
@@ -9337,7 +9337,7 @@ function StartsWithSubshell(node: Node): boolean {
     return false;
   }
   if (node instanceof Pipeline) {
-    if (node.commands.length > 0) {
+    if ((node.commands.length > 0)) {
       return StartsWithSubshell(node.commands[0]);
     }
     return false;
@@ -9370,7 +9370,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
       }
     }
     parts.push(...node.redirects.map(r => FormatRedirect(r, compactRedirects, true)));
-    if (compactRedirects && node.words.length > 0 && node.redirects.length > 0) {
+    if (compactRedirects && (node.words.length > 0) && (node.redirects.length > 0)) {
       var wordParts: any = parts.slice(0, node.words.length);
       var redirectParts: any = parts.slice(node.words.length);
       var result: any = wordParts.join(" ") + redirectParts.join("");
@@ -9406,7 +9406,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
       var formatted: any = FormatCmdsubNode(cmd, indent, inProcsub, false, procsubFirst && idx === 0);
       var isLast: any = idx === cmds.length - 1;
       var hasHeredoc: any = false;
-      if (cmd.kind === "command" && (cmd as unknown as Command).redirects.length > 0) {
+      if (cmd.kind === "command" && ((cmd as unknown as Command).redirects.length > 0)) {
         for (const r of (cmd as unknown as Command).redirects as Node[]) {
           if (r instanceof HereDoc) {
             hasHeredoc = true;
@@ -9437,7 +9437,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
       }
       idx += 1;
     }
-    var compactPipe: any = inProcsub && cmds.length > 0 && cmds[0][0].kind === "subshell";
+    var compactPipe: any = inProcsub && (cmds.length > 0) && cmds[0][0].kind === "subshell";
     var result: any = "";
     idx = 0;
     while (idx < resultParts.length) {
@@ -9462,7 +9462,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
   if (node instanceof List) {
     var hasHeredoc: any = false;
     for (const p of node.parts as Node[]) {
-      if (p.kind === "command" && (p as unknown as Command).redirects.length > 0) {
+      if (p.kind === "command" && ((p as unknown as Command).redirects.length > 0)) {
         for (const r of (p as unknown as Command).redirects as Node[]) {
           if (r instanceof HereDoc) {
             hasHeredoc = true;
@@ -9472,7 +9472,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
       } else {
         if (p instanceof Pipeline) {
           for (const cmd of p.commands as Node[]) {
-            if (cmd.kind === "command" && (cmd as unknown as Command).redirects.length > 0) {
+            if (cmd.kind === "command" && ((cmd as unknown as Command).redirects.length > 0)) {
               for (const r of (cmd as unknown as Command).redirects as Node[]) {
                 if (r instanceof HereDoc) {
                   hasHeredoc = true;
@@ -9493,7 +9493,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
     for (const p of node.parts as Node[]) {
       if (p instanceof Operator) {
         if (p.op === ";") {
-          if (result.length > 0 && result[result.length - 1].endsWith("\n")) {
+          if ((result.length > 0) && result[result.length - 1].endsWith("\n")) {
             skippedSemi = true;
             continue;
           }
@@ -9505,11 +9505,11 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
           skippedSemi = false;
         } else {
           if (p.op === "\n") {
-            if (result.length > 0 && result[result.length - 1] === ";") {
+            if ((result.length > 0) && result[result.length - 1] === ";") {
               skippedSemi = false;
               continue;
             }
-            if (result.length > 0 && result[result.length - 1].endsWith("\n")) {
+            if ((result.length > 0) && result[result.length - 1].endsWith("\n")) {
               result.push((skippedSemi ? " " : "\n"));
               skippedSemi = false;
               continue;
@@ -9518,7 +9518,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
             skippedSemi = false;
           } else {
             if (p.op === "&") {
-              if (result.length > 0 && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
+              if ((result.length > 0) && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
                 var last: any = result[result.length - 1];
                 if (last.includes(" |") || last.startsWith("|")) {
                   result[result.length - 1] = last + " &";
@@ -9530,7 +9530,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
                 result.push(" &");
               }
             } else {
-              if (result.length > 0 && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
+              if ((result.length > 0) && result[result.length - 1].includes("<<") && result[result.length - 1].includes("\n")) {
                 var last: any = result[result.length - 1];
                 var firstNl: any = last.indexOf("\n");
                 result[result.length - 1] = last.slice(0, firstNl) + " " + p.op + " " + last.slice(firstNl);
@@ -9541,7 +9541,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
           }
         }
       } else {
-        if (result.length > 0 && !(result[result.length - 1].endsWith(" ") || result[result.length - 1].endsWith("\n"))) {
+        if ((result.length > 0) && !(result[result.length - 1].endsWith(" ") || result[result.length - 1].endsWith("\n"))) {
           result.push(" ");
         }
         var formattedCmd: any = FormatCmdsubNode(p, indent, inProcsub, compactRedirects, procsubFirst && cmdCount === 0);
@@ -9588,7 +9588,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
     var cond: any = FormatCmdsubNode(node.condition, indent, false, false, false);
     var body: any = FormatCmdsubNode(node.body, indent + 4, false, false, false);
     var result: any = "while " + cond + "; do\n" + innerSp + body + ";\n" + sp + "done";
-    if (node.redirects.length > 0) {
+    if ((node.redirects.length > 0)) {
       for (const r of node.redirects as Node[]) {
         result = result + " " + FormatRedirect(r, false, false);
       }
@@ -9599,7 +9599,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
     var cond: any = FormatCmdsubNode(node.condition, indent, false, false, false);
     var body: any = FormatCmdsubNode(node.body, indent + 4, false, false, false);
     var result: any = "until " + cond + "; do\n" + innerSp + body + ";\n" + sp + "done";
-    if (node.redirects.length > 0) {
+    if ((node.redirects.length > 0)) {
       for (const r of node.redirects as Node[]) {
         result = result + " " + FormatRedirect(r, false, false);
       }
@@ -9613,7 +9613,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
       var wordVals: any = [];
       wordVals.push(...node.words.map(w => w.value));
       var words: any = wordVals.join(" ");
-      if (words !== "") {
+      if ((words.length > 0)) {
         var result: any = "for " + varName + " in " + words + ";\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
       } else {
         var result: any = "for " + varName + " in ;\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
@@ -9621,7 +9621,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
     } else {
       var result: any = "for " + varName + " in \"$@\";\n" + sp + "do\n" + innerSp + body + ";\n" + sp + "done";
     }
-    if (node.redirects.length > 0) {
+    if ((node.redirects.length > 0)) {
       for (const r of node.redirects as Node[]) {
         var result: any = result + " " + FormatRedirect(r, false, false);
       }
@@ -9631,7 +9631,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
   if (node instanceof ForArith) {
     var body: any = FormatCmdsubNode(node.body, indent + 4, false, false, false);
     var result: any = "for ((" + node.init + "; " + node.cond + "; " + node.incr + "))\ndo\n" + innerSp + body + ";\n" + sp + "done";
-    if (node.redirects.length > 0) {
+    if ((node.redirects.length > 0)) {
       for (const r of node.redirects as Node[]) {
         result = result + " " + FormatRedirect(r, false, false);
       }
@@ -9653,7 +9653,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
       var term: any = (p as unknown as CasePattern).terminator;
       var patIndent: any = RepeatStr(" ", indent + 8);
       var termIndent: any = RepeatStr(" ", indent + 4);
-      var bodyPart: any = (body !== "" ? patIndent + body + "\n" : "\n");
+      var bodyPart: any = ((body.length > 0) ? patIndent + body + "\n" : "\n");
       if (i === 0) {
         patterns.push(" " + pat + ")\n" + bodyPart + termIndent + term);
       } else {
@@ -9663,7 +9663,7 @@ function FormatCmdsubNode(node: Node, indent: number, inProcsub: boolean, compac
     }
     var patternStr: any = patterns.join("\n" + RepeatStr(" ", indent + 4));
     var redirects: any = "";
-    if (node.redirects.length > 0) {
+    if ((node.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...node.redirects.map(r => FormatRedirect(r, false, false)));
       redirects = " " + redirectParts.join(" ");
@@ -9682,18 +9682,18 @@ ${innerSp}${body}
   if (node instanceof Subshell) {
     var body: any = FormatCmdsubNode(node.body, indent, inProcsub, compactRedirects, false);
     var redirects: any = "";
-    if (node.redirects.length > 0) {
+    if ((node.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...node.redirects.map(r => FormatRedirect(r, false, false)));
       redirects = redirectParts.join(" ");
     }
     if (procsubFirst) {
-      if (redirects !== "") {
+      if ((redirects.length > 0)) {
         return "(" + body + ") " + redirects;
       }
       return "(" + body + ")";
     }
-    if (redirects !== "") {
+    if ((redirects.length > 0)) {
       return "( " + body + " ) " + redirects;
     }
     return "( " + body + " )";
@@ -9703,12 +9703,12 @@ ${innerSp}${body}
     body = body.replace(/[;]+$/, '');
     var terminator: any = (body.endsWith(" &") ? " }" : "; }");
     var redirects: any = "";
-    if (node.redirects.length > 0) {
+    if ((node.redirects.length > 0)) {
       var redirectParts: any = [];
       redirectParts.push(...node.redirects.map(r => FormatRedirect(r, false, false)));
       redirects = redirectParts.join(" ");
     }
-    if (redirects !== "") {
+    if ((redirects.length > 0)) {
       return "{ " + body + terminator + " " + redirects;
     }
     return "{ " + body + terminator;
@@ -10590,7 +10590,7 @@ function IsWordEndContext(c: string): boolean {
 
 function SkipMatchedPair(s: string, start: number, open: string, close: string, flags: number): number {
   var n: any = s.length;
-  if ((flags & _SMP_PAST_OPEN) !== 0) {
+  if (((flags & _SMP_PAST_OPEN) !== 0)) {
     var i: any = start;
   } else {
     if (start >= n || s[start] !== open) {
@@ -10609,7 +10609,7 @@ function SkipMatchedPair(s: string, start: number, open: string, close: string, 
       continue;
     }
     var literal: any = flags & _SMP_LITERAL;
-    if (literal === 0 && c === "\\") {
+    if (!(literal !== 0) && c === "\\") {
       passNext = true;
       i += 1;
       continue;
@@ -10621,28 +10621,28 @@ function SkipMatchedPair(s: string, start: number, open: string, close: string, 
       i += 1;
       continue;
     }
-    if (literal === 0 && c === "`") {
+    if (!(literal !== 0) && c === "`") {
       backq = true;
       i += 1;
       continue;
     }
-    if (literal === 0 && c === "'") {
+    if (!(literal !== 0) && c === "'") {
       var i: any = SkipSingleQuoted(s, i + 1);
       continue;
     }
-    if (literal === 0 && c === "\"") {
+    if (!(literal !== 0) && c === "\"") {
       var i: any = SkipDoubleQuoted(s, i + 1);
       continue;
     }
-    if (literal === 0 && IsExpansionStart(s, i, "$(")) {
+    if (!(literal !== 0) && IsExpansionStart(s, i, "$(")) {
       var i: any = FindCmdsubEnd(s, i + 2);
       continue;
     }
-    if (literal === 0 && IsExpansionStart(s, i, "${")) {
+    if (!(literal !== 0) && IsExpansionStart(s, i, "${")) {
       var i: any = FindBracedParamEnd(s, i + 2);
       continue;
     }
-    if (literal === 0 && c === open) {
+    if (!(literal !== 0) && c === open) {
       depth += 1;
     } else {
       if (c === close) {
@@ -10659,7 +10659,7 @@ function SkipSubscript(s: string, start: number, flags: number): number {
 }
 
 function Assignment(s: string, flags: number): number {
-  if (s === "") {
+  if (!(s.length > 0)) {
     return -1;
   }
   if (!(/^[a-zA-Z]$/.test(s[0]) || s[0] === "_")) {
@@ -10672,7 +10672,7 @@ function Assignment(s: string, flags: number): number {
       return i;
     }
     if (c === "[") {
-      var subFlags: any = ((flags & 2) !== 0 ? _SMP_LITERAL : 0);
+      var subFlags: any = (((flags & 2) !== 0) ? _SMP_LITERAL : 0);
       var end: any = SkipSubscript(s, i, subFlags);
       if (end === -1) {
         return -1;
@@ -10794,7 +10794,7 @@ function LooksLikeAssignment(s: string): boolean {
 }
 
 function IsValidIdentifier(name: string): boolean {
-  if (name === "") {
+  if (!(name.length > 0)) {
     return false;
   }
   if (!(/^[a-zA-Z]$/.test(name[0]) || name[0] === "_")) {

--- a/transpiler/src/backend/python.py
+++ b/transpiler/src/backend/python.py
@@ -4,11 +4,6 @@ COMPENSATIONS FOR EARLIER STAGE DEFICIENCIES
 ============================================
 
 Frontend deficiencies (should be fixed in frontend.py):
-- BinaryOp patterns like "len(x) > 0" and "x != ''" are converted back to Python
-  truthy checks. Frontend creates these explicit comparisons for other backends,
-  but Python backend must undo them. Frontend could emit a "Truthy" IR node that
-  each backend renders appropriately.
-- UnaryOp "!(len(x) > 0)" similarly converted back to "not x" - same issue.
 - Marker variables "_skip_docstring" and "_pass" require special-case filtering.
   Frontend should either not emit these or use a dedicated NoOp IR node.
 
@@ -107,6 +102,7 @@ from src.ir import (
     TryCatch,
     Tuple,
     TupleAssign,
+    Truthy,
     TupleLit,
     Type,
     TypeAssert,
@@ -634,37 +630,13 @@ class PythonBackend:
                 args_str = ", ".join(self._expr(a) for a in args)
                 type_name = self._type_name_for_check(on_type)
                 return f"{type_name}.{method}({args_str})"
-            case BinaryOp(op=">", left=Len(expr=inner), right=IntLit(value=0)):
-                # Convert len(x) > 0 back to truthy check for Python
-                return self._expr(inner)
-            case BinaryOp(op="==", left=Len(expr=inner), right=IntLit(value=0)):
-                # Convert len(x) == 0 back to "not x" for Python
-                return f"not {self._expr(inner)}"
-            case BinaryOp(op="!=", left=left, right=StringLit(value="")):
-                # Convert x != "" back to truthy check for Python
-                return self._expr(left)
-            case BinaryOp(op="==", left=left, right=StringLit(value="")):
-                # Convert x == "" back to "not x" for Python
-                return f"not {self._expr(left)}"
-            case BinaryOp(op="!=", left=BinaryOp(op="&") as inner, right=IntLit(value=0)):
-                # Convert (x & Y) != 0 back to truthy check for Python
-                return f"({self._expr(inner)})"
-            case BinaryOp(op="==", left=BinaryOp(op="&") as inner, right=IntLit(value=0)):
-                # Convert (x & Y) == 0 back to "not (x & Y)" for Python
-                return f"not ({self._expr(inner)})"
+            case Truthy(expr=e):
+                return self._expr(e)
             case BinaryOp(op=op, left=left, right=right):
                 py_op = _binary_op(op)
                 left_str = self._maybe_paren(left, op, is_left=True)
                 right_str = self._maybe_paren(right, op, is_left=False)
                 return f"{left_str} {py_op} {right_str}"
-            case UnaryOp(
-                op="!", operand=BinaryOp(op=">", left=Len(expr=inner), right=IntLit(value=0))
-            ):
-                # Convert !(len(x) > 0) back to "not x" for Python
-                return f"not {self._expr(inner)}"
-            case UnaryOp(op="!", operand=BinaryOp(op="!=", left=left, right=StringLit(value=""))):
-                # Convert !(x != "") back to "not x" for Python
-                return f"not {self._expr(left)}"
             case UnaryOp(op=op, operand=operand):
                 py_op = _unary_op(op)
                 # For 'not', wrap compound expressions in parens for correct precedence

--- a/transpiler/src/frontend/lowering.py
+++ b/transpiler/src/frontend/lowering.py
@@ -1243,38 +1243,18 @@ def lower_expr_as_bool(
     # Bool expressions don't need nil check
     if expr_type == BOOL:
         return expr
-    # String truthy check: s != ""
+    # String truthy check
     if expr_type == STRING:
-        return ir.BinaryOp(
-            op="!=",
-            left=expr,
-            right=ir.StringLit(value="", typ=STRING),
-            typ=BOOL,
-            loc=loc_from_node(node),
-        )
-    # Int truthy check: n != 0
+        return ir.Truthy(expr=expr, typ=BOOL, loc=loc_from_node(node))
+    # Int truthy check
     if expr_type == INT:
-        return ir.BinaryOp(
-            op="!=", left=expr, right=ir.IntLit(value=0, typ=INT), typ=BOOL, loc=loc_from_node(node)
-        )
-    # Slice/Map/Set truthy check: len(x) > 0
+        return ir.Truthy(expr=expr, typ=BOOL, loc=loc_from_node(node))
+    # Slice/Map/Set truthy check
     if isinstance(expr_type, (Slice, Map, Set)):
-        return ir.BinaryOp(
-            op=">",
-            left=ir.Len(expr=expr, typ=INT, loc=loc_from_node(node)),
-            right=ir.IntLit(value=0, typ=INT),
-            typ=BOOL,
-            loc=loc_from_node(node),
-        )
-    # Optional(Slice) truthy check: len(x) > 0 (nil slice has len 0)
+        return ir.Truthy(expr=expr, typ=BOOL, loc=loc_from_node(node))
+    # Optional(Slice/Map/Set) truthy check (nil slice has len 0)
     if isinstance(expr_type, Optional) and isinstance(expr_type.inner, (Slice, Map, Set)):
-        return ir.BinaryOp(
-            op=">",
-            left=ir.Len(expr=expr, typ=INT, loc=loc_from_node(node)),
-            right=ir.IntLit(value=0, typ=INT),
-            typ=BOOL,
-            loc=loc_from_node(node),
-        )
+        return ir.Truthy(expr=expr, typ=BOOL, loc=loc_from_node(node))
     # Interface truthy check: x != nil
     if isinstance(expr_type, InterfaceRef):
         return ir.IsNil(expr=expr, negated=True, typ=BOOL, loc=loc_from_node(node))


### PR DESCRIPTION
## Summary

- Lowering now emits `Truthy` IR nodes for boolean contexts instead of explicit patterns like `len(x) > 0` or `s != ""`
- Each backend renders `Truthy` appropriately for its target language:
  - **Python**: just the expression (idiomatic truthy check)
  - **Go**: `len(x) > 0`, `x != 0`, `x != nil`
  - **Java**: `!x.isEmpty()`, `x != 0`, `x != null`
  - **TypeScript**: `x.length > 0`, `x !== 0`, `x != null`
- Removes 8 compensation patterns from Python backend and 3 from Java backend that were undoing explicit comparisons