### PR TITLE
transpiler: emit ForClassic IR for range() iteration

### DIFF
--- a/dist/go/parable.go
+++ b/dist/go/parable.go
@@ -2009,7 +2009,7 @@ func (self *Word) doubleCtlescSmart(value string) string {
 		if c == '\x01' {
 			if quote.Double {
 				bsCount := 0
-				for _, j := range Range(len(result)-2, -1, -1) {
+				for j := len(result) - 2; j > -1; j += -1 {
 					if result[j] == "\\" {
 						bsCount++
 					} else {
@@ -3554,7 +3554,7 @@ func (self *List) ToSexp() string {
 		return parts[0].ToSexp()
 	}
 	if parts[len(parts)-1].GetKind() == "operator" && parts[len(parts)-1].(*Operator).Op == "&" {
-		for _, i := range Range(len(parts)-3, 0, -2) {
+		for i := len(parts) - 3; i > 0; i += -2 {
 			if parts[i].GetKind() == "operator" && (parts[i].(*Operator).Op == ";" || parts[i].(*Operator).Op == "\n") {
 				left := parts[0:i]
 				right := parts[i+1 : len(parts)-1]
@@ -3585,7 +3585,7 @@ func (self *List) ToSexp() string {
 
 func (self *List) toSexpWithPrecedence(parts []Node, opNames map[string]string) string {
 	semiPositions := []int{}
-	for _, i := range Range(len(parts)) {
+	for i := 0; i < len(parts); i++ {
 		if parts[i].GetKind() == "operator" && (parts[i].(*Operator).Op == ";" || parts[i].(*Operator).Op == "\n") {
 			semiPositions = append(semiPositions, i)
 		}
@@ -3609,7 +3609,7 @@ func (self *List) toSexpWithPrecedence(parts []Node, opNames map[string]string) 
 			return "()"
 		}
 		result := self.toSexpAmpAndHigher(segments[0], opNames)
-		for _, i := range Range(1, len(segments)) {
+		for i := 1; i < len(segments); i++ {
 			result = "(semi " + result + " " + self.toSexpAmpAndHigher(segments[i], opNames) + ")"
 		}
 		return result
@@ -3622,7 +3622,7 @@ func (self *List) toSexpAmpAndHigher(parts []Node, opNames map[string]string) st
 		return parts[0].ToSexp()
 	}
 	ampPositions := []int{}
-	for _, i := range Range(1, len(parts)-1, 2) {
+	for i := 1; i < len(parts)-1; i += 2 {
 		if parts[i].GetKind() == "operator" && parts[i].(*Operator).Op == "&" {
 			ampPositions = append(ampPositions, i)
 		}
@@ -3636,7 +3636,7 @@ func (self *List) toSexpAmpAndHigher(parts []Node, opNames map[string]string) st
 		}
 		segments = append(segments, parts[start:len(parts)])
 		result := self.toSexpAndOr(segments[0], opNames)
-		for _, i := range Range(1, len(segments)) {
+		for i := 1; i < len(segments); i++ {
 			result = "(background " + result + " " + self.toSexpAndOr(segments[i], opNames) + ")"
 		}
 		return result
@@ -3649,7 +3649,7 @@ func (self *List) toSexpAndOr(parts []Node, opNames map[string]string) string {
 		return parts[0].ToSexp()
 	}
 	result := parts[0].ToSexp()
-	for _, i := range Range(1, len(parts)-1, 2) {
+	for i := 1; i < len(parts)-1; i += 2 {
 		op := parts[i]
 		cmd := parts[i+1]
 		opName := _mapGet(opNames, op.(*Operator).Op, op.(*Operator).Op)
@@ -5290,7 +5290,7 @@ func (self *Parser) parseBacktickSubstitution() (Node, string) {
 			} else if strings.HasPrefix(checkLine, currentHeredocDelim) && _runeLen(checkLine) > _runeLen(currentHeredocDelim) {
 				tabsStripped := _runeLen(line) - _runeLen(checkLine)
 				endPos := tabsStripped + _runeLen(currentHeredocDelim)
-				for _, i := range Range(endPos) {
+				for i := 0; i < endPos; i++ {
 					contentChars = append(contentChars, _runeAt(line, i))
 					textChars = append(textChars, _runeAt(line, i))
 				}
@@ -9854,7 +9854,7 @@ func skipHeredoc(value string, start int) int {
 		line := substring(value, lineStart, lineEnd)
 		for lineEnd < _runeLen(value) {
 			trailingBs := 0
-			for _, j := range Range(_runeLen(line)-1, -1, -1) {
+			for j := _runeLen(line) - 1; j > -1; j += -1 {
 				if _runeAt(line, j) == "\\" {
 					trailingBs++
 				} else {
@@ -9926,7 +9926,7 @@ func findHeredocContentEnd(source string, start int, delimiters []struct {
 			line := substring(source, lineStart, lineEnd)
 			for lineEnd < _runeLen(source) {
 				trailingBs := 0
-				for _, j := range Range(_runeLen(line)-1, -1, -1) {
+				for j := _runeLen(line) - 1; j > -1; j += -1 {
 					if _runeAt(line, j) == "\\" {
 						trailingBs++
 					} else {
@@ -10018,7 +10018,7 @@ func collapseWhitespace(s string) string {
 
 func countTrailingBackslashes(s string) int {
 	count := 0
-	for _, i := range Range(_runeLen(s)-1, -1, -1) {
+	for i := _runeLen(s) - 1; i > -1; i += -1 {
 		if _runeAt(s, i) == "\\" {
 			count++
 		} else {

--- a/dist/java/Parable.java
+++ b/dist/java/Parable.java
@@ -1999,7 +1999,7 @@ class Word implements Node {
             if (c.equals("")) {
                 if (quote.double_) {
                     int bsCount = 0;
-                    for (Integer j : java.util.stream.IntStream.iterate(result.size() - 2, _x -> _x > -1, _x -> _x + -1).boxed().toList()) {
+                    for (int j = result.size() - 2; j > -1; j += -1) {
                         if (result.get(j).equals("\\")) {
                             bsCount += 1;
                         } else {
@@ -3673,7 +3673,7 @@ class ListNode implements Node {
             return ((Node) parts.get(0)).toSexp();
         }
         if (parts.get(parts.size() - 1).getKind() == "operator" && ((Operator) parts.get(parts.size() - 1)).op.equals("&")) {
-            for (Integer i : java.util.stream.IntStream.iterate(parts.size() - 3, _x -> _x > 0, _x -> _x + -2).boxed().toList()) {
+            for (int i = parts.size() - 3; i > 0; i += -2) {
                 if (parts.get(i).getKind() == "operator" && (((Operator) parts.get(i)).op.equals(";") || ((Operator) parts.get(i)).op.equals("\n"))) {
                     List<Node> left = ParableFunctions._sublist(parts, 0, i);
                     List<Node> right = ParableFunctions._sublist(parts, i + 1, parts.size() - 1);
@@ -3704,7 +3704,7 @@ class ListNode implements Node {
 
     public String _toSexpWithPrecedence(List<Node> parts, Map<String, String> opNames) {
         List<Integer> semiPositions = new ArrayList<>();
-        for (Integer i : java.util.stream.IntStream.range(0, parts.size()).boxed().toList()) {
+        for (int i = 0; i < parts.size(); i += 1) {
             if (parts.get(i).getKind() == "operator" && (((Operator) parts.get(i)).op.equals(";") || ((Operator) parts.get(i)).op.equals("\n"))) {
                 semiPositions.add(i);
             }
@@ -3728,7 +3728,7 @@ class ListNode implements Node {
                 return "()";
             }
             String result = this._toSexpAmpAndHigher(segments.get(0), opNames);
-            for (Integer i : java.util.stream.IntStream.range(1, segments.size()).boxed().toList()) {
+            for (int i = 1; i < segments.size(); i += 1) {
                 result = "(semi " + result + " " + this._toSexpAmpAndHigher(segments.get(i), opNames) + ")";
             }
             return result;
@@ -3741,7 +3741,7 @@ class ListNode implements Node {
             return ((Node) parts.get(0)).toSexp();
         }
         List<Integer> ampPositions = new ArrayList<>();
-        for (Integer i : java.util.stream.IntStream.iterate(1, _x -> _x < parts.size() - 1, _x -> _x + 2).boxed().toList()) {
+        for (int i = 1; i < parts.size() - 1; i += 2) {
             if (parts.get(i).getKind() == "operator" && ((Operator) parts.get(i)).op.equals("&")) {
                 ampPositions.add(i);
             }
@@ -3755,7 +3755,7 @@ class ListNode implements Node {
             }
             segments.add(ParableFunctions._sublist(parts, start, parts.size()));
             String result = this._toSexpAndOr(segments.get(0), opNames);
-            for (Integer i : java.util.stream.IntStream.range(1, segments.size()).boxed().toList()) {
+            for (int i = 1; i < segments.size(); i += 1) {
                 result = "(background " + result + " " + this._toSexpAndOr(segments.get(i), opNames) + ")";
             }
             return result;
@@ -3768,7 +3768,7 @@ class ListNode implements Node {
             return ((Node) parts.get(0)).toSexp();
         }
         String result = ((Node) parts.get(0)).toSexp();
-        for (Integer i : java.util.stream.IntStream.iterate(1, _x -> _x < parts.size() - 1, _x -> _x + 2).boxed().toList()) {
+        for (int i = 1; i < parts.size() - 1; i += 2) {
             Node op = parts.get(i);
             Node cmd = parts.get(i + 1);
             String opName = opNames.getOrDefault(((Operator) op).op, ((Operator) op).op);
@@ -5743,7 +5743,7 @@ class Parser {
                     if (checkLine.startsWith(currentHeredocDelim) && checkLine.length() > currentHeredocDelim.length()) {
                         int tabsStripped = line.length() - checkLine.length();
                         int endPos = tabsStripped + currentHeredocDelim.length();
-                        for (Integer i : java.util.stream.IntStream.range(0, endPos).boxed().toList()) {
+                        for (int i = 0; i < endPos; i += 1) {
                             contentChars.add(String.valueOf(line.charAt(i)));
                             textChars.add(String.valueOf(line.charAt(i)));
                         }
@@ -10445,7 +10445,7 @@ final class ParableFunctions {
             String line = ParableFunctions._substring(value, lineStart, lineEnd);
             while (lineEnd < value.length()) {
                 int trailingBs = 0;
-                for (Integer j : java.util.stream.IntStream.iterate(line.length() - 1, _x -> _x > -1, _x -> _x + -1).boxed().toList()) {
+                for (int j = line.length() - 1; j > -1; j += -1) {
                     if (line.charAt(j) == '\\') {
                         trailingBs += 1;
                     } else {
@@ -10514,7 +10514,7 @@ final class ParableFunctions {
                 String line = ParableFunctions._substring(source, lineStart, lineEnd);
                 while (lineEnd < source.length()) {
                     int trailingBs = 0;
-                    for (Integer j : java.util.stream.IntStream.iterate(line.length() - 1, _x -> _x > -1, _x -> _x + -1).boxed().toList()) {
+                    for (int j = line.length() - 1; j > -1; j += -1) {
                         if (line.charAt(j) == '\\') {
                             trailingBs += 1;
                         } else {
@@ -10595,7 +10595,7 @@ final class ParableFunctions {
 
     static int _countTrailingBackslashes(String s) {
         int count = 0;
-        for (Integer i : java.util.stream.IntStream.iterate(s.length() - 1, _x -> _x > -1, _x -> _x + -1).boxed().toList()) {
+        for (int i = s.length() - 1; i > -1; i += -1) {
             if (s.charAt(i) == '\\') {
                 count += 1;
             } else {

--- a/dist/js/parable.js
+++ b/dist/js/parable.js
@@ -1960,8 +1960,7 @@ var Word = /** @class */ (function () {
             if (c === "") {
                 if (quote.double) {
                     var bsCount = 0;
-                    for (var _a = 0, _b = range(result.length - 2, -1, -1); _a < _b.length; _a++) {
-                        var j = _b[_a];
+                    for (var j = result.length - 2; j > -1; j += -1) {
                         if (result[j] === "\\") {
                             bsCount += 1;
                         }
@@ -3744,8 +3743,7 @@ var List = /** @class */ (function () {
             return parts[0].toSexp();
         }
         if (parts[parts.length - 1].kind === "operator" && parts[parts.length - 1].op === "&") {
-            for (var _i = 0, _a = range(parts.length - 3, 0, -2); _i < _a.length; _i++) {
-                var i = _a[_i];
+            for (var i = parts.length - 3; i > 0; i += -2) {
                 if (parts[i].kind === "operator" && (parts[i].op === ";" || parts[i].op === "\n")) {
                     var left = Sublist(parts, 0, i);
                     var right = Sublist(parts, i + 1, parts.length - 1);
@@ -3775,8 +3773,7 @@ var List = /** @class */ (function () {
     };
     List.prototype.ToSexpWithPrecedence = function (parts, opNames) {
         var semiPositions = [];
-        for (var _i = 0, _a = range(parts.length); _i < _a.length; _i++) {
-            var i = _a[_i];
+        for (var i = 0; i < parts.length; i += 1) {
             if (parts[i].kind === "operator" && (parts[i].op === ";" || parts[i].op === "\n")) {
                 semiPositions.push(i);
             }
@@ -3784,8 +3781,8 @@ var List = /** @class */ (function () {
         if ((semiPositions.length > 0)) {
             var segments = [];
             var start = 0;
-            for (var _b = 0, _c = semiPositions; _b < _c.length; _b++) {
-                var pos = _c[_b];
+            for (var _i = 0, _a = semiPositions; _i < _a.length; _i++) {
+                var pos = _a[_i];
                 var seg = Sublist(parts, start, pos);
                 if ((seg.length > 0) && seg[0].kind !== "operator") {
                     segments.push(seg);
@@ -3800,8 +3797,7 @@ var List = /** @class */ (function () {
                 return "()";
             }
             var result = this.ToSexpAmpAndHigher(segments[0], opNames);
-            for (var _d = 0, _f = range(1, segments.length); _d < _f.length; _d++) {
-                var i = _f[_d];
+            for (var i = 1; i < segments.length; i += 1) {
                 result = "(semi " + result + " " + this.ToSexpAmpAndHigher(segments[i], opNames) + ")";
             }
             return result;
@@ -3813,8 +3809,7 @@ var List = /** @class */ (function () {
             return parts[0].toSexp();
         }
         var ampPositions = [];
-        for (var _i = 0, _a = range(1, parts.length - 1, 2); _i < _a.length; _i++) {
-            var i = _a[_i];
+        for (var i = 1; i < parts.length - 1; i += 2) {
             if (parts[i].kind === "operator" && parts[i].op === "&") {
                 ampPositions.push(i);
             }
@@ -3822,15 +3817,14 @@ var List = /** @class */ (function () {
         if ((ampPositions.length > 0)) {
             var segments = [];
             var start = 0;
-            for (var _b = 0, _c = ampPositions; _b < _c.length; _b++) {
-                var pos = _c[_b];
+            for (var _i = 0, _a = ampPositions; _i < _a.length; _i++) {
+                var pos = _a[_i];
                 segments.push(Sublist(parts, start, pos));
                 start = pos + 1;
             }
             segments.push(Sublist(parts, start, parts.length));
             var result = this.ToSexpAndOr(segments[0], opNames);
-            for (var _d = 0, _f = range(1, segments.length); _d < _f.length; _d++) {
-                var i = _f[_d];
+            for (var i = 1; i < segments.length; i += 1) {
                 result = "(background " + result + " " + this.ToSexpAndOr(segments[i], opNames) + ")";
             }
             return result;
@@ -3843,8 +3837,7 @@ var List = /** @class */ (function () {
             return parts[0].toSexp();
         }
         var result = parts[0].toSexp();
-        for (var _i = 0, _b = range(1, parts.length - 1, 2); _i < _b.length; _i++) {
-            var i = _b[_i];
+        for (var i = 1; i < parts.length - 1; i += 2) {
             var op = parts[i];
             var cmd = parts[i + 1];
             var opName = (_a = opNames.get(op.op)) !== null && _a !== void 0 ? _a : op.op;
@@ -5707,8 +5700,7 @@ var Parser = /** @class */ (function () {
                     if (checkLine.startsWith(currentHeredocDelim) && checkLine.length > currentHeredocDelim.length) {
                         var tabsStripped = line.length - checkLine.length;
                         var endPos = tabsStripped + currentHeredocDelim.length;
-                        for (var _d = 0, _f = range(endPos); _d < _f.length; _d++) {
-                            var i = _f[_d];
+                        for (var i = 0; i < endPos; i += 1) {
                             contentChars.push(line[i]);
                             textChars.push(line[i]);
                         }
@@ -5720,8 +5712,8 @@ var Parser = /** @class */ (function () {
                         }
                     }
                     else {
-                        for (var _g = 0, line_2 = line; _g < line_2.length; _g++) {
-                            var ch_2 = line_2[_g];
+                        for (var _d = 0, line_2 = line; _d < line_2.length; _d++) {
+                            var ch_2 = line_2[_d];
                             contentChars.push(ch_2);
                             textChars.push(ch_2);
                         }
@@ -5933,7 +5925,7 @@ var Parser = /** @class */ (function () {
         var text = textChars.join("");
         var content = contentChars.join("");
         if (pendingHeredocs.length > 0) {
-            var _h = FindHeredocContentEnd(this.source, this.pos, pendingHeredocs), heredocStart = _h[0], heredocEnd = _h[1];
+            var _f = FindHeredocContentEnd(this.source, this.pos, pendingHeredocs), heredocStart = _f[0], heredocEnd = _f[1];
             if (heredocEnd > heredocStart) {
                 content = content + Substring(this.source, heredocStart, heredocEnd);
                 if (this.CmdsubHeredocEnd === -1) {
@@ -10450,8 +10442,7 @@ function SkipHeredoc(value, start) {
         var line = Substring(value, lineStart, lineEnd);
         while (lineEnd < value.length) {
             var trailingBs = 0;
-            for (var _i = 0, _a = range(line.length - 1, -1, -1); _i < _a.length; _i++) {
-                var j = _a[_i];
+            for (var j = line.length - 1; j > -1; j += -1) {
                 if (line[j] === "\\") {
                     trailingBs += 1;
                 }
@@ -10523,8 +10514,7 @@ function FindHeredocContentEnd(source, start, delimiters) {
             var line = Substring(source, lineStart, lineEnd);
             while (lineEnd < source.length) {
                 var trailingBs = 0;
-                for (var _b = 0, _c = range(line.length - 1, -1, -1); _b < _c.length; _b++) {
-                    var j = _c[_b];
+                for (var j = line.length - 1; j > -1; j += -1) {
                     if (line[j] === "\\") {
                         trailingBs += 1;
                     }
@@ -10603,8 +10593,7 @@ function CollapseWhitespace(s) {
 }
 function CountTrailingBackslashes(s) {
     var count = 0;
-    for (var _i = 0, _a = range(s.length - 1, -1, -1); _i < _a.length; _i++) {
-        var i = _a[_i];
+    for (var i = s.length - 1; i > -1; i += -1) {
         if (s[i] === "\\") {
             count += 1;
         }

--- a/dist/python/parable.py
+++ b/dist/python/parable.py
@@ -1455,11 +1455,13 @@ class Word(Node):
             if c == "":
                 if quote.double:
                     bs_count = 0
-                    for j in range(len(result) - 2, -1, -1):
+                    j: int = len(result) - 2
+                    while j > -1:
                         if result[j] == "\\":
                             bs_count += 1
                         else:
                             break
+                        j += -1
                     if bs_count % 2 == 0:
                         result.append("")
                 else:
@@ -2694,7 +2696,8 @@ class List(Node):
         if len(parts) == 1:
             return parts[0].to_sexp()
         if parts[-1].kind == "operator" and parts[-1].op == "&":
-            for i in range(len(parts) - 3, 0, -2):
+            i: int = len(parts) - 3
+            while i > 0:
                 if parts[i].kind == "operator" and (parts[i].op == ";" or parts[i].op == "\n"):
                     left = _sublist(parts, 0, i)
                     right = _sublist(parts, i + 1, len(parts) - 1)
@@ -2707,6 +2710,7 @@ class List(Node):
                     else:
                         right_sexp = right[0].to_sexp()
                     return "(semi " + left_sexp + " (background " + right_sexp + "))"
+                i += -2
             inner_parts = _sublist(parts, 0, len(parts) - 1)
             if len(inner_parts) == 1:
                 return "(background " + inner_parts[0].to_sexp() + ")"
@@ -2733,8 +2737,10 @@ class List(Node):
             if not segments:
                 return "()"
             result = self._to_sexp_amp_and_higher(segments[0], op_names)
-            for i in range(1, len(segments)):
+            i: int = 1
+            while i < len(segments):
                 result = "(semi " + result + " " + self._to_sexp_amp_and_higher(segments[i], op_names) + ")"
+                i += 1
             return result
         return self._to_sexp_amp_and_higher(parts, op_names)
 
@@ -2742,9 +2748,11 @@ class List(Node):
         if len(parts) == 1:
             return parts[0].to_sexp()
         amp_positions = []
-        for i in range(1, len(parts) - 1, 2):
+        i: int = 1
+        while i < len(parts) - 1:
             if parts[i].kind == "operator" and parts[i].op == "&":
                 amp_positions.append(i)
+            i += 2
         if amp_positions:
             segments = []
             start = 0
@@ -2753,8 +2761,10 @@ class List(Node):
                 start = pos + 1
             segments.append(_sublist(parts, start, len(parts)))
             result = self._to_sexp_and_or(segments[0], op_names)
-            for i in range(1, len(segments)):
+            i: int = 1
+            while i < len(segments):
                 result = "(background " + result + " " + self._to_sexp_and_or(segments[i], op_names) + ")"
+                i += 1
             return result
         return self._to_sexp_and_or(parts, op_names)
 
@@ -2762,11 +2772,13 @@ class List(Node):
         if len(parts) == 1:
             return parts[0].to_sexp()
         result = parts[0].to_sexp()
-        for i in range(1, len(parts) - 1, 2):
+        i: int = 1
+        while i < len(parts) - 1:
             op = parts[i]
             cmd = parts[i + 1]
             op_name = op_names.get(op.op, op.op)
             result = "(" + op_name + " " + result + " " + cmd.to_sexp() + ")"
+            i += 2
         return result
 
 
@@ -4044,9 +4056,11 @@ class Parser:
                 elif check_line.startswith(current_heredoc_delim) and len(check_line) > len(current_heredoc_delim):
                     tabs_stripped = len(line) - len(check_line)
                     end_pos = tabs_stripped + len(current_heredoc_delim)
-                    for i in range(end_pos):
+                    i: int = 0
+                    while i < end_pos:
                         content_chars.append(line[i])
                         text_chars.append(line[i])
+                        i += 1
                     self.pos = line_start + end_pos
                     in_heredoc_body = False
                     if len(pending_heredocs) > 0:
@@ -7556,11 +7570,13 @@ def _skip_heredoc(value: str, start: int) -> int:
         line = _substring(value, line_start, line_end)
         while line_end < len(value):
             trailing_bs = 0
-            for j in range(len(line) - 1, -1, -1):
+            j: int = len(line) - 1
+            while j > -1:
                 if line[j] == "\\":
                     trailing_bs += 1
                 else:
                     break
+                j += -1
             if trailing_bs % 2 == 0:
                 break
             line = line[:-1]
@@ -7609,11 +7625,13 @@ def _find_heredoc_content_end(source: str, start: int, delimiters: list[tuple[st
             line = _substring(source, line_start, line_end)
             while line_end < len(source):
                 trailing_bs = 0
-                for j in range(len(line) - 1, -1, -1):
+                j: int = len(line) - 1
+                while j > -1:
                     if line[j] == "\\":
                         trailing_bs += 1
                     else:
                         break
+                    j += -1
                 if trailing_bs % 2 == 0:
                     break
                 line = line[:-1]
@@ -7671,11 +7689,13 @@ def _collapse_whitespace(s: str) -> str:
 
 def _count_trailing_backslashes(s: str) -> int:
     count = 0
-    for i in range(len(s) - 1, -1, -1):
+    i: int = len(s) - 1
+    while i > -1:
         if s[i] == "\\":
             count += 1
         else:
             break
+        i += -1
     return count
 
 

--- a/dist/ts/parable.ts
+++ b/dist/ts/parable.ts
@@ -1917,7 +1917,7 @@ class Word implements Node {
       if (c === "") {
         if (quote.double) {
           var bsCount: any = 0;
-          for (const j of range(result.length - 2, -1, -1)) {
+          for (var j: any = result.length - 2; j > -1; j += -1) {
             if (result[j] === "\\") {
               bsCount += 1;
             } else {
@@ -3565,7 +3565,7 @@ class List implements Node {
       return parts[0].toSexp();
     }
     if (parts[parts.length - 1].kind === "operator" && (parts[parts.length - 1] as unknown as Operator).op === "&") {
-      for (const i of range(parts.length - 3, 0, -2)) {
+      for (var i: any = parts.length - 3; i > 0; i += -2) {
         if (parts[i].kind === "operator" && ((parts[i] as unknown as Operator).op === ";" || (parts[i] as unknown as Operator).op === "\n")) {
           var left: any = Sublist(parts, 0, i);
           var right: any = Sublist(parts, i + 1, parts.length - 1);
@@ -3594,7 +3594,7 @@ class List implements Node {
 
   ToSexpWithPrecedence(parts: Node[], opNames: Map<string, string>): string {
     var semiPositions: any = [];
-    for (const i of range(parts.length)) {
+    for (var i: any = 0; i < parts.length; i += 1) {
       if (parts[i].kind === "operator" && ((parts[i] as unknown as Operator).op === ";" || (parts[i] as unknown as Operator).op === "\n")) {
         semiPositions.push(i);
       }
@@ -3617,7 +3617,7 @@ class List implements Node {
         return "()";
       }
       var result: any = this.ToSexpAmpAndHigher(segments[0], opNames);
-      for (const i of range(1, segments.length)) {
+      for (var i: any = 1; i < segments.length; i += 1) {
         result = "(semi " + result + " " + this.ToSexpAmpAndHigher(segments[i], opNames) + ")";
       }
       return result;
@@ -3630,7 +3630,7 @@ class List implements Node {
       return parts[0].toSexp();
     }
     var ampPositions: any = [];
-    for (const i of range(1, parts.length - 1, 2)) {
+    for (var i: any = 1; i < parts.length - 1; i += 2) {
       if (parts[i].kind === "operator" && (parts[i] as unknown as Operator).op === "&") {
         ampPositions.push(i);
       }
@@ -3644,7 +3644,7 @@ class List implements Node {
       }
       segments.push(Sublist(parts, start, parts.length));
       var result: any = this.ToSexpAndOr(segments[0], opNames);
-      for (const i of range(1, segments.length)) {
+      for (var i: any = 1; i < segments.length; i += 1) {
         result = "(background " + result + " " + this.ToSexpAndOr(segments[i], opNames) + ")";
       }
       return result;
@@ -3657,7 +3657,7 @@ class List implements Node {
       return parts[0].toSexp();
     }
     var result: any = parts[0].toSexp();
-    for (const i of range(1, parts.length - 1, 2)) {
+    for (var i: any = 1; i < parts.length - 1; i += 2) {
       var op: any = parts[i];
       var cmd: any = parts[i + 1];
       var opName: any = opNames.get((op as unknown as Operator).op) ?? (op as unknown as Operator).op;
@@ -5685,7 +5685,7 @@ class Parser {
           if (checkLine.startsWith(currentHeredocDelim) && checkLine.length > currentHeredocDelim.length) {
             var tabsStripped: any = line.length - checkLine.length;
             var endPos: any = tabsStripped + currentHeredocDelim.length;
-            for (const i of range(endPos)) {
+            for (var i: any = 0; i < endPos; i += 1) {
               contentChars.push(line[i]);
               textChars.push(line[i]);
             }
@@ -10300,7 +10300,7 @@ function SkipHeredoc(value: string, start: number): number {
     var line: any = Substring(value, lineStart, lineEnd);
     while (lineEnd < value.length) {
       var trailingBs: any = 0;
-      for (const j of range(line.length - 1, -1, -1)) {
+      for (var j: any = line.length - 1; j > -1; j += -1) {
         if (line[j] === "\\") {
           trailingBs += 1;
         } else {
@@ -10368,7 +10368,7 @@ function FindHeredocContentEnd(source: string, start: number, delimiters: [strin
       var line: any = Substring(source, lineStart, lineEnd);
       while (lineEnd < source.length) {
         var trailingBs: any = 0;
-        for (const j of range(line.length - 1, -1, -1)) {
+        for (var j: any = line.length - 1; j > -1; j += -1) {
           if (line[j] === "\\") {
             trailingBs += 1;
           } else {
@@ -10447,7 +10447,7 @@ function CollapseWhitespace(s: string): string {
 
 function CountTrailingBackslashes(s: string): number {
   var count: any = 0;
-  for (const i of range(s.length - 1, -1, -1)) {
+  for (var i: any = s.length - 1; i > -1; i += -1) {
     if (s[i] === "\\") {
       count += 1;
     } else {

--- a/transpiler/src/backend/go.py
+++ b/transpiler/src/backend/go.py
@@ -44,8 +44,6 @@ Frontend deficiencies (should be fixed in frontend.py):
 - Helper function indirection: `_parseInt(x, 10)` helper instead of inline
   error-ignoring pattern, `_intPtr(fd)` instead of inline pointer creation.
   (~15 call sites)
-- Range() helper allocates slices: `for _, i := range Range(n)` instead of
-  `for i := 0; i < n; i++`. Frontend should emit ForClassic IR. (~11 sites)
 - IIFE for ternary: `func() T { if c { return a } else { return b } }()`.
   Frontend could emit Ternary with a flag indicating if/else expansion is
   acceptable, or middleend could lift to variable assignment. (~30 sites)

--- a/transpiler/src/backend/java.py
+++ b/transpiler/src/backend/java.py
@@ -53,8 +53,6 @@ Frontend deficiencies (should be fixed in frontend.py):
   assigns each field. Frontend should emit constructor calls or StructLit. (~7 factories)
 - Nullable fields without Optional: fields used with null but declared as bare
   types. Frontend should emit Optional wrapper for nullable fields. (~47 fields)
-- Complex iteration patterns: `IntStream.iterate(n-1, _x -> _x < -1, _x -> _x + -1)`
-  instead of `for (int i = n-1; i >= 0; i--)`. Frontend should emit ForClassic. (~7 sites)
 - Last-element access: `list.get(list.size() - 1)` instead of `list.getLast()`.
   Frontend could emit Index with -1 sentinel that backend maps to getLast(). (~19 sites)
 


### PR DESCRIPTION
## Summary

- Frontend detects `range()` patterns and emits `ForClassic` IR instead of `ForRange`
- Enables idiomatic C-style loops in Go/Java/TypeScript backends
- Eliminates Range() helper calls in Go and IntStream.iterate in Java

## Patterns Handled

| Source Python | Output |
|---------------|--------|
| `range(n)` | `for i := 0; i < n; i++` |
| `range(start, end)` | `for i := start; i < end; i++` |
| `range(start, end, step)` | `for i := start; i < end; i += step` |
| `range(n, 0, -1)` | `for i := n; i > 0; i += -1` |