### PR TITLE
transpiler: move Node interface knowledge from backends to frontend

### DIFF
--- a/dist/go/parable.go
+++ b/dist/go/parable.go
@@ -1972,8 +1972,6 @@ type Word struct {
 	Kind  string
 }
 
-func (self *Word) GetKind() string { return self.Kind }
-
 func (self *Word) ToSexp() string {
 	value := self.Value
 	value = self.expandAllAnsiCQuotes(value)
@@ -3434,13 +3432,15 @@ func (self *Word) GetCondFormattedValue() string {
 	return strings.TrimRight(value, "\n")
 }
 
+func (self *Word) GetKind() string {
+	return self.Kind
+}
+
 type Command struct {
 	Words     []*Word
 	Redirects []Node
 	Kind      string
 }
-
-func (self *Command) GetKind() string { return self.Kind }
 
 func (self *Command) ToSexp() string {
 	parts := []string{}
@@ -3457,12 +3457,14 @@ func (self *Command) ToSexp() string {
 	return "(command " + inner + ")"
 }
 
+func (self *Command) GetKind() string {
+	return self.Kind
+}
+
 type Pipeline struct {
 	Commands []Node
 	Kind     string
 }
-
-func (self *Pipeline) GetKind() string { return self.Kind }
 
 func (self *Pipeline) ToSexp() string {
 	if len(self.Commands) == 1 {
@@ -3537,12 +3539,14 @@ func (self *Pipeline) cmdSexp(cmd Node, needsRedirect bool) string {
 	return cmd.ToSexp()
 }
 
+func (self *Pipeline) GetKind() string {
+	return self.Kind
+}
+
 type List struct {
 	Parts []Node
 	Kind  string
 }
-
-func (self *List) GetKind() string { return self.Kind }
 
 func (self *List) ToSexp() string {
 	parts := append(self.Parts[:0:0], self.Parts...)
@@ -3658,36 +3662,46 @@ func (self *List) toSexpAndOr(parts []Node, opNames map[string]string) string {
 	return result
 }
 
+func (self *List) GetKind() string {
+	return self.Kind
+}
+
 type Operator struct {
 	Op   string
 	Kind string
 }
-
-func (self *Operator) GetKind() string { return self.Kind }
 
 func (self *Operator) ToSexp() string {
 	names := map[string]string{"&&": "and", "||": "or", ";": "semi", "&": "bg", "|": "pipe"}
 	return "(" + _mapGet(names, self.Op, self.Op) + ")"
 }
 
+func (self *Operator) GetKind() string {
+	return self.Kind
+}
+
 type PipeBoth struct {
 	Kind string
 }
 
-func (self *PipeBoth) GetKind() string { return self.Kind }
-
 func (self *PipeBoth) ToSexp() string {
 	return "(pipe-both)"
+}
+
+func (self *PipeBoth) GetKind() string {
+	return self.Kind
 }
 
 type Empty struct {
 	Kind string
 }
 
-func (self *Empty) GetKind() string { return self.Kind }
-
 func (self *Empty) ToSexp() string {
 	return ""
+}
+
+func (self *Empty) GetKind() string {
+	return self.Kind
 }
 
 type Comment struct {
@@ -3695,10 +3709,12 @@ type Comment struct {
 	Kind string
 }
 
-func (self *Comment) GetKind() string { return self.Kind }
-
 func (self *Comment) ToSexp() string {
 	return ""
+}
+
+func (self *Comment) GetKind() string {
+	return self.Kind
 }
 
 type Redirect struct {
@@ -3707,8 +3723,6 @@ type Redirect struct {
 	Fd     *int
 	Kind   string
 }
-
-func (self *Redirect) GetKind() string { return self.Kind }
 
 func (self *Redirect) ToSexp() string {
 	op := strings.TrimLeft(self.Op, "0123456789")
@@ -3788,6 +3802,10 @@ func (self *Redirect) ToSexp() string {
 	return "(redirect \"" + op + "\" \"" + targetVal + "\")"
 }
 
+func (self *Redirect) GetKind() string {
+	return self.Kind
+}
+
 type HereDoc struct {
 	Delimiter string
 	Content   string
@@ -3798,8 +3816,6 @@ type HereDoc struct {
 	startPos  int
 	Kind      string
 }
-
-func (self *HereDoc) GetKind() string { return self.Kind }
 
 func (self *HereDoc) ToSexp() string {
 	op := func() string {
@@ -3816,17 +3832,23 @@ func (self *HereDoc) ToSexp() string {
 	return fmt.Sprintf("(redirect \"%v\" \"%v\")", op, content)
 }
 
+func (self *HereDoc) GetKind() string {
+	return self.Kind
+}
+
 type Subshell struct {
 	Body      Node
 	Redirects []Node
 	Kind      string
 }
 
-func (self *Subshell) GetKind() string { return self.Kind }
-
 func (self *Subshell) ToSexp() string {
 	base := "(subshell " + self.Body.ToSexp() + ")"
 	return appendRedirects(base, self.Redirects)
+}
+
+func (self *Subshell) GetKind() string {
+	return self.Kind
 }
 
 type BraceGroup struct {
@@ -3835,11 +3857,13 @@ type BraceGroup struct {
 	Kind      string
 }
 
-func (self *BraceGroup) GetKind() string { return self.Kind }
-
 func (self *BraceGroup) ToSexp() string {
 	base := "(brace-group " + self.Body.ToSexp() + ")"
 	return appendRedirects(base, self.Redirects)
+}
+
+func (self *BraceGroup) GetKind() string {
+	return self.Kind
 }
 
 type If struct {
@@ -3849,8 +3873,6 @@ type If struct {
 	Redirects []Node
 	Kind      string
 }
-
-func (self *If) GetKind() string { return self.Kind }
 
 func (self *If) ToSexp() string {
 	result := "(if " + self.Condition.ToSexp() + " " + self.ThenBody.ToSexp()
@@ -3864,6 +3886,10 @@ func (self *If) ToSexp() string {
 	return result
 }
 
+func (self *If) GetKind() string {
+	return self.Kind
+}
+
 type While struct {
 	Condition Node
 	Body      Node
@@ -3871,11 +3897,13 @@ type While struct {
 	Kind      string
 }
 
-func (self *While) GetKind() string { return self.Kind }
-
 func (self *While) ToSexp() string {
 	base := "(while " + self.Condition.ToSexp() + " " + self.Body.ToSexp() + ")"
 	return appendRedirects(base, self.Redirects)
+}
+
+func (self *While) GetKind() string {
+	return self.Kind
 }
 
 type Until struct {
@@ -3885,11 +3913,13 @@ type Until struct {
 	Kind      string
 }
 
-func (self *Until) GetKind() string { return self.Kind }
-
 func (self *Until) ToSexp() string {
 	base := "(until " + self.Condition.ToSexp() + " " + self.Body.ToSexp() + ")"
 	return appendRedirects(base, self.Redirects)
+}
+
+func (self *Until) GetKind() string {
+	return self.Kind
 }
 
 type For struct {
@@ -3899,8 +3929,6 @@ type For struct {
 	Redirects []Node
 	Kind      string
 }
-
-func (self *For) GetKind() string { return self.Kind }
 
 func (self *For) ToSexp() string {
 	suffix := ""
@@ -3928,6 +3956,10 @@ func (self *For) ToSexp() string {
 	}
 }
 
+func (self *For) GetKind() string {
+	return self.Kind
+}
+
 type ForArith struct {
 	Init      string
 	Cond      string
@@ -3936,8 +3968,6 @@ type ForArith struct {
 	Redirects []Node
 	Kind      string
 }
-
-func (self *ForArith) GetKind() string { return self.Kind }
 
 func (self *ForArith) ToSexp() string {
 	suffix := ""
@@ -3976,6 +4006,10 @@ func (self *ForArith) ToSexp() string {
 	return fmt.Sprintf("(arith-for (init (word \"%v\")) (test (word \"%v\")) (step (word \"%v\")) %v)%v", initStr, condStr, incrStr, bodyStr, suffix)
 }
 
+func (self *ForArith) GetKind() string {
+	return self.Kind
+}
+
 type Select struct {
 	Var       string
 	Words     []*Word
@@ -3983,8 +4017,6 @@ type Select struct {
 	Redirects []Node
 	Kind      string
 }
-
-func (self *Select) GetKind() string { return self.Kind }
 
 func (self *Select) ToSexp() string {
 	suffix := ""
@@ -4014,14 +4046,16 @@ func (self *Select) ToSexp() string {
 	return "(select (word \"" + varEscaped + "\") " + inClause + " " + self.Body.ToSexp() + ")" + suffix
 }
 
+func (self *Select) GetKind() string {
+	return self.Kind
+}
+
 type Case struct {
 	Word      Node
 	Patterns  []Node
 	Redirects []Node
 	Kind      string
 }
-
-func (self *Case) GetKind() string { return self.Kind }
 
 func (self *Case) ToSexp() string {
 	parts := []string{}
@@ -4033,14 +4067,16 @@ func (self *Case) ToSexp() string {
 	return appendRedirects(base, self.Redirects)
 }
 
+func (self *Case) GetKind() string {
+	return self.Kind
+}
+
 type CasePattern struct {
 	Pattern    string
 	Body       Node
 	Terminator string
 	Kind       string
 }
-
-func (self *CasePattern) GetKind() string { return self.Kind }
 
 func (self *CasePattern) ToSexp() string {
 	alternatives := []string{}
@@ -4107,16 +4143,22 @@ func (self *CasePattern) ToSexp() string {
 	return strings.Join(parts, "")
 }
 
+func (self *CasePattern) GetKind() string {
+	return self.Kind
+}
+
 type Function struct {
 	Name string
 	Body Node
 	Kind string
 }
 
-func (self *Function) GetKind() string { return self.Kind }
-
 func (self *Function) ToSexp() string {
 	return "(function \"" + self.Name + "\" " + self.Body.ToSexp() + ")"
+}
+
+func (self *Function) GetKind() string {
+	return self.Kind
 }
 
 type ParamExpansion struct {
@@ -4125,8 +4167,6 @@ type ParamExpansion struct {
 	Arg   string
 	Kind  string
 }
-
-func (self *ParamExpansion) GetKind() string { return self.Kind }
 
 func (self *ParamExpansion) ToSexp() string {
 	escapedParam := strings.ReplaceAll(strings.ReplaceAll(self.Param, "\\", "\\\\"), "\"", "\\\"")
@@ -4144,16 +4184,22 @@ func (self *ParamExpansion) ToSexp() string {
 	return "(param \"" + escapedParam + "\")"
 }
 
+func (self *ParamExpansion) GetKind() string {
+	return self.Kind
+}
+
 type ParamLength struct {
 	Param string
 	Kind  string
 }
 
-func (self *ParamLength) GetKind() string { return self.Kind }
-
 func (self *ParamLength) ToSexp() string {
 	escaped := strings.ReplaceAll(strings.ReplaceAll(self.Param, "\\", "\\\\"), "\"", "\\\"")
 	return "(param-len \"" + escaped + "\")"
+}
+
+func (self *ParamLength) GetKind() string {
+	return self.Kind
 }
 
 type ParamIndirect struct {
@@ -4162,8 +4208,6 @@ type ParamIndirect struct {
 	Arg   string
 	Kind  string
 }
-
-func (self *ParamIndirect) GetKind() string { return self.Kind }
 
 func (self *ParamIndirect) ToSexp() string {
 	escaped := strings.ReplaceAll(strings.ReplaceAll(self.Param, "\\", "\\\\"), "\"", "\\\"")
@@ -4181,13 +4225,15 @@ func (self *ParamIndirect) ToSexp() string {
 	return "(param-indirect \"" + escaped + "\")"
 }
 
+func (self *ParamIndirect) GetKind() string {
+	return self.Kind
+}
+
 type CommandSubstitution struct {
 	Command Node
 	Brace   bool
 	Kind    string
 }
-
-func (self *CommandSubstitution) GetKind() string { return self.Kind }
 
 func (self *CommandSubstitution) ToSexp() string {
 	if self.Brace {
@@ -4196,12 +4242,14 @@ func (self *CommandSubstitution) ToSexp() string {
 	return "(cmdsub " + self.Command.ToSexp() + ")"
 }
 
+func (self *CommandSubstitution) GetKind() string {
+	return self.Kind
+}
+
 type ArithmeticExpansion struct {
 	Expression Node
 	Kind       string
 }
-
-func (self *ArithmeticExpansion) GetKind() string { return self.Kind }
 
 func (self *ArithmeticExpansion) ToSexp() string {
 	if self.Expression == nil {
@@ -4210,14 +4258,16 @@ func (self *ArithmeticExpansion) ToSexp() string {
 	return "(arith " + self.Expression.ToSexp() + ")"
 }
 
+func (self *ArithmeticExpansion) GetKind() string {
+	return self.Kind
+}
+
 type ArithmeticCommand struct {
 	Expression Node
 	Redirects  []Node
 	RawContent string
 	Kind       string
 }
-
-func (self *ArithmeticCommand) GetKind() string { return self.Kind }
 
 func (self *ArithmeticCommand) ToSexp() string {
 	formatted := (&Word{Value: self.RawContent, Kind: "word"}).formatCommandSubstitutions(self.RawContent, true)
@@ -4234,25 +4284,33 @@ func (self *ArithmeticCommand) ToSexp() string {
 	return result
 }
 
+func (self *ArithmeticCommand) GetKind() string {
+	return self.Kind
+}
+
 type ArithNumber struct {
 	Value string
 	Kind  string
 }
 
-func (self *ArithNumber) GetKind() string { return self.Kind }
-
 func (self *ArithNumber) ToSexp() string {
 	return "(number \"" + self.Value + "\")"
+}
+
+func (self *ArithNumber) GetKind() string {
+	return self.Kind
 }
 
 type ArithEmpty struct {
 	Kind string
 }
 
-func (self *ArithEmpty) GetKind() string { return self.Kind }
-
 func (self *ArithEmpty) ToSexp() string {
 	return "(empty)"
+}
+
+func (self *ArithEmpty) GetKind() string {
+	return self.Kind
 }
 
 type ArithVar struct {
@@ -4260,10 +4318,12 @@ type ArithVar struct {
 	Kind string
 }
 
-func (self *ArithVar) GetKind() string { return self.Kind }
-
 func (self *ArithVar) ToSexp() string {
 	return "(var \"" + self.Name + "\")"
+}
+
+func (self *ArithVar) GetKind() string {
+	return self.Kind
 }
 
 type ArithBinaryOp struct {
@@ -4273,10 +4333,12 @@ type ArithBinaryOp struct {
 	Kind  string
 }
 
-func (self *ArithBinaryOp) GetKind() string { return self.Kind }
-
 func (self *ArithBinaryOp) ToSexp() string {
 	return "(binary-op \"" + self.Op + "\" " + self.Left.ToSexp() + " " + self.Right.ToSexp() + ")"
+}
+
+func (self *ArithBinaryOp) GetKind() string {
+	return self.Kind
 }
 
 type ArithUnaryOp struct {
@@ -4285,10 +4347,12 @@ type ArithUnaryOp struct {
 	Kind    string
 }
 
-func (self *ArithUnaryOp) GetKind() string { return self.Kind }
-
 func (self *ArithUnaryOp) ToSexp() string {
 	return "(unary-op \"" + self.Op + "\" " + self.Operand.ToSexp() + ")"
+}
+
+func (self *ArithUnaryOp) GetKind() string {
+	return self.Kind
 }
 
 type ArithPreIncr struct {
@@ -4296,10 +4360,12 @@ type ArithPreIncr struct {
 	Kind    string
 }
 
-func (self *ArithPreIncr) GetKind() string { return self.Kind }
-
 func (self *ArithPreIncr) ToSexp() string {
 	return "(pre-incr " + self.Operand.ToSexp() + ")"
+}
+
+func (self *ArithPreIncr) GetKind() string {
+	return self.Kind
 }
 
 type ArithPostIncr struct {
@@ -4307,10 +4373,12 @@ type ArithPostIncr struct {
 	Kind    string
 }
 
-func (self *ArithPostIncr) GetKind() string { return self.Kind }
-
 func (self *ArithPostIncr) ToSexp() string {
 	return "(post-incr " + self.Operand.ToSexp() + ")"
+}
+
+func (self *ArithPostIncr) GetKind() string {
+	return self.Kind
 }
 
 type ArithPreDecr struct {
@@ -4318,10 +4386,12 @@ type ArithPreDecr struct {
 	Kind    string
 }
 
-func (self *ArithPreDecr) GetKind() string { return self.Kind }
-
 func (self *ArithPreDecr) ToSexp() string {
 	return "(pre-decr " + self.Operand.ToSexp() + ")"
+}
+
+func (self *ArithPreDecr) GetKind() string {
+	return self.Kind
 }
 
 type ArithPostDecr struct {
@@ -4329,10 +4399,12 @@ type ArithPostDecr struct {
 	Kind    string
 }
 
-func (self *ArithPostDecr) GetKind() string { return self.Kind }
-
 func (self *ArithPostDecr) ToSexp() string {
 	return "(post-decr " + self.Operand.ToSexp() + ")"
+}
+
+func (self *ArithPostDecr) GetKind() string {
+	return self.Kind
 }
 
 type ArithAssign struct {
@@ -4342,10 +4414,12 @@ type ArithAssign struct {
 	Kind   string
 }
 
-func (self *ArithAssign) GetKind() string { return self.Kind }
-
 func (self *ArithAssign) ToSexp() string {
 	return "(assign \"" + self.Op + "\" " + self.Target.ToSexp() + " " + self.Value.ToSexp() + ")"
+}
+
+func (self *ArithAssign) GetKind() string {
+	return self.Kind
 }
 
 type ArithTernary struct {
@@ -4355,10 +4429,12 @@ type ArithTernary struct {
 	Kind      string
 }
 
-func (self *ArithTernary) GetKind() string { return self.Kind }
-
 func (self *ArithTernary) ToSexp() string {
 	return "(ternary " + self.Condition.ToSexp() + " " + self.IfTrue.ToSexp() + " " + self.IfFalse.ToSexp() + ")"
+}
+
+func (self *ArithTernary) GetKind() string {
+	return self.Kind
 }
 
 type ArithComma struct {
@@ -4367,10 +4443,12 @@ type ArithComma struct {
 	Kind  string
 }
 
-func (self *ArithComma) GetKind() string { return self.Kind }
-
 func (self *ArithComma) ToSexp() string {
 	return "(comma " + self.Left.ToSexp() + " " + self.Right.ToSexp() + ")"
+}
+
+func (self *ArithComma) GetKind() string {
+	return self.Kind
 }
 
 type ArithSubscript struct {
@@ -4379,10 +4457,12 @@ type ArithSubscript struct {
 	Kind  string
 }
 
-func (self *ArithSubscript) GetKind() string { return self.Kind }
-
 func (self *ArithSubscript) ToSexp() string {
 	return "(subscript \"" + self.Array + "\" " + self.Index.ToSexp() + ")"
+}
+
+func (self *ArithSubscript) GetKind() string {
+	return self.Kind
 }
 
 type ArithEscape struct {
@@ -4390,10 +4470,12 @@ type ArithEscape struct {
 	Kind string
 }
 
-func (self *ArithEscape) GetKind() string { return self.Kind }
-
 func (self *ArithEscape) ToSexp() string {
 	return "(escape \"" + self.Char + "\")"
+}
+
+func (self *ArithEscape) GetKind() string {
+	return self.Kind
 }
 
 type ArithDeprecated struct {
@@ -4401,19 +4483,19 @@ type ArithDeprecated struct {
 	Kind       string
 }
 
-func (self *ArithDeprecated) GetKind() string { return self.Kind }
-
 func (self *ArithDeprecated) ToSexp() string {
 	escaped := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(self.Expression, "\\", "\\\\"), "\"", "\\\""), "\n", "\\n")
 	return "(arith-deprecated \"" + escaped + "\")"
+}
+
+func (self *ArithDeprecated) GetKind() string {
+	return self.Kind
 }
 
 type ArithConcat struct {
 	Parts []Node
 	Kind  string
 }
-
-func (self *ArithConcat) GetKind() string { return self.Kind }
 
 func (self *ArithConcat) ToSexp() string {
 	sexps := []string{}
@@ -4423,16 +4505,22 @@ func (self *ArithConcat) ToSexp() string {
 	return "(arith-concat " + strings.Join(sexps, " ") + ")"
 }
 
+func (self *ArithConcat) GetKind() string {
+	return self.Kind
+}
+
 type AnsiCQuote struct {
 	Content string
 	Kind    string
 }
 
-func (self *AnsiCQuote) GetKind() string { return self.Kind }
-
 func (self *AnsiCQuote) ToSexp() string {
 	escaped := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(self.Content, "\\", "\\\\"), "\"", "\\\""), "\n", "\\n")
 	return "(ansi-c \"" + escaped + "\")"
+}
+
+func (self *AnsiCQuote) GetKind() string {
+	return self.Kind
 }
 
 type LocaleString struct {
@@ -4440,11 +4528,13 @@ type LocaleString struct {
 	Kind    string
 }
 
-func (self *LocaleString) GetKind() string { return self.Kind }
-
 func (self *LocaleString) ToSexp() string {
 	escaped := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(self.Content, "\\", "\\\\"), "\"", "\\\""), "\n", "\\n")
 	return "(locale \"" + escaped + "\")"
+}
+
+func (self *LocaleString) GetKind() string {
+	return self.Kind
 }
 
 type ProcessSubstitution struct {
@@ -4453,18 +4543,18 @@ type ProcessSubstitution struct {
 	Kind      string
 }
 
-func (self *ProcessSubstitution) GetKind() string { return self.Kind }
-
 func (self *ProcessSubstitution) ToSexp() string {
 	return "(procsub \"" + self.Direction + "\" " + self.Command.ToSexp() + ")"
+}
+
+func (self *ProcessSubstitution) GetKind() string {
+	return self.Kind
 }
 
 type Negation struct {
 	Pipeline Node
 	Kind     string
 }
-
-func (self *Negation) GetKind() string { return self.Kind }
 
 func (self *Negation) ToSexp() string {
 	if _isNilInterfaceRef(self.Pipeline) {
@@ -4473,13 +4563,15 @@ func (self *Negation) ToSexp() string {
 	return "(negation " + self.Pipeline.ToSexp() + ")"
 }
 
+func (self *Negation) GetKind() string {
+	return self.Kind
+}
+
 type Time struct {
 	Pipeline Node
 	Posix    bool
 	Kind     string
 }
-
-func (self *Time) GetKind() string { return self.Kind }
 
 func (self *Time) ToSexp() string {
 	if _isNilInterfaceRef(self.Pipeline) {
@@ -4495,13 +4587,15 @@ func (self *Time) ToSexp() string {
 	return "(time " + self.Pipeline.ToSexp() + ")"
 }
 
+func (self *Time) GetKind() string {
+	return self.Kind
+}
+
 type ConditionalExpr struct {
 	Body      interface{}
 	Redirects []Node
 	Kind      string
 }
-
-func (self *ConditionalExpr) GetKind() string { return self.Kind }
 
 func (self *ConditionalExpr) ToSexp() string {
 	body := self.Body
@@ -4527,17 +4621,23 @@ func (self *ConditionalExpr) ToSexp() string {
 	return result
 }
 
+func (self *ConditionalExpr) GetKind() string {
+	return self.Kind
+}
+
 type UnaryTest struct {
 	Op      string
 	Operand Node
 	Kind    string
 }
 
-func (self *UnaryTest) GetKind() string { return self.Kind }
-
 func (self *UnaryTest) ToSexp() string {
 	operandVal := self.Operand.(*Word).GetCondFormattedValue()
 	return "(cond-unary \"" + self.Op + "\" (cond-term \"" + operandVal + "\"))"
+}
+
+func (self *UnaryTest) GetKind() string {
+	return self.Kind
 }
 
 type BinaryTest struct {
@@ -4547,12 +4647,14 @@ type BinaryTest struct {
 	Kind  string
 }
 
-func (self *BinaryTest) GetKind() string { return self.Kind }
-
 func (self *BinaryTest) ToSexp() string {
 	leftVal := self.Left.(*Word).GetCondFormattedValue()
 	rightVal := self.Right.(*Word).GetCondFormattedValue()
 	return "(cond-binary \"" + self.Op + "\" (cond-term \"" + leftVal + "\") (cond-term \"" + rightVal + "\"))"
+}
+
+func (self *BinaryTest) GetKind() string {
+	return self.Kind
 }
 
 type CondAnd struct {
@@ -4561,10 +4663,12 @@ type CondAnd struct {
 	Kind  string
 }
 
-func (self *CondAnd) GetKind() string { return self.Kind }
-
 func (self *CondAnd) ToSexp() string {
 	return "(cond-and " + self.Left.ToSexp() + " " + self.Right.ToSexp() + ")"
+}
+
+func (self *CondAnd) GetKind() string {
+	return self.Kind
 }
 
 type CondOr struct {
@@ -4573,10 +4677,12 @@ type CondOr struct {
 	Kind  string
 }
 
-func (self *CondOr) GetKind() string { return self.Kind }
-
 func (self *CondOr) ToSexp() string {
 	return "(cond-or " + self.Left.ToSexp() + " " + self.Right.ToSexp() + ")"
+}
+
+func (self *CondOr) GetKind() string {
+	return self.Kind
 }
 
 type CondNot struct {
@@ -4584,10 +4690,12 @@ type CondNot struct {
 	Kind    string
 }
 
-func (self *CondNot) GetKind() string { return self.Kind }
-
 func (self *CondNot) ToSexp() string {
 	return self.Operand.ToSexp()
+}
+
+func (self *CondNot) GetKind() string {
+	return self.Kind
 }
 
 type CondParen struct {
@@ -4595,18 +4703,18 @@ type CondParen struct {
 	Kind  string
 }
 
-func (self *CondParen) GetKind() string { return self.Kind }
-
 func (self *CondParen) ToSexp() string {
 	return "(cond-expr " + self.Inner.ToSexp() + ")"
+}
+
+func (self *CondParen) GetKind() string {
+	return self.Kind
 }
 
 type Array struct {
 	Elements []*Word
 	Kind     string
 }
-
-func (self *Array) GetKind() string { return self.Kind }
 
 func (self *Array) ToSexp() string {
 	if !(len(self.Elements) > 0) {
@@ -4620,13 +4728,15 @@ func (self *Array) ToSexp() string {
 	return "(array " + inner + ")"
 }
 
+func (self *Array) GetKind() string {
+	return self.Kind
+}
+
 type Coproc struct {
 	Command Node
 	Name    string
 	Kind    string
 }
-
-func (self *Coproc) GetKind() string { return self.Kind }
 
 func (self *Coproc) ToSexp() string {
 	var name string
@@ -4636,6 +4746,10 @@ func (self *Coproc) ToSexp() string {
 		name = "COPROC"
 	}
 	return "(coproc \"" + name + "\" " + self.Command.ToSexp() + ")"
+}
+
+func (self *Coproc) GetKind() string {
+	return self.Kind
 }
 
 type Parser struct {

--- a/dist/java/Parable.java
+++ b/dist/java/Parable.java
@@ -1959,8 +1959,6 @@ class Word implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String value = this.value;
         value = this._expandAllAnsiCQuotes(value);
@@ -3547,6 +3545,10 @@ class Word implements Node {
         value = value.replace("", "");
         return value.replaceFirst("[" + "\n" + "]+$", "");
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class Command implements Node {
@@ -3559,8 +3561,6 @@ class Command implements Node {
         this.redirects = redirects;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         List<String> parts = new ArrayList<>();
@@ -3576,6 +3576,10 @@ class Command implements Node {
         }
         return "(command " + inner + ")";
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class Pipeline implements Node {
@@ -3586,8 +3590,6 @@ class Pipeline implements Node {
         this.commands = commands;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         if (this.commands.size() == 1) {
@@ -3650,6 +3652,10 @@ class Pipeline implements Node {
         }
         return ((Node) cmd).toSexp();
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class ListNode implements Node {
@@ -3660,8 +3666,6 @@ class ListNode implements Node {
         this.parts = parts;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         List<Node> parts = new ArrayList<>(this.parts);
@@ -3776,6 +3780,10 @@ class ListNode implements Node {
         }
         return result;
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class Operator implements Node {
@@ -3787,11 +3795,13 @@ class Operator implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         Map<String, String> names = new HashMap<>(Map.of("&&", "and", "||", "or", ";", "semi", "&", "bg", "|", "pipe"));
         return "(" + names.getOrDefault(this.op, this.op) + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -3802,10 +3812,12 @@ class PipeBoth implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(pipe-both)";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -3816,10 +3828,12 @@ class Empty implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -3832,10 +3846,12 @@ class Comment implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -3851,8 +3867,6 @@ class Redirect implements Node {
         this.fd = fd;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         String op = this.op.replaceFirst("^[" + "0123456789" + "]+", "");
@@ -3921,6 +3935,10 @@ class Redirect implements Node {
         }
         return "(redirect \"" + op + "\" \"" + targetVal + "\")";
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class HereDoc implements Node {
@@ -3944,8 +3962,6 @@ class HereDoc implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String op = (this.stripTabs ? "<<-" : "<<");
         String content = this.content;
@@ -3953,6 +3969,10 @@ class HereDoc implements Node {
             content = content + "\\";
         }
         return String.format("(redirect \"%s\" \"%s\")", op, content);
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -3967,11 +3987,13 @@ class Subshell implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String base = "(subshell " + ((Node) this.body).toSexp() + ")";
         return ParableFunctions._appendRedirects(base, this.redirects);
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -3986,11 +4008,13 @@ class BraceGroup implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String base = "(brace-group " + ((Node) this.body).toSexp() + ")";
         return ParableFunctions._appendRedirects(base, this.redirects);
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4009,8 +4033,6 @@ class If implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String result = "(if " + ((Node) this.condition).toSexp() + " " + ((Node) this.thenBody).toSexp();
         if (this.elseBody != null) {
@@ -4021,6 +4043,10 @@ class If implements Node {
             result = result + " " + ((Node) r).toSexp();
         }
         return result;
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4037,11 +4063,13 @@ class While implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String base = "(while " + ((Node) this.condition).toSexp() + " " + ((Node) this.body).toSexp() + ")";
         return ParableFunctions._appendRedirects(base, this.redirects);
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4058,11 +4086,13 @@ class Until implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String base = "(until " + ((Node) this.condition).toSexp() + " " + ((Node) this.body).toSexp() + ")";
         return ParableFunctions._appendRedirects(base, this.redirects);
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4080,8 +4110,6 @@ class For implements Node {
         this.redirects = redirects;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         String suffix = "";
@@ -4110,6 +4138,10 @@ class For implements Node {
             }
         }
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class ForArith implements Node {
@@ -4129,8 +4161,6 @@ class ForArith implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String suffix = "";
         if ((!this.redirects.isEmpty())) {
@@ -4149,6 +4179,10 @@ class ForArith implements Node {
         String bodyStr = ((Node) this.body).toSexp();
         return String.format("(arith-for (init (word \"%s\")) (test (word \"%s\")) (step (word \"%s\")) %s)%s", initStr, condStr, incrStr, bodyStr, suffix);
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class Select implements Node {
@@ -4165,8 +4199,6 @@ class Select implements Node {
         this.redirects = redirects;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         String suffix = "";
@@ -4195,6 +4227,10 @@ class Select implements Node {
         }
         return "(select (word \"" + varEscaped + "\") " + inClause + " " + ((Node) this.body).toSexp() + ")" + suffix;
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class Case implements Node {
@@ -4210,8 +4246,6 @@ class Case implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         List<String> parts = new ArrayList<>();
         parts.add("(case " + ((Node) this.word).toSexp());
@@ -4220,6 +4254,10 @@ class Case implements Node {
         }
         String base = String.join(" ", parts) + ")";
         return ParableFunctions._appendRedirects(base, this.redirects);
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4235,8 +4273,6 @@ class CasePattern implements Node {
         this.terminator = terminator;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         List<String> alternatives = new ArrayList<>();
@@ -4327,6 +4363,10 @@ class CasePattern implements Node {
         parts.add(")");
         return String.join("", parts);
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class Function implements Node {
@@ -4340,10 +4380,12 @@ class Function implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(function \"" + this.name + "\" " + ((Node) this.body).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4360,8 +4402,6 @@ class ParamExpansion implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String escapedParam = this.param.replace("\\", "\\\\").replace("\"", "\\\"");
         if (!this.op.equals("")) {
@@ -4377,6 +4417,10 @@ class ParamExpansion implements Node {
         }
         return "(param \"" + escapedParam + "\")";
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class ParamLength implements Node {
@@ -4388,11 +4432,13 @@ class ParamLength implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String escaped = this.param.replace("\\", "\\\\").replace("\"", "\\\"");
         return "(param-len \"" + escaped + "\")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4409,8 +4455,6 @@ class ParamIndirect implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String escaped = this.param.replace("\\", "\\\\").replace("\"", "\\\"");
         if (!this.op.equals("")) {
@@ -4426,6 +4470,10 @@ class ParamIndirect implements Node {
         }
         return "(param-indirect \"" + escaped + "\")";
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class CommandSubstitution implements Node {
@@ -4439,13 +4487,15 @@ class CommandSubstitution implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         if (this.brace) {
             return "(funsub " + ((Node) this.command).toSexp() + ")";
         }
         return "(cmdsub " + ((Node) this.command).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4458,13 +4508,15 @@ class ArithmeticExpansion implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         if (this.expression == null) {
             return "(arith)";
         }
         return "(arith " + ((Node) this.expression).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4481,8 +4533,6 @@ class ArithmeticCommand implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String formatted = new Word(this.rawContent, new ArrayList<>(), "word")._formatCommandSubstitutions(this.rawContent, true);
         String escaped = formatted.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\t", "\\t");
@@ -4497,6 +4547,10 @@ class ArithmeticCommand implements Node {
         }
         return result;
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class ArithNumber implements Node {
@@ -4508,10 +4562,12 @@ class ArithNumber implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(number \"" + this.value + "\")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4522,10 +4578,12 @@ class ArithEmpty implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(empty)";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4538,10 +4596,12 @@ class ArithVar implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(var \"" + this.name + "\")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4558,10 +4618,12 @@ class ArithBinaryOp implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(binary-op \"" + this.op + "\" " + ((Node) this.left).toSexp() + " " + ((Node) this.right).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4576,10 +4638,12 @@ class ArithUnaryOp implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(unary-op \"" + this.op + "\" " + ((Node) this.operand).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4592,10 +4656,12 @@ class ArithPreIncr implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(pre-incr " + ((Node) this.operand).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4608,10 +4674,12 @@ class ArithPostIncr implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(post-incr " + ((Node) this.operand).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4624,10 +4692,12 @@ class ArithPreDecr implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(pre-decr " + ((Node) this.operand).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4640,10 +4710,12 @@ class ArithPostDecr implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(post-decr " + ((Node) this.operand).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4660,10 +4732,12 @@ class ArithAssign implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(assign \"" + this.op + "\" " + ((Node) this.target).toSexp() + " " + ((Node) this.value).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4680,10 +4754,12 @@ class ArithTernary implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(ternary " + ((Node) this.condition).toSexp() + " " + ((Node) this.ifTrue).toSexp() + " " + ((Node) this.ifFalse).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4698,10 +4774,12 @@ class ArithComma implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(comma " + ((Node) this.left).toSexp() + " " + ((Node) this.right).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4716,10 +4794,12 @@ class ArithSubscript implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(subscript \"" + this.array + "\" " + ((Node) this.index).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4732,10 +4812,12 @@ class ArithEscape implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(escape \"" + this.char_ + "\")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4748,11 +4830,13 @@ class ArithDeprecated implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String escaped = this.expression.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
         return "(arith-deprecated \"" + escaped + "\")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4765,14 +4849,16 @@ class ArithConcat implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         List<String> sexps = new ArrayList<>();
         for (Node p : this.parts) {
             sexps.add(((Node) p).toSexp());
         }
         return "(arith-concat " + String.join(" ", sexps) + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4785,11 +4871,13 @@ class AnsiCQuote implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String escaped = this.content.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
         return "(ansi-c \"" + escaped + "\")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4802,11 +4890,13 @@ class LocaleString implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String escaped = this.content.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
         return "(locale \"" + escaped + "\")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4821,10 +4911,12 @@ class ProcessSubstitution implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(procsub \"" + this.direction + "\" " + ((Node) this.command).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4837,13 +4929,15 @@ class Negation implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         if (this.pipeline == null) {
             return "(negation (command))";
         }
         return "(negation " + ((Node) this.pipeline).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4858,8 +4952,6 @@ class Time implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         if (this.pipeline == null) {
             if (this.posix) {
@@ -4873,6 +4965,10 @@ class Time implements Node {
         }
         return "(time " + ((Node) this.pipeline).toSexp() + ")";
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class ConditionalExpr implements Node {
@@ -4885,8 +4981,6 @@ class ConditionalExpr implements Node {
         this.redirects = redirects;
         this.kind = kind;
     }
-
-    public String getKind() { return this.kind; }
 
     public String toSexp() {
         Object body = this.body;
@@ -4907,6 +5001,10 @@ class ConditionalExpr implements Node {
         }
         return result;
     }
+
+    public String getKind() {
+        return this.kind;
+    }
 }
 
 class UnaryTest implements Node {
@@ -4920,11 +5018,13 @@ class UnaryTest implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String operandVal = ((Word) this.operand).getCondFormattedValue();
         return "(cond-unary \"" + this.op + "\" (cond-term \"" + operandVal + "\"))";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4941,12 +5041,14 @@ class BinaryTest implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String leftVal = ((Word) this.left).getCondFormattedValue();
         String rightVal = ((Word) this.right).getCondFormattedValue();
         return "(cond-binary \"" + this.op + "\" (cond-term \"" + leftVal + "\") (cond-term \"" + rightVal + "\"))";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4961,10 +5063,12 @@ class CondAnd implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(cond-and " + ((Node) this.left).toSexp() + " " + ((Node) this.right).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4979,10 +5083,12 @@ class CondOr implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(cond-or " + ((Node) this.left).toSexp() + " " + ((Node) this.right).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -4995,10 +5101,12 @@ class CondNot implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return ((Node) this.operand).toSexp();
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -5011,10 +5119,12 @@ class CondParen implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         return "(cond-expr " + ((Node) this.inner).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -5027,8 +5137,6 @@ class Array implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         if (!(!this.elements.isEmpty())) {
             return "(array)";
@@ -5039,6 +5147,10 @@ class Array implements Node {
         }
         String inner = String.join(" ", parts);
         return "(array " + inner + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 
@@ -5053,8 +5165,6 @@ class Coproc implements Node {
         this.kind = kind;
     }
 
-    public String getKind() { return this.kind; }
-
     public String toSexp() {
         String name = "";
         if ((!this.name.isEmpty())) {
@@ -5063,6 +5173,10 @@ class Coproc implements Node {
             name = "COPROC";
         }
         return "(coproc \"" + name + "\" " + ((Node) this.command).toSexp() + ")";
+    }
+
+    public String getKind() {
+        return this.kind;
     }
 }
 

--- a/dist/js/parable.js
+++ b/dist/js/parable.js
@@ -1920,9 +1920,6 @@ var Word = /** @class */ (function () {
         this.parts = parts !== null && parts !== void 0 ? parts : [];
         this.kind = kind;
     }
-    Word.prototype.getKind = function () {
-        return this.kind;
-    };
     Word.prototype.toSexp = function () {
         var value = this.value;
         value = this.ExpandAllAnsiCQuotes(value);
@@ -3631,6 +3628,9 @@ var Word = /** @class */ (function () {
         value = value.replace(//g, "");
         return value.replace(/[\n]+$/, '');
     };
+    Word.prototype.getKind = function () {
+        return this.kind;
+    };
     return Word;
 }());
 var Command = /** @class */ (function () {
@@ -3642,9 +3642,6 @@ var Command = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    Command.prototype.getKind = function () {
-        return this.kind;
-    };
     Command.prototype.toSexp = function () {
         var parts = [];
         parts.push.apply(parts, this.words.map(function (w) { return w.toSexp(); }));
@@ -3655,6 +3652,9 @@ var Command = /** @class */ (function () {
         }
         return "(command " + inner + ")";
     };
+    Command.prototype.getKind = function () {
+        return this.kind;
+    };
     return Command;
 }());
 var Pipeline = /** @class */ (function () {
@@ -3664,9 +3664,6 @@ var Pipeline = /** @class */ (function () {
         this.commands = commands !== null && commands !== void 0 ? commands : [];
         this.kind = kind;
     }
-    Pipeline.prototype.getKind = function () {
-        return this.kind;
-    };
     Pipeline.prototype.toSexp = function () {
         if (this.commands.length === 1) {
             return this.commands[0].toSexp();
@@ -3721,6 +3718,9 @@ var Pipeline = /** @class */ (function () {
         }
         return cmd.toSexp();
     };
+    Pipeline.prototype.getKind = function () {
+        return this.kind;
+    };
     return Pipeline;
 }());
 var List = /** @class */ (function () {
@@ -3730,9 +3730,6 @@ var List = /** @class */ (function () {
         this.parts = parts !== null && parts !== void 0 ? parts : [];
         this.kind = kind;
     }
-    List.prototype.getKind = function () {
-        return this.kind;
-    };
     List.prototype.toSexp = function () {
         var parts = this.parts.slice();
         var opNames = new Map([["&&", "and"], ["||", "or"], [";", "semi"], ["\n", "semi"], ["&", "background"]]);
@@ -3845,6 +3842,9 @@ var List = /** @class */ (function () {
         }
         return result;
     };
+    List.prototype.getKind = function () {
+        return this.kind;
+    };
     return List;
 }());
 var Operator = /** @class */ (function () {
@@ -3854,13 +3854,13 @@ var Operator = /** @class */ (function () {
         this.op = op;
         this.kind = kind;
     }
-    Operator.prototype.getKind = function () {
-        return this.kind;
-    };
     Operator.prototype.toSexp = function () {
         var _a;
         var names = new Map([["&&", "and"], ["||", "or"], [";", "semi"], ["&", "bg"], ["|", "pipe"]]);
         return ("(" + ((_a = names.get(this.op)) !== null && _a !== void 0 ? _a : this.op)) + ")";
+    };
+    Operator.prototype.getKind = function () {
+        return this.kind;
     };
     return Operator;
 }());
@@ -3869,11 +3869,11 @@ var PipeBoth = /** @class */ (function () {
         if (kind === void 0) { kind = ""; }
         this.kind = kind;
     }
-    PipeBoth.prototype.getKind = function () {
-        return this.kind;
-    };
     PipeBoth.prototype.toSexp = function () {
         return "(pipe-both)";
+    };
+    PipeBoth.prototype.getKind = function () {
+        return this.kind;
     };
     return PipeBoth;
 }());
@@ -3882,11 +3882,11 @@ var Empty = /** @class */ (function () {
         if (kind === void 0) { kind = ""; }
         this.kind = kind;
     }
-    Empty.prototype.getKind = function () {
-        return this.kind;
-    };
     Empty.prototype.toSexp = function () {
         return "";
+    };
+    Empty.prototype.getKind = function () {
+        return this.kind;
     };
     return Empty;
 }());
@@ -3897,11 +3897,11 @@ var Comment = /** @class */ (function () {
         this.text = text;
         this.kind = kind;
     }
-    Comment.prototype.getKind = function () {
-        return this.kind;
-    };
     Comment.prototype.toSexp = function () {
         return "";
+    };
+    Comment.prototype.getKind = function () {
+        return this.kind;
     };
     return Comment;
 }());
@@ -3916,9 +3916,6 @@ var Redirect = /** @class */ (function () {
         this.fd = fd;
         this.kind = kind;
     }
-    Redirect.prototype.getKind = function () {
-        return this.kind;
-    };
     Redirect.prototype.toSexp = function () {
         var op = this.op.replace(/^[0123456789]+/, '');
         if (op.startsWith("{")) {
@@ -3987,6 +3984,9 @@ var Redirect = /** @class */ (function () {
         }
         return "(redirect \"" + op + "\" \"" + targetVal + "\")";
     };
+    Redirect.prototype.getKind = function () {
+        return this.kind;
+    };
     return Redirect;
 }());
 var HereDoc = /** @class */ (function () {
@@ -4008,9 +4008,6 @@ var HereDoc = /** @class */ (function () {
         this.StartPos = StartPos;
         this.kind = kind;
     }
-    HereDoc.prototype.getKind = function () {
-        return this.kind;
-    };
     HereDoc.prototype.toSexp = function () {
         var op = (this.stripTabs ? "<<-" : "<<");
         var content = this.content;
@@ -4018,6 +4015,9 @@ var HereDoc = /** @class */ (function () {
             content = content + "\\";
         }
         return "(redirect \"".concat(op, "\" \"").concat(content, "\")");
+    };
+    HereDoc.prototype.getKind = function () {
+        return this.kind;
     };
     return HereDoc;
 }());
@@ -4030,12 +4030,12 @@ var Subshell = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    Subshell.prototype.getKind = function () {
-        return this.kind;
-    };
     Subshell.prototype.toSexp = function () {
         var base = "(subshell " + this.body.toSexp() + ")";
         return AppendRedirects(base, this.redirects);
+    };
+    Subshell.prototype.getKind = function () {
+        return this.kind;
     };
     return Subshell;
 }());
@@ -4048,12 +4048,12 @@ var BraceGroup = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    BraceGroup.prototype.getKind = function () {
-        return this.kind;
-    };
     BraceGroup.prototype.toSexp = function () {
         var base = "(brace-group " + this.body.toSexp() + ")";
         return AppendRedirects(base, this.redirects);
+    };
+    BraceGroup.prototype.getKind = function () {
+        return this.kind;
     };
     return BraceGroup;
 }());
@@ -4070,9 +4070,6 @@ var If = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    If.prototype.getKind = function () {
-        return this.kind;
-    };
     If.prototype.toSexp = function () {
         var result = "(if " + this.condition.toSexp() + " " + this.thenBody.toSexp();
         if (this.elseBody !== null) {
@@ -4084,6 +4081,9 @@ var If = /** @class */ (function () {
             result = result + " " + r.toSexp();
         }
         return result;
+    };
+    If.prototype.getKind = function () {
+        return this.kind;
     };
     return If;
 }());
@@ -4098,12 +4098,12 @@ var While = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    While.prototype.getKind = function () {
-        return this.kind;
-    };
     While.prototype.toSexp = function () {
         var base = "(while " + this.condition.toSexp() + " " + this.body.toSexp() + ")";
         return AppendRedirects(base, this.redirects);
+    };
+    While.prototype.getKind = function () {
+        return this.kind;
     };
     return While;
 }());
@@ -4118,12 +4118,12 @@ var Until = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    Until.prototype.getKind = function () {
-        return this.kind;
-    };
     Until.prototype.toSexp = function () {
         var base = "(until " + this.condition.toSexp() + " " + this.body.toSexp() + ")";
         return AppendRedirects(base, this.redirects);
+    };
+    Until.prototype.getKind = function () {
+        return this.kind;
     };
     return Until;
 }());
@@ -4140,9 +4140,6 @@ var For = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    For.prototype.getKind = function () {
-        return this.kind;
-    };
     For.prototype.toSexp = function () {
         var suffix = "";
         if ((this.redirects.length > 0)) {
@@ -4168,6 +4165,9 @@ var For = /** @class */ (function () {
             }
         }
     };
+    For.prototype.getKind = function () {
+        return this.kind;
+    };
     return For;
 }());
 var ForArith = /** @class */ (function () {
@@ -4185,9 +4185,6 @@ var ForArith = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    ForArith.prototype.getKind = function () {
-        return this.kind;
-    };
     ForArith.prototype.toSexp = function () {
         var suffix = "";
         if ((this.redirects.length > 0)) {
@@ -4204,6 +4201,9 @@ var ForArith = /** @class */ (function () {
         var bodyStr = this.body.toSexp();
         return "(arith-for (init (word \"".concat(initStr, "\")) (test (word \"").concat(condStr, "\")) (step (word \"").concat(incrStr, "\")) ").concat(bodyStr, ")").concat(suffix);
     };
+    ForArith.prototype.getKind = function () {
+        return this.kind;
+    };
     return ForArith;
 }());
 var Select = /** @class */ (function () {
@@ -4219,9 +4219,6 @@ var Select = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    Select.prototype.getKind = function () {
-        return this.kind;
-    };
     Select.prototype.toSexp = function () {
         var suffix = "";
         if ((this.redirects.length > 0)) {
@@ -4246,6 +4243,9 @@ var Select = /** @class */ (function () {
         }
         return "(select (word \"" + varEscaped + "\") " + inClause + " " + this.body.toSexp() + ")" + suffix;
     };
+    Select.prototype.getKind = function () {
+        return this.kind;
+    };
     return Select;
 }());
 var Case = /** @class */ (function () {
@@ -4259,15 +4259,15 @@ var Case = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    Case.prototype.getKind = function () {
-        return this.kind;
-    };
     Case.prototype.toSexp = function () {
         var parts = [];
         parts.push("(case " + this.word.toSexp());
         parts.push.apply(parts, this.patterns.map(function (p) { return p.toSexp(); }));
         var base = parts.join(" ") + ")";
         return AppendRedirects(base, this.redirects);
+    };
+    Case.prototype.getKind = function () {
+        return this.kind;
     };
     return Case;
 }());
@@ -4282,9 +4282,6 @@ var CasePattern = /** @class */ (function () {
         this.terminator = terminator;
         this.kind = kind;
     }
-    CasePattern.prototype.getKind = function () {
-        return this.kind;
-    };
     CasePattern.prototype.toSexp = function () {
         var alternatives = [];
         var current = [];
@@ -4373,6 +4370,9 @@ var CasePattern = /** @class */ (function () {
         parts.push(")");
         return parts.join("");
     };
+    CasePattern.prototype.getKind = function () {
+        return this.kind;
+    };
     return CasePattern;
 }());
 var FunctionName = /** @class */ (function () {
@@ -4384,11 +4384,11 @@ var FunctionName = /** @class */ (function () {
         this.body = body;
         this.kind = kind;
     }
-    FunctionName.prototype.getKind = function () {
-        return this.kind;
-    };
     FunctionName.prototype.toSexp = function () {
         return "(function \"" + this.name + "\" " + this.body.toSexp() + ")";
+    };
+    FunctionName.prototype.getKind = function () {
+        return this.kind;
     };
     return FunctionName;
 }());
@@ -4403,9 +4403,6 @@ var ParamExpansion = /** @class */ (function () {
         this.arg = arg;
         this.kind = kind;
     }
-    ParamExpansion.prototype.getKind = function () {
-        return this.kind;
-    };
     ParamExpansion.prototype.toSexp = function () {
         var escapedParam = this.param.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
         if (this.op !== "") {
@@ -4421,6 +4418,9 @@ var ParamExpansion = /** @class */ (function () {
         }
         return "(param \"" + escapedParam + "\")";
     };
+    ParamExpansion.prototype.getKind = function () {
+        return this.kind;
+    };
     return ParamExpansion;
 }());
 var ParamLength = /** @class */ (function () {
@@ -4430,12 +4430,12 @@ var ParamLength = /** @class */ (function () {
         this.param = param;
         this.kind = kind;
     }
-    ParamLength.prototype.getKind = function () {
-        return this.kind;
-    };
     ParamLength.prototype.toSexp = function () {
         var escaped = this.param.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
         return "(param-len \"" + escaped + "\")";
+    };
+    ParamLength.prototype.getKind = function () {
+        return this.kind;
     };
     return ParamLength;
 }());
@@ -4450,9 +4450,6 @@ var ParamIndirect = /** @class */ (function () {
         this.arg = arg;
         this.kind = kind;
     }
-    ParamIndirect.prototype.getKind = function () {
-        return this.kind;
-    };
     ParamIndirect.prototype.toSexp = function () {
         var escaped = this.param.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
         if (this.op !== "") {
@@ -4468,6 +4465,9 @@ var ParamIndirect = /** @class */ (function () {
         }
         return "(param-indirect \"" + escaped + "\")";
     };
+    ParamIndirect.prototype.getKind = function () {
+        return this.kind;
+    };
     return ParamIndirect;
 }());
 var CommandSubstitution = /** @class */ (function () {
@@ -4479,14 +4479,14 @@ var CommandSubstitution = /** @class */ (function () {
         this.brace = brace;
         this.kind = kind;
     }
-    CommandSubstitution.prototype.getKind = function () {
-        return this.kind;
-    };
     CommandSubstitution.prototype.toSexp = function () {
         if (this.brace) {
             return "(funsub " + this.command.toSexp() + ")";
         }
         return "(cmdsub " + this.command.toSexp() + ")";
+    };
+    CommandSubstitution.prototype.getKind = function () {
+        return this.kind;
     };
     return CommandSubstitution;
 }());
@@ -4497,14 +4497,14 @@ var ArithmeticExpansion = /** @class */ (function () {
         this.expression = expression;
         this.kind = kind;
     }
-    ArithmeticExpansion.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithmeticExpansion.prototype.toSexp = function () {
         if (this.expression === null) {
             return "(arith)";
         }
         return "(arith " + this.expression.toSexp() + ")";
+    };
+    ArithmeticExpansion.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithmeticExpansion;
 }());
@@ -4519,9 +4519,6 @@ var ArithmeticCommand = /** @class */ (function () {
         this.rawContent = rawContent;
         this.kind = kind;
     }
-    ArithmeticCommand.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithmeticCommand.prototype.toSexp = function () {
         var formatted = new Word(this.rawContent, [], "word").FormatCommandSubstitutions(this.rawContent, true);
         var escaped = formatted.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
@@ -4534,6 +4531,9 @@ var ArithmeticCommand = /** @class */ (function () {
         }
         return result;
     };
+    ArithmeticCommand.prototype.getKind = function () {
+        return this.kind;
+    };
     return ArithmeticCommand;
 }());
 var ArithNumber = /** @class */ (function () {
@@ -4543,11 +4543,11 @@ var ArithNumber = /** @class */ (function () {
         this.value = value;
         this.kind = kind;
     }
-    ArithNumber.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithNumber.prototype.toSexp = function () {
         return "(number \"" + this.value + "\")";
+    };
+    ArithNumber.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithNumber;
 }());
@@ -4556,11 +4556,11 @@ var ArithEmpty = /** @class */ (function () {
         if (kind === void 0) { kind = ""; }
         this.kind = kind;
     }
-    ArithEmpty.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithEmpty.prototype.toSexp = function () {
         return "(empty)";
+    };
+    ArithEmpty.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithEmpty;
 }());
@@ -4571,11 +4571,11 @@ var ArithVar = /** @class */ (function () {
         this.name = name;
         this.kind = kind;
     }
-    ArithVar.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithVar.prototype.toSexp = function () {
         return "(var \"" + this.name + "\")";
+    };
+    ArithVar.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithVar;
 }());
@@ -4590,11 +4590,11 @@ var ArithBinaryOp = /** @class */ (function () {
         this.right = right;
         this.kind = kind;
     }
-    ArithBinaryOp.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithBinaryOp.prototype.toSexp = function () {
         return "(binary-op \"" + this.op + "\" " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+    };
+    ArithBinaryOp.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithBinaryOp;
 }());
@@ -4607,11 +4607,11 @@ var ArithUnaryOp = /** @class */ (function () {
         this.operand = operand;
         this.kind = kind;
     }
-    ArithUnaryOp.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithUnaryOp.prototype.toSexp = function () {
         return "(unary-op \"" + this.op + "\" " + this.operand.toSexp() + ")";
+    };
+    ArithUnaryOp.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithUnaryOp;
 }());
@@ -4622,11 +4622,11 @@ var ArithPreIncr = /** @class */ (function () {
         this.operand = operand;
         this.kind = kind;
     }
-    ArithPreIncr.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithPreIncr.prototype.toSexp = function () {
         return "(pre-incr " + this.operand.toSexp() + ")";
+    };
+    ArithPreIncr.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithPreIncr;
 }());
@@ -4637,11 +4637,11 @@ var ArithPostIncr = /** @class */ (function () {
         this.operand = operand;
         this.kind = kind;
     }
-    ArithPostIncr.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithPostIncr.prototype.toSexp = function () {
         return "(post-incr " + this.operand.toSexp() + ")";
+    };
+    ArithPostIncr.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithPostIncr;
 }());
@@ -4652,11 +4652,11 @@ var ArithPreDecr = /** @class */ (function () {
         this.operand = operand;
         this.kind = kind;
     }
-    ArithPreDecr.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithPreDecr.prototype.toSexp = function () {
         return "(pre-decr " + this.operand.toSexp() + ")";
+    };
+    ArithPreDecr.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithPreDecr;
 }());
@@ -4667,11 +4667,11 @@ var ArithPostDecr = /** @class */ (function () {
         this.operand = operand;
         this.kind = kind;
     }
-    ArithPostDecr.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithPostDecr.prototype.toSexp = function () {
         return "(post-decr " + this.operand.toSexp() + ")";
+    };
+    ArithPostDecr.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithPostDecr;
 }());
@@ -4686,11 +4686,11 @@ var ArithAssign = /** @class */ (function () {
         this.value = value;
         this.kind = kind;
     }
-    ArithAssign.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithAssign.prototype.toSexp = function () {
         return "(assign \"" + this.op + "\" " + this.target.toSexp() + " " + this.value.toSexp() + ")";
+    };
+    ArithAssign.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithAssign;
 }());
@@ -4705,11 +4705,11 @@ var ArithTernary = /** @class */ (function () {
         this.ifFalse = ifFalse;
         this.kind = kind;
     }
-    ArithTernary.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithTernary.prototype.toSexp = function () {
         return "(ternary " + this.condition.toSexp() + " " + this.ifTrue.toSexp() + " " + this.ifFalse.toSexp() + ")";
+    };
+    ArithTernary.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithTernary;
 }());
@@ -4722,11 +4722,11 @@ var ArithComma = /** @class */ (function () {
         this.right = right;
         this.kind = kind;
     }
-    ArithComma.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithComma.prototype.toSexp = function () {
         return "(comma " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+    };
+    ArithComma.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithComma;
 }());
@@ -4739,11 +4739,11 @@ var ArithSubscript = /** @class */ (function () {
         this.index = index;
         this.kind = kind;
     }
-    ArithSubscript.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithSubscript.prototype.toSexp = function () {
         return "(subscript \"" + this.array + "\" " + this.index.toSexp() + ")";
+    };
+    ArithSubscript.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithSubscript;
 }());
@@ -4754,11 +4754,11 @@ var ArithEscape = /** @class */ (function () {
         this.char = char;
         this.kind = kind;
     }
-    ArithEscape.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithEscape.prototype.toSexp = function () {
         return "(escape \"" + this.char + "\")";
+    };
+    ArithEscape.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithEscape;
 }());
@@ -4769,12 +4769,12 @@ var ArithDeprecated = /** @class */ (function () {
         this.expression = expression;
         this.kind = kind;
     }
-    ArithDeprecated.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithDeprecated.prototype.toSexp = function () {
         var escaped = this.expression.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n");
         return "(arith-deprecated \"" + escaped + "\")";
+    };
+    ArithDeprecated.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithDeprecated;
 }());
@@ -4785,13 +4785,13 @@ var ArithConcat = /** @class */ (function () {
         this.parts = parts !== null && parts !== void 0 ? parts : [];
         this.kind = kind;
     }
-    ArithConcat.prototype.getKind = function () {
-        return this.kind;
-    };
     ArithConcat.prototype.toSexp = function () {
         var sexps = [];
         sexps.push.apply(sexps, this.parts.map(function (p) { return p.toSexp(); }));
         return "(arith-concat " + sexps.join(" ") + ")";
+    };
+    ArithConcat.prototype.getKind = function () {
+        return this.kind;
     };
     return ArithConcat;
 }());
@@ -4802,12 +4802,12 @@ var AnsiCQuote = /** @class */ (function () {
         this.content = content;
         this.kind = kind;
     }
-    AnsiCQuote.prototype.getKind = function () {
-        return this.kind;
-    };
     AnsiCQuote.prototype.toSexp = function () {
         var escaped = this.content.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n");
         return "(ansi-c \"" + escaped + "\")";
+    };
+    AnsiCQuote.prototype.getKind = function () {
+        return this.kind;
     };
     return AnsiCQuote;
 }());
@@ -4818,12 +4818,12 @@ var LocaleString = /** @class */ (function () {
         this.content = content;
         this.kind = kind;
     }
-    LocaleString.prototype.getKind = function () {
-        return this.kind;
-    };
     LocaleString.prototype.toSexp = function () {
         var escaped = this.content.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n");
         return "(locale \"" + escaped + "\")";
+    };
+    LocaleString.prototype.getKind = function () {
+        return this.kind;
     };
     return LocaleString;
 }());
@@ -4836,11 +4836,11 @@ var ProcessSubstitution = /** @class */ (function () {
         this.command = command;
         this.kind = kind;
     }
-    ProcessSubstitution.prototype.getKind = function () {
-        return this.kind;
-    };
     ProcessSubstitution.prototype.toSexp = function () {
         return "(procsub \"" + this.direction + "\" " + this.command.toSexp() + ")";
+    };
+    ProcessSubstitution.prototype.getKind = function () {
+        return this.kind;
     };
     return ProcessSubstitution;
 }());
@@ -4851,14 +4851,14 @@ var Negation = /** @class */ (function () {
         this.pipeline = pipeline;
         this.kind = kind;
     }
-    Negation.prototype.getKind = function () {
-        return this.kind;
-    };
     Negation.prototype.toSexp = function () {
         if (this.pipeline === null) {
             return "(negation (command))";
         }
         return "(negation " + this.pipeline.toSexp() + ")";
+    };
+    Negation.prototype.getKind = function () {
+        return this.kind;
     };
     return Negation;
 }());
@@ -4871,9 +4871,6 @@ var Time = /** @class */ (function () {
         this.posix = posix;
         this.kind = kind;
     }
-    Time.prototype.getKind = function () {
-        return this.kind;
-    };
     Time.prototype.toSexp = function () {
         if (this.pipeline === null) {
             if (this.posix) {
@@ -4888,6 +4885,9 @@ var Time = /** @class */ (function () {
         }
         return "(time " + this.pipeline.toSexp() + ")";
     };
+    Time.prototype.getKind = function () {
+        return this.kind;
+    };
     return Time;
 }());
 var ConditionalExpr = /** @class */ (function () {
@@ -4899,9 +4899,6 @@ var ConditionalExpr = /** @class */ (function () {
         this.redirects = redirects !== null && redirects !== void 0 ? redirects : [];
         this.kind = kind;
     }
-    ConditionalExpr.prototype.getKind = function () {
-        return this.kind;
-    };
     ConditionalExpr.prototype.toSexp = function () {
         var body = this.body;
         if (typeof body === 'string') {
@@ -4919,6 +4916,9 @@ var ConditionalExpr = /** @class */ (function () {
         }
         return result;
     };
+    ConditionalExpr.prototype.getKind = function () {
+        return this.kind;
+    };
     return ConditionalExpr;
 }());
 var UnaryTest = /** @class */ (function () {
@@ -4930,12 +4930,12 @@ var UnaryTest = /** @class */ (function () {
         this.operand = operand;
         this.kind = kind;
     }
-    UnaryTest.prototype.getKind = function () {
-        return this.kind;
-    };
     UnaryTest.prototype.toSexp = function () {
         var operandVal = this.operand.getCondFormattedValue();
         return "(cond-unary \"" + this.op + "\" (cond-term \"" + operandVal + "\"))";
+    };
+    UnaryTest.prototype.getKind = function () {
+        return this.kind;
     };
     return UnaryTest;
 }());
@@ -4950,13 +4950,13 @@ var BinaryTest = /** @class */ (function () {
         this.right = right;
         this.kind = kind;
     }
-    BinaryTest.prototype.getKind = function () {
-        return this.kind;
-    };
     BinaryTest.prototype.toSexp = function () {
         var leftVal = this.left.getCondFormattedValue();
         var rightVal = this.right.getCondFormattedValue();
         return "(cond-binary \"" + this.op + "\" (cond-term \"" + leftVal + "\") (cond-term \"" + rightVal + "\"))";
+    };
+    BinaryTest.prototype.getKind = function () {
+        return this.kind;
     };
     return BinaryTest;
 }());
@@ -4969,11 +4969,11 @@ var CondAnd = /** @class */ (function () {
         this.right = right;
         this.kind = kind;
     }
-    CondAnd.prototype.getKind = function () {
-        return this.kind;
-    };
     CondAnd.prototype.toSexp = function () {
         return "(cond-and " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+    };
+    CondAnd.prototype.getKind = function () {
+        return this.kind;
     };
     return CondAnd;
 }());
@@ -4986,11 +4986,11 @@ var CondOr = /** @class */ (function () {
         this.right = right;
         this.kind = kind;
     }
-    CondOr.prototype.getKind = function () {
-        return this.kind;
-    };
     CondOr.prototype.toSexp = function () {
         return "(cond-or " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+    };
+    CondOr.prototype.getKind = function () {
+        return this.kind;
     };
     return CondOr;
 }());
@@ -5001,11 +5001,11 @@ var CondNot = /** @class */ (function () {
         this.operand = operand;
         this.kind = kind;
     }
-    CondNot.prototype.getKind = function () {
-        return this.kind;
-    };
     CondNot.prototype.toSexp = function () {
         return this.operand.toSexp();
+    };
+    CondNot.prototype.getKind = function () {
+        return this.kind;
     };
     return CondNot;
 }());
@@ -5016,11 +5016,11 @@ var CondParen = /** @class */ (function () {
         this.inner = inner;
         this.kind = kind;
     }
-    CondParen.prototype.getKind = function () {
-        return this.kind;
-    };
     CondParen.prototype.toSexp = function () {
         return "(cond-expr " + this.inner.toSexp() + ")";
+    };
+    CondParen.prototype.getKind = function () {
+        return this.kind;
     };
     return CondParen;
 }());
@@ -5031,9 +5031,6 @@ var ArrayName = /** @class */ (function () {
         this.elements = elements !== null && elements !== void 0 ? elements : [];
         this.kind = kind;
     }
-    ArrayName.prototype.getKind = function () {
-        return this.kind;
-    };
     ArrayName.prototype.toSexp = function () {
         if (!(this.elements.length > 0)) {
             return "(array)";
@@ -5042,6 +5039,9 @@ var ArrayName = /** @class */ (function () {
         parts.push.apply(parts, this.elements.map(function (e) { return e.toSexp(); }));
         var inner = parts.join(" ");
         return "(array " + inner + ")";
+    };
+    ArrayName.prototype.getKind = function () {
+        return this.kind;
     };
     return ArrayName;
 }());
@@ -5054,9 +5054,6 @@ var Coproc = /** @class */ (function () {
         this.name = name;
         this.kind = kind;
     }
-    Coproc.prototype.getKind = function () {
-        return this.kind;
-    };
     Coproc.prototype.toSexp = function () {
         if ((this.name.length > 0)) {
             var name = this.name;
@@ -5065,6 +5062,9 @@ var Coproc = /** @class */ (function () {
             var name = "COPROC";
         }
         return "(coproc \"" + name + "\" " + this.command.toSexp() + ")";
+    };
+    Coproc.prototype.getKind = function () {
+        return this.kind;
     };
     return Coproc;
 }());

--- a/dist/python/parable.py
+++ b/dist/python/parable.py
@@ -2609,6 +2609,9 @@ class Word(Node):
         value = value.replace("", "")
         return value.rstrip("\n")
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Command(Node):
@@ -2626,6 +2629,9 @@ class Command(Node):
         if not inner:
             return "(command)"
         return "(command " + inner + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -2681,6 +2687,9 @@ class Pipeline(Node):
             parts.append("(redirect \">&\" 1)")
             return "(command " + " ".join(parts) + ")"
         return cmd.to_sexp()
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -2781,6 +2790,9 @@ class List(Node):
             i += 2
         return result
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Operator(Node):
@@ -2791,6 +2803,9 @@ class Operator(Node):
         names = {"&&": "and", "||": "or", ";": "semi", "&": "bg", "|": "pipe"}
         return "(" + names.get(self.op, self.op) + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class PipeBoth(Node):
@@ -2798,6 +2813,9 @@ class PipeBoth(Node):
 
     def to_sexp(self) -> str:
         return "(pipe-both)"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -2807,6 +2825,9 @@ class Empty(Node):
     def to_sexp(self) -> str:
         return ""
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Comment(Node):
@@ -2815,6 +2836,9 @@ class Comment(Node):
 
     def to_sexp(self) -> str:
         return ""
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -2872,6 +2896,9 @@ class Redirect(Node):
             return "(redirect \"" + op + "\" \"" + out_val + "\")"
         return "(redirect \"" + op + "\" \"" + target_val + "\")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class HereDoc(Node):
@@ -2891,6 +2918,9 @@ class HereDoc(Node):
             content = content + "\\"
         return f"(redirect \"{op}\" \"{content}\")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Subshell(Node):
@@ -2902,6 +2932,9 @@ class Subshell(Node):
         base = "(subshell " + self.body.to_sexp() + ")"
         return _append_redirects(base, self.redirects)
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class BraceGroup(Node):
@@ -2912,6 +2945,9 @@ class BraceGroup(Node):
     def to_sexp(self) -> str:
         base = "(brace-group " + self.body.to_sexp() + ")"
         return _append_redirects(base, self.redirects)
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -2931,6 +2967,9 @@ class If(Node):
             result = result + " " + r.to_sexp()
         return result
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class While(Node):
@@ -2943,6 +2982,9 @@ class While(Node):
         base = "(while " + self.condition.to_sexp() + " " + self.body.to_sexp() + ")"
         return _append_redirects(base, self.redirects)
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Until(Node):
@@ -2954,6 +2996,9 @@ class Until(Node):
     def to_sexp(self) -> str:
         base = "(until " + self.condition.to_sexp() + " " + self.body.to_sexp() + ")"
         return _append_redirects(base, self.redirects)
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -2985,6 +3030,9 @@ class For(Node):
             word_strs = " ".join(word_parts)
             return "(for (word \"" + var_escaped + "\") (in " + word_strs + ") " + self.body.to_sexp() + ")" + suffix
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ForArith(Node):
@@ -3010,6 +3058,9 @@ class ForArith(Node):
         incr_str = _format_arith_val(incr_val)
         body_str = self.body.to_sexp()
         return f"(arith-for (init (word \"{init_str}\")) (test (word \"{cond_str}\")) (step (word \"{incr_str}\")) {body_str}){suffix}"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3041,6 +3092,9 @@ class Select(Node):
             in_clause = "(in (word \"\\\"$@\\\"\"))"
         return "(select (word \"" + var_escaped + "\") " + in_clause + " " + self.body.to_sexp() + ")" + suffix
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Case(Node):
@@ -3056,6 +3110,9 @@ class Case(Node):
             parts.append(p.to_sexp())
         base = " ".join(parts) + ")"
         return _append_redirects(base, self.redirects)
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3125,6 +3182,9 @@ class CasePattern(Node):
         parts.append(")")
         return "".join(parts)
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Function(Node):
@@ -3134,6 +3194,9 @@ class Function(Node):
 
     def to_sexp(self) -> str:
         return "(function \"" + self.name + "\" " + self.body.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3155,6 +3218,9 @@ class ParamExpansion(Node):
             return "(param \"" + escaped_param + "\" \"" + escaped_op + "\" \"" + escaped_arg + "\")"
         return "(param \"" + escaped_param + "\")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ParamLength(Node):
@@ -3164,6 +3230,9 @@ class ParamLength(Node):
     def to_sexp(self) -> str:
         escaped = self.param.replace("\\", "\\\\").replace("\"", "\\\"")
         return "(param-len \"" + escaped + "\")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3185,6 +3254,9 @@ class ParamIndirect(Node):
             return "(param-indirect \"" + escaped + "\" \"" + escaped_op + "\" \"" + escaped_arg + "\")"
         return "(param-indirect \"" + escaped + "\")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class CommandSubstitution(Node):
@@ -3197,6 +3269,9 @@ class CommandSubstitution(Node):
             return "(funsub " + self.command.to_sexp() + ")"
         return "(cmdsub " + self.command.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithmeticExpansion(Node):
@@ -3207,6 +3282,9 @@ class ArithmeticExpansion(Node):
         if self.expression is None:
             return "(arith)"
         return "(arith " + self.expression.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3228,6 +3306,9 @@ class ArithmeticCommand(Node):
             return result + " " + redirect_sexps
         return result
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithNumber(Node):
@@ -3237,6 +3318,9 @@ class ArithNumber(Node):
     def to_sexp(self) -> str:
         return "(number \"" + self.value + "\")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithEmpty(Node):
@@ -3244,6 +3328,9 @@ class ArithEmpty(Node):
 
     def to_sexp(self) -> str:
         return "(empty)"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3253,6 +3340,9 @@ class ArithVar(Node):
 
     def to_sexp(self) -> str:
         return "(var \"" + self.name + "\")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3265,6 +3355,9 @@ class ArithBinaryOp(Node):
     def to_sexp(self) -> str:
         return "(binary-op \"" + self.op + "\" " + self.left.to_sexp() + " " + self.right.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithUnaryOp(Node):
@@ -3275,6 +3368,9 @@ class ArithUnaryOp(Node):
     def to_sexp(self) -> str:
         return "(unary-op \"" + self.op + "\" " + self.operand.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithPreIncr(Node):
@@ -3283,6 +3379,9 @@ class ArithPreIncr(Node):
 
     def to_sexp(self) -> str:
         return "(pre-incr " + self.operand.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3293,6 +3392,9 @@ class ArithPostIncr(Node):
     def to_sexp(self) -> str:
         return "(post-incr " + self.operand.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithPreDecr(Node):
@@ -3302,6 +3404,9 @@ class ArithPreDecr(Node):
     def to_sexp(self) -> str:
         return "(pre-decr " + self.operand.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithPostDecr(Node):
@@ -3310,6 +3415,9 @@ class ArithPostDecr(Node):
 
     def to_sexp(self) -> str:
         return "(post-decr " + self.operand.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3322,6 +3430,9 @@ class ArithAssign(Node):
     def to_sexp(self) -> str:
         return "(assign \"" + self.op + "\" " + self.target.to_sexp() + " " + self.value.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithTernary(Node):
@@ -3333,6 +3444,9 @@ class ArithTernary(Node):
     def to_sexp(self) -> str:
         return "(ternary " + self.condition.to_sexp() + " " + self.if_true.to_sexp() + " " + self.if_false.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithComma(Node):
@@ -3342,6 +3456,9 @@ class ArithComma(Node):
 
     def to_sexp(self) -> str:
         return "(comma " + self.left.to_sexp() + " " + self.right.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3353,6 +3470,9 @@ class ArithSubscript(Node):
     def to_sexp(self) -> str:
         return "(subscript \"" + self.array + "\" " + self.index.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ArithEscape(Node):
@@ -3361,6 +3481,9 @@ class ArithEscape(Node):
 
     def to_sexp(self) -> str:
         return "(escape \"" + self.char + "\")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3371,6 +3494,9 @@ class ArithDeprecated(Node):
     def to_sexp(self) -> str:
         escaped = self.expression.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
         return "(arith-deprecated \"" + escaped + "\")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3384,6 +3510,9 @@ class ArithConcat(Node):
             sexps.append(p.to_sexp())
         return "(arith-concat " + " ".join(sexps) + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class AnsiCQuote(Node):
@@ -3393,6 +3522,9 @@ class AnsiCQuote(Node):
     def to_sexp(self) -> str:
         escaped = self.content.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
         return "(ansi-c \"" + escaped + "\")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3404,6 +3536,9 @@ class LocaleString(Node):
         escaped = self.content.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
         return "(locale \"" + escaped + "\")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class ProcessSubstitution(Node):
@@ -3413,6 +3548,9 @@ class ProcessSubstitution(Node):
 
     def to_sexp(self) -> str:
         return "(procsub \"" + self.direction + "\" " + self.command.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3424,6 +3562,9 @@ class Negation(Node):
         if self.pipeline is None:
             return "(negation (command))"
         return "(negation " + self.pipeline.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3441,6 +3582,9 @@ class Time(Node):
         if self.posix:
             return "(time -p " + self.pipeline.to_sexp() + ")"
         return "(time " + self.pipeline.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3465,6 +3609,9 @@ class ConditionalExpr(Node):
             return result + " " + redirect_sexps
         return result
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class UnaryTest(Node):
@@ -3475,6 +3622,9 @@ class UnaryTest(Node):
     def to_sexp(self) -> str:
         operand_val = self.operand.get_cond_formatted_value()
         return "(cond-unary \"" + self.op + "\" (cond-term \"" + operand_val + "\"))"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3489,6 +3639,9 @@ class BinaryTest(Node):
         right_val = self.right.get_cond_formatted_value()
         return "(cond-binary \"" + self.op + "\" (cond-term \"" + left_val + "\") (cond-term \"" + right_val + "\"))"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class CondAnd(Node):
@@ -3498,6 +3651,9 @@ class CondAnd(Node):
 
     def to_sexp(self) -> str:
         return "(cond-and " + self.left.to_sexp() + " " + self.right.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3509,6 +3665,9 @@ class CondOr(Node):
     def to_sexp(self) -> str:
         return "(cond-or " + self.left.to_sexp() + " " + self.right.to_sexp() + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class CondNot(Node):
@@ -3518,6 +3677,9 @@ class CondNot(Node):
     def to_sexp(self) -> str:
         return self.operand.to_sexp()
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class CondParen(Node):
@@ -3526,6 +3688,9 @@ class CondParen(Node):
 
     def to_sexp(self) -> str:
         return "(cond-expr " + self.inner.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass
@@ -3542,6 +3707,9 @@ class Array(Node):
         inner = " ".join(parts)
         return "(array " + inner + ")"
 
+    def GetKind(self) -> str:
+        return self.kind
+
 
 @dataclass
 class Coproc(Node):
@@ -3555,6 +3723,9 @@ class Coproc(Node):
         else:
             name = "COPROC"
         return "(coproc \"" + name + "\" " + self.command.to_sexp() + ")"
+
+    def GetKind(self) -> str:
+        return self.kind
 
 
 @dataclass

--- a/dist/ts/parable.ts
+++ b/dist/ts/parable.ts
@@ -1876,10 +1876,6 @@ class Word implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var value: any = this.value;
     value = this.ExpandAllAnsiCQuotes(value);
@@ -3444,6 +3440,10 @@ class Word implements Node {
     value = value.replace(//g, "");
     return value.replace(/[\n]+$/, '');
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class Command implements Node {
@@ -3457,10 +3457,6 @@ class Command implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var parts: any = [];
     parts.push(...this.words.map(w => w.toSexp()));
@@ -3471,6 +3467,10 @@ class Command implements Node {
     }
     return "(command " + inner + ")";
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class Pipeline implements Node {
@@ -3480,10 +3480,6 @@ class Pipeline implements Node {
   constructor(commands: Node[] = [], kind: string = "") {
     this.commands = commands ?? [];
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -3540,6 +3536,10 @@ class Pipeline implements Node {
     }
     return cmd.toSexp();
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class List implements Node {
@@ -3549,10 +3549,6 @@ class List implements Node {
   constructor(parts: Node[] = [], kind: string = "") {
     this.parts = parts ?? [];
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -3665,6 +3661,10 @@ class List implements Node {
     }
     return result;
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class Operator implements Node {
@@ -3676,13 +3676,13 @@ class Operator implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var names: any = new Map([["&&", "and"], ["||", "or"], [";", "semi"], ["&", "bg"], ["|", "pipe"]]);
     return ("(" + (names.get(this.op) ?? this.op)) + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3693,12 +3693,12 @@ class PipeBoth implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(pipe-both)";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3709,12 +3709,12 @@ class Empty implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3727,12 +3727,12 @@ class Comment implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3747,10 +3747,6 @@ class Redirect implements Node {
     this.target = target;
     this.fd = fd;
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -3820,6 +3816,10 @@ class Redirect implements Node {
     }
     return "(redirect \"" + op + "\" \"" + targetVal + "\")";
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class HereDoc implements Node {
@@ -3843,10 +3843,6 @@ class HereDoc implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var op: any = (this.stripTabs ? "<<-" : "<<");
     var content: any = this.content;
@@ -3854,6 +3850,10 @@ class HereDoc implements Node {
       content = content + "\\";
     }
     return `(redirect "${op}" "${content}")`;
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3868,13 +3868,13 @@ class Subshell implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var base: any = "(subshell " + this.body.toSexp() + ")";
     return AppendRedirects(base, this.redirects);
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3889,13 +3889,13 @@ class BraceGroup implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var base: any = "(brace-group " + this.body.toSexp() + ")";
     return AppendRedirects(base, this.redirects);
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3914,10 +3914,6 @@ class If implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var result: any = "(if " + this.condition.toSexp() + " " + this.thenBody.toSexp();
     if (this.elseBody !== null) {
@@ -3928,6 +3924,10 @@ class If implements Node {
       result = result + " " + r.toSexp();
     }
     return result;
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3944,13 +3944,13 @@ class While implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var base: any = "(while " + this.condition.toSexp() + " " + this.body.toSexp() + ")";
     return AppendRedirects(base, this.redirects);
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3967,13 +3967,13 @@ class Until implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var base: any = "(until " + this.condition.toSexp() + " " + this.body.toSexp() + ")";
     return AppendRedirects(base, this.redirects);
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -3990,10 +3990,6 @@ class For implements Node {
     this.body = body;
     this.redirects = redirects ?? [];
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -4019,6 +4015,10 @@ class For implements Node {
       }
     }
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class ForArith implements Node {
@@ -4038,10 +4038,6 @@ class ForArith implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var suffix: any = "";
     if ((this.redirects.length > 0)) {
@@ -4058,6 +4054,10 @@ class ForArith implements Node {
     var bodyStr: any = this.body.toSexp();
     return `(arith-for (init (word "${initStr}")) (test (word "${condStr}")) (step (word "${incrStr}")) ${bodyStr})${suffix}`;
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class Select implements Node {
@@ -4073,10 +4073,6 @@ class Select implements Node {
     this.body = body;
     this.redirects = redirects ?? [];
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -4101,6 +4097,10 @@ class Select implements Node {
     }
     return "(select (word \"" + varEscaped + "\") " + inClause + " " + this.body.toSexp() + ")" + suffix;
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class Case implements Node {
@@ -4116,16 +4116,16 @@ class Case implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var parts: any = [];
     parts.push("(case " + this.word.toSexp());
     parts.push(...this.patterns.map(p => p.toSexp()));
     var base: any = parts.join(" ") + ")";
     return AppendRedirects(base, this.redirects);
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4140,10 +4140,6 @@ class CasePattern implements Node {
     this.body = body;
     this.terminator = terminator;
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -4224,6 +4220,10 @@ class CasePattern implements Node {
     parts.push(")");
     return parts.join("");
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class FunctionName implements Node {
@@ -4237,12 +4237,12 @@ class FunctionName implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(function \"" + this.name + "\" " + this.body.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4259,10 +4259,6 @@ class ParamExpansion implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var escapedParam: any = this.param.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
     if (this.op !== "") {
@@ -4277,6 +4273,10 @@ class ParamExpansion implements Node {
     }
     return "(param \"" + escapedParam + "\")";
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class ParamLength implements Node {
@@ -4288,13 +4288,13 @@ class ParamLength implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var escaped: any = this.param.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
     return "(param-len \"" + escaped + "\")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4311,10 +4311,6 @@ class ParamIndirect implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var escaped: any = this.param.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
     if (this.op !== "") {
@@ -4329,6 +4325,10 @@ class ParamIndirect implements Node {
     }
     return "(param-indirect \"" + escaped + "\")";
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class CommandSubstitution implements Node {
@@ -4342,15 +4342,15 @@ class CommandSubstitution implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     if (this.brace) {
       return "(funsub " + this.command.toSexp() + ")";
     }
     return "(cmdsub " + this.command.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4363,15 +4363,15 @@ class ArithmeticExpansion implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     if (this.expression === null) {
       return "(arith)";
     }
     return "(arith " + this.expression.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4388,10 +4388,6 @@ class ArithmeticCommand implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var formatted: any = new Word(this.rawContent as any, [], "word" as any).FormatCommandSubstitutions(this.rawContent, true);
     var escaped: any = formatted.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
@@ -4404,6 +4400,10 @@ class ArithmeticCommand implements Node {
     }
     return result;
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class ArithNumber implements Node {
@@ -4415,12 +4415,12 @@ class ArithNumber implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(number \"" + this.value + "\")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4431,12 +4431,12 @@ class ArithEmpty implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(empty)";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4449,12 +4449,12 @@ class ArithVar implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(var \"" + this.name + "\")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4471,12 +4471,12 @@ class ArithBinaryOp implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(binary-op \"" + this.op + "\" " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4491,12 +4491,12 @@ class ArithUnaryOp implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(unary-op \"" + this.op + "\" " + this.operand.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4509,12 +4509,12 @@ class ArithPreIncr implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(pre-incr " + this.operand.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4527,12 +4527,12 @@ class ArithPostIncr implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(post-incr " + this.operand.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4545,12 +4545,12 @@ class ArithPreDecr implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(pre-decr " + this.operand.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4563,12 +4563,12 @@ class ArithPostDecr implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(post-decr " + this.operand.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4585,12 +4585,12 @@ class ArithAssign implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(assign \"" + this.op + "\" " + this.target.toSexp() + " " + this.value.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4607,12 +4607,12 @@ class ArithTernary implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(ternary " + this.condition.toSexp() + " " + this.ifTrue.toSexp() + " " + this.ifFalse.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4627,12 +4627,12 @@ class ArithComma implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(comma " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4647,12 +4647,12 @@ class ArithSubscript implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(subscript \"" + this.array + "\" " + this.index.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4665,12 +4665,12 @@ class ArithEscape implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(escape \"" + this.char + "\")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4683,13 +4683,13 @@ class ArithDeprecated implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var escaped: any = this.expression.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n");
     return "(arith-deprecated \"" + escaped + "\")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4702,14 +4702,14 @@ class ArithConcat implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var sexps: any = [];
     sexps.push(...this.parts.map(p => p.toSexp()));
     return "(arith-concat " + sexps.join(" ") + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4722,13 +4722,13 @@ class AnsiCQuote implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var escaped: any = this.content.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n");
     return "(ansi-c \"" + escaped + "\")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4741,13 +4741,13 @@ class LocaleString implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var escaped: any = this.content.replace(/\\/g, "\\\\").replace(/"/g, "\\\"").replace(/\n/g, "\\n");
     return "(locale \"" + escaped + "\")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4762,12 +4762,12 @@ class ProcessSubstitution implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(procsub \"" + this.direction + "\" " + this.command.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4780,15 +4780,15 @@ class Negation implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     if (this.pipeline === null) {
       return "(negation (command))";
     }
     return "(negation " + this.pipeline.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4801,10 +4801,6 @@ class Time implements Node {
     this.pipeline = pipeline;
     this.posix = posix;
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -4820,6 +4816,10 @@ class Time implements Node {
     }
     return "(time " + this.pipeline.toSexp() + ")";
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class ConditionalExpr implements Node {
@@ -4831,10 +4831,6 @@ class ConditionalExpr implements Node {
     this.body = body;
     this.redirects = redirects ?? [];
     this.kind = kind;
-  }
-
-  getKind(): string {
-    return this.kind;
   }
 
   toSexp(): string {
@@ -4853,6 +4849,10 @@ class ConditionalExpr implements Node {
     }
     return result;
   }
+
+  getKind(): string {
+    return this.kind;
+  }
 }
 
 class UnaryTest implements Node {
@@ -4866,13 +4866,13 @@ class UnaryTest implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var operandVal: any = (this.operand as unknown as Word).getCondFormattedValue();
     return "(cond-unary \"" + this.op + "\" (cond-term \"" + operandVal + "\"))";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4889,14 +4889,14 @@ class BinaryTest implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     var leftVal: any = (this.left as unknown as Word).getCondFormattedValue();
     var rightVal: any = (this.right as unknown as Word).getCondFormattedValue();
     return "(cond-binary \"" + this.op + "\" (cond-term \"" + leftVal + "\") (cond-term \"" + rightVal + "\"))";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4911,12 +4911,12 @@ class CondAnd implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(cond-and " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4931,12 +4931,12 @@ class CondOr implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(cond-or " + this.left.toSexp() + " " + this.right.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4949,12 +4949,12 @@ class CondNot implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return this.operand.toSexp();
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4967,12 +4967,12 @@ class CondParen implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     return "(cond-expr " + this.inner.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -4985,10 +4985,6 @@ class ArrayName implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     if (!(this.elements.length > 0)) {
       return "(array)";
@@ -4997,6 +4993,10 @@ class ArrayName implements Node {
     parts.push(...this.elements.map(e => e.toSexp()));
     var inner: any = parts.join(" ");
     return "(array " + inner + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 
@@ -5011,10 +5011,6 @@ class Coproc implements Node {
     this.kind = kind;
   }
 
-  getKind(): string {
-    return this.kind;
-  }
-
   toSexp(): string {
     if ((this.name.length > 0)) {
       var name: any = this.name;
@@ -5022,6 +5018,10 @@ class Coproc implements Node {
       var name: any = "COPROC";
     }
     return "(coproc \"" + name + "\" " + this.command.toSexp() + ")";
+  }
+
+  getKind(): string {
+    return this.kind;
   }
 }
 

--- a/transpiler/src/backend/go.py
+++ b/transpiler/src/backend/go.py
@@ -557,11 +557,6 @@ func _Substring(s string, start int, end int) string {
                 self._line("}")
                 self._line("")
             # Exceptions with embedded_type inherit Error() from parent
-        # If struct implements Node interface, emit the interface methods
-        if "Node" in struct.implements:
-            # GetKind getter for the Kind field
-            self._line(f"func (self *{struct.name}) GetKind() string {{ return self.Kind }}")
-            self._line("")
         # Emit methods
         for method in struct.methods:
             self._emit_function(method)
@@ -1801,9 +1796,7 @@ func _Substring(s string, start int, end int) string {
         # Check if the expression type is an interface type
         # In Go, interface nil check requires reflection when interface might
         # contain a typed nil pointer (e.g., var x SomeInterface = (*Impl)(nil))
-        expr_type = expr.expr.typ
-        is_interface = isinstance(expr_type, InterfaceRef)
-        if is_interface:
+        if isinstance(expr.expr.typ, InterfaceRef):
             # Use helper function that handles typed nil pointers
             if expr.negated:
                 return f"!_isNilInterfaceRef({inner})"

--- a/transpiler/src/backend/java.py
+++ b/transpiler/src/backend/java.py
@@ -581,13 +581,6 @@ class JavaBackend:
         # Default constructor
         self._emit_default_constructor(struct)
         self._line("")
-        # Generate getters for interface methods that map to fields
-        # e.g., if interface requires getKind() and struct has kind field
-        field_names = {f.name for f in struct.fields}
-        method_names = {m.name for m in struct.methods}
-        if "Node" in struct.implements and "kind" in field_names and "GetKind" not in method_names:
-            self._line("public String getKind() { return this.kind; }")
-            self._line("")
         for i, method in enumerate(struct.methods):
             if i > 0:
                 self._line("")

--- a/transpiler/src/backend/typescript.py
+++ b/transpiler/src/backend/typescript.py
@@ -246,9 +246,8 @@ class TsBackend:
     def _emit_interface(self, iface: InterfaceDef) -> None:
         self._line(f"interface {_safe_name(iface.name)} {{")
         self.indent += 1
-        # Node interface needs a kind property for type discrimination
-        if iface.name == "Node":
-            self._line("kind: string;")
+        for fld in iface.fields:
+            self._line(f"{_camel(fld.name)}: {self._type(fld.typ)};")
         for method in iface.methods:
             params = self._params(method.params)
             ret = self._type(method.ret)
@@ -272,16 +271,6 @@ class TsBackend:
         if struct.fields:
             self._line()
             self._emit_constructor(struct)
-        # Add getKind() method for Node implementations that have a kind field
-        has_kind_field = any(f.name == "kind" for f in struct.fields)
-        has_getkind_method = any(m.name in ("GetKind", "get_kind") for m in struct.methods)
-        if "Node" in struct.implements and has_kind_field and not has_getkind_method:
-            self._line()
-            self._line("getKind(): string {")
-            self.indent += 1
-            self._line("return this.kind;")
-            self.indent -= 1
-            self._line("}")
         self.current_struct = struct.name
         for i, method in enumerate(struct.methods):
             if i > 0 or struct.fields:


### PR DESCRIPTION
## Summary

- Add `kind` field to `InterfaceDef.fields` for the Node interface
- Synthesize `GetKind()` method in `build_struct()` for Node structs with a kind field
- Add `is_interface` annotation pass in scope.py for InterfaceRef-typed expressions
- Remove hardcoded getKind() generation from Go, Java, and TypeScript backends
- TypeScript now emits interface fields from `InterfaceDef.fields`

This moves Parable-specific domain knowledge about the Node interface from backends to frontend/middleend, making the GetKind methods visible as proper IR Function nodes to all backends uniformly.