### PR TITLE
transpiler: emit FuncRef IR for bound method references

### DIFF
--- a/transpiler/src/backend/go.py
+++ b/transpiler/src/backend/go.py
@@ -91,6 +91,7 @@ from src.ir import (
     FloatLit,
     ForClassic,
     ForRange,
+    FuncRef,
     Function,
     FuncType,
     If,
@@ -1347,6 +1348,8 @@ func _Substring(s string, start int, end int) string {
             return self._emit_expr_Var(expr)
         if isinstance(expr, FieldAccess):
             return self._emit_expr_FieldAccess(expr)
+        if isinstance(expr, FuncRef):
+            return self._emit_expr_FuncRef(expr)
         if isinstance(expr, Index):
             return self._emit_expr_Index(expr)
         if isinstance(expr, SliceExpr):
@@ -1439,6 +1442,13 @@ func _Substring(s string, start int, end int) string {
         if is_node_type and expr.field == "kind":
             return f"{obj}.GetKind()"
         return f"{obj}.{field}"
+
+    def _emit_expr_FuncRef(self, expr: FuncRef) -> str:
+        """Emit method reference: obj.Method (Go method values capture receiver)."""
+        if expr.obj is not None:
+            obj_str = self._emit_expr(expr.obj)
+            return f"{obj_str}.{go_to_pascal(expr.name)}"
+        return go_to_pascal(expr.name)
 
     def _emit_expr_Index(self, expr: Index) -> str:
         obj = self._emit_expr(expr.obj)

--- a/transpiler/src/backend/python.py
+++ b/transpiler/src/backend/python.py
@@ -48,6 +48,7 @@ from src.ir import (
     FloatLit,
     ForClassic,
     ForRange,
+    FuncRef,
     FuncType,
     Function,
     If,
@@ -606,6 +607,10 @@ class PythonBackend:
                 if field.startswith("F") and field[1:].isdigit():
                     return f"{self._expr(obj)}[{field[1:]}]"
                 return f"{self._expr(obj)}.{field}"
+            case FuncRef(name=name, obj=obj):
+                if obj is not None:
+                    return f"{self._expr(obj)}.{name}"
+                return name
             case Index(obj=obj, index=index):
                 # Detect len(x) - N pattern for negative indexing
                 if neg_idx := self._negative_index(obj, index):

--- a/transpiler/src/frontend/lowering.py
+++ b/transpiler/src/frontend/lowering.py
@@ -14,6 +14,7 @@ from ..ir import (
     RUNE,
     STRING,
     VOID,
+    FuncType,
     InterfaceRef,
     Loc,
     Map,
@@ -665,6 +666,12 @@ def lower_expr_Attribute(
             field_info = struct_info.fields.get(node_attr)
             if field_info:
                 field_type = field_info.typ
+            # Check if this is a method reference (bound method, not field access)
+            elif node_attr in struct_info.methods:
+                method_info = struct_info.methods[node_attr]
+                param_types = tuple(p.typ for p in method_info.params)
+                func_type = FuncType(params=param_types, ret=method_info.return_type, captures=True)
+                return ir.FuncRef(name=node_attr, obj=obj, typ=func_type, loc=loc_from_node(node))
     # Also look up field type from the asserted struct type
     if isinstance(obj, ir.TypeAssert):
         asserted = obj.asserted


### PR DESCRIPTION
Move bound method reference handling from backend compensation to frontend IR emission.

Frontend now emits `FuncRef(obj=self, name=method)` for `self.method` when method is in `struct_info.methods` but not in `struct_info.fields`. This removes backend workarounds that detected method references via pattern matching (`_arith_parse_*` in Java, struct field lookup in TypeScript).