### PR TITLE
docs: remove stale compensation entries from backend docstrings

### DIFF
--- a/transpiler/src/backend/go.py
+++ b/transpiler/src/backend/go.py
@@ -12,11 +12,6 @@ Frontend deficiencies (should be fixed in frontend.py):
 - _runeAt, _runeLen, _Substring helpers exist because frontend emits string
   indexing as Index nodes without distinguishing byte vs character semantics.
   Frontend should emit distinct IR for character-based string operations.
-- ExprStmt filters expressions starting with "skip", "pass", "localFunc" -
-  frontend emits these markers that should be handled before backend.
-- Auto-generates GetKind() when struct implements "Node" - Parable-specific
-  knowledge about AST Node interface contract. Frontend should emit getter
-  methods explicitly or IR should have interface satisfaction markers.
 
 Middleend deficiencies (should be fixed in middleend.py):
 - _infer_tuple_element_type scans return statements to infer hoisted variable

--- a/transpiler/src/backend/java.py
+++ b/transpiler/src/backend/java.py
@@ -13,10 +13,6 @@ Frontend deficiencies (should be fixed in frontend.py):
 - Loop variable types in ForRange sometimes fall back to "Object" when element
   type is unknown - frontend should infer element types from iterable types and
   include them in the IR.
-- Frontend now emits NoOp IR nodes for skipped statements.
-- Auto-generates getKind() when struct implements "Node" and has "kind" field -
-  Parable-specific knowledge about AST Node interface contract. Frontend should
-  emit getter methods explicitly or IR should have interface satisfaction markers.
 - ParableFunctions._bytesToString() and _stringToBytes() helpers hardcode Parable's
   byte encoding. Frontend should emit BytesToString/StringToBytes IR nodes that
   backend renders with appropriate charset handling.

--- a/transpiler/src/backend/typescript.py
+++ b/transpiler/src/backend/typescript.py
@@ -6,12 +6,6 @@ COMPENSATIONS FOR EARLIER STAGE DEFICIENCIES
 Frontend deficiencies (should be fixed in frontend.py):
 - CommonJS exports hardcode "parse" and "ParseError" - this is Parable-specific
   knowledge. Frontend should emit Export IR nodes that backend renders.
-- Node interface special-cases "Node" to add "kind: string" property - Parable-
-  specific. Frontend should emit interface fields explicitly.
-- Auto-generated getKind() for Node implementations - backend has Parable-specific
-  knowledge about Node interface contract.
-- Frontend now emits TrimChars IR nodes for strip/lstrip/rstrip methods.
-- Frontend now emits NoOp IR nodes for skipped statements.
 
 Middleend deficiencies (should be fixed in middleend.py):
 - VarDecl and Assign use "any" type because middleend doesn't track that the same


### PR DESCRIPTION
Remove outdated entries from backend COMPENSATIONS sections:

- GetKind() auto-generation (fixed in #399)
- "Frontend now emits NoOp/TrimChars" (documenting fixes, not compensations)
- Node interface special-casing (fixed in #399)