### PR TITLE
Add Perl to released languages, bump Tongues to 0.2.5

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -37,4 +37,4 @@ Tag, push, and clean up:
 git checkout main && git pull && git tag v$ARGUMENTS && git push --tags && git push origin --delete release/v$ARGUMENTS
 ```
 
-The tag triggers a workflow that creates the GitHub release with transpiled binaries (parable.py, parable.js).
+The tag triggers a workflow that creates the GitHub release with transpiled binaries (parable.py, parable.js, parable.pl).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install Tongues
         env:
-          TONGUES_VERSION: v0.2.4
+          TONGUES_VERSION: v0.2.5
         run: |
           mkdir -p "$HOME/.local/lib/tongues/lib" "$HOME/.local/lib/tongues/bin" "$HOME/.local/bin"
           curl -sSfL "https://github.com/ldayton/Tongues/releases/download/${TONGUES_VERSION}/tongues.js" \
@@ -46,6 +46,15 @@ jobs:
 
       - name: Run checks
         run: just check
+
+      - name: Transpile Perl
+        run: just _transpile perl
+
+      - name: Build Perl Docker image
+        run: docker build -t parable-perl docker/perl
+
+      - name: Test Perl backend
+        run: docker run --rm -v $PWD:/workspace parable-perl just _run-lang-tests perl
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Tongues
         env:
-          TONGUES_VERSION: v0.2.4
+          TONGUES_VERSION: v0.2.5
         run: |
           mkdir -p "$HOME/.local/lib/tongues/lib" "$HOME/.local/lib/tongues/bin" "$HOME/.local/bin"
           curl -sSfL "https://github.com/ldayton/Tongues/releases/download/${TONGUES_VERSION}/tongues.js" \
@@ -72,6 +72,14 @@ jobs:
           tongues --target python -o .out/parable.py src/parable.py
           tongues --target javascript -o .out/parable.js src/parable.py
           echo 'module.exports = { parse, ParseError, MatchedPairError };' >> .out/parable.js
+          tongues --target perl -o .out/parable.pl src/parable.py
+          echo '1;' >> .out/parable.pl
+
+      - name: Build Perl Docker image
+        run: docker build -t parable-perl docker/perl
+
+      - name: Test Perl backend
+        run: docker run --rm -v $PWD:/workspace parable-perl just _run-lang-tests perl
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -81,3 +89,4 @@ jobs:
           files: |
             .out/parable.py
             .out/parable.js
+            .out/parable.pl

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All releases, even Python, run through the transpiler. Current languages:
 | Language   | Min Version       | v0.1.0                                                                               |
 | ---------- | ----------------- | ------------------------------------------------------------------------------------ |
 | Javascript | Node.js 21        | [parable.js](https://github.com/ldayton/Parable/releases/download/v0.1.0/parable.js) |
+| Perl       | Perl 5.36         | [parable.pl](https://github.com/ldayton/Parable/releases/download/v0.1.0/parable.pl) |
 | Python     | CPython/Pypy 3.12 | [parable.py](https://github.com/ldayton/Parable/releases/download/v0.1.0/parable.py) |
 
 Caveats: output code quality is a work in progress. Currently the transpiler prioritizes correctness over readability; generated code may not yet match hand-written idioms, yet. Additionally, the project's fuzzer still finds obscure edge cases where Parable differs from GNU Bash. While Parable matches bash for essentially 100% of real world examples, we're still shaking out remaining theoretical differences.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All releases, even Python, run through the transpiler. Current languages:
 | Language   | Min Version       | v0.1.0                                                                               |
 | ---------- | ----------------- | ------------------------------------------------------------------------------------ |
 | Javascript | Node.js 21        | [parable.js](https://github.com/ldayton/Parable/releases/download/v0.1.0/parable.js) |
-| Perl       | Perl 5.36         | [parable.pl](https://github.com/ldayton/Parable/releases/download/v0.1.0/parable.pl) |
+| Perl       | Perl 5.38         | [parable.pl](https://github.com/ldayton/Parable/releases/download/v0.1.0/parable.pl) |
 | Python     | CPython/Pypy 3.12 | [parable.py](https://github.com/ldayton/Parable/releases/download/v0.1.0/parable.py) |
 
 Caveats: output code quality is a work in progress. Currently the transpiler prioritizes correctness over readability; generated code may not yet match hand-written idioms, yet. Additionally, the project's fuzzer still finds obscure edge cases where Parable differs from GNU Bash. While Parable matches bash for essentially 100% of real world examples, we're still shaking out remaining theoretical differences.

--- a/docker/perl/Dockerfile
+++ b/docker/perl/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y perl curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && perl -v | grep -q "v5\.38" \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+ARG JUST_VERSION=1.46.0
+RUN curl -sSfL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar xz -C /usr/local/bin just
+WORKDIR /workspace

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ src-verify-lock: (_banner "src-verify-lock")
 check-tongues: (_banner "check-tongues")
     #!/usr/bin/env bash
     set -euo pipefail
-    required="0.2.4"
+    required="0.2.5"
     if ! command -v tongues &>/dev/null; then
         echo "FAIL: tongues not found. Install with: brew install ldayton/tap/tongues"
         exit 1
@@ -60,7 +60,7 @@ pycheck: check-tongues (_banner "pycheck")
 # Internal: run all parallel checks
 [private]
 [parallel]
-_check-parallel: src-test src-lint src-fmt src-verify-lock check-dump-ast pycheck (lang "javascript")
+_check-parallel: src-test src-lint src-fmt src-verify-lock check-dump-ast pycheck (lang "javascript") (lang "python")
 
 # Run all checks (parallel)
 [group: 'ci']


### PR DESCRIPTION
## Summary
- Publish `parable.pl` alongside `parable.py` and `parable.js` in GitHub releases
- Bump Tongues from 0.2.4 to 0.2.5 across justfile and both workflows
- Add Perl Docker container (ubuntu:24.04, Perl 5.38) for CI and release testing
- Add transpiled Python to `just check` so all published languages are tested
- Update README releases table and release skill with Perl